### PR TITLE
Refactor MD5 generator

### DIFF
--- a/framework/src/main/java/com/e2eq/framework/util/CommonUtils.java
+++ b/framework/src/main/java/com/e2eq/framework/util/CommonUtils.java
@@ -5,9 +5,10 @@ import io.quarkus.logging.Log;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -141,20 +142,13 @@ public class CommonUtils {
             return null;
         }
 
-        MessageDigest messageDigest = null;
         try {
-            messageDigest = MessageDigest.getInstance("MD5");
+            MessageDigest messageDigest = MessageDigest.getInstance("MD5");
 
-            byte[] array = messageDigest.digest(input.getBytes("UTF-8"));
+            byte[] array = messageDigest.digest(input.getBytes(StandardCharsets.UTF_8));
 
-            StringBuffer sb = new StringBuffer();
-            for (int i = 0; i < array.length; ++i) {
-                sb.append(Integer.toHexString((array[i] & 0xFF) | 0x100).substring(1, 3));
-            }
-            return sb.toString();
+            return HexFormat.of().formatHex(array);
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
         throw new IllegalStateException("MD5 calculation failed");

--- a/framework/src/test/java/com/e2eq/framework/util/TestCalculateMD5.java
+++ b/framework/src/test/java/com/e2eq/framework/util/TestCalculateMD5.java
@@ -1,0 +1,13 @@
+package com.e2eq.framework.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestCalculateMD5 {
+    @Test
+    public void testCalculateMD5() {
+        String input = "hello world";
+        String expected = "5eb63bbbe01eeed093cb22bb8f5acdc3";
+        assertEquals(expected, CommonUtils.calculateMD5(input));
+    }
+}


### PR DESCRIPTION
## Summary
- simplify hex conversion logic in `calculateMD5`
- switch from `StringBuffer` loop to `HexFormat`
- add a unit test for MD5 hashes

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e2afb5a688326beb4c666292ab194