### PR TITLE
Improve CSV helpers with typed processors

### DIFF
--- a/framework/src/main/java/com/e2eq/framework/util/CSVImportHelper.java
+++ b/framework/src/main/java/com/e2eq/framework/util/CSVImportHelper.java
@@ -11,6 +11,10 @@ import jakarta.validation.ValidationException;
 import jakarta.validation.Validator;
 import jakarta.ws.rs.WebApplicationException;
 
+import org.supercsv.cellprocessor.ParseBigDecimal;
+import org.supercsv.cellprocessor.ParseDouble;
+import org.supercsv.cellprocessor.ParseInt;
+import org.supercsv.cellprocessor.ParseLong;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.io.dozer.CsvDozerBeanReader;
 import org.supercsv.io.dozer.ICsvDozerBeanReader;
@@ -184,7 +188,8 @@ public class CSVImportHelper {
 
             beanReader.configureBeanMapping(repo.getPersistentClass(), fieldMapping);
 
-            CellProcessor[] processors = new CellProcessor[fieldMapping.length];
+            ListCellProcessor listProcessor = new ListCellProcessor();
+            CellProcessor[] processors = buildProcessors(repo.getPersistentClass(), requestedColumns, listProcessor);
 
             result = preprocessFlatProperty(repo, beanReader, processors, failedRecordHandler);
 
@@ -194,6 +199,69 @@ public class CSVImportHelper {
         }
 
         return result;
+    }
+
+    private CellProcessor[] buildProcessors(Class<?> clazz, List<String> cols, ListCellProcessor listProcessor) {
+        CellProcessor[] processors = new CellProcessor[cols.size()];
+        for (int i = 0; i < cols.size(); i++) {
+            String fieldName = cols.get(i);
+            if (fieldName.contains("[")) {
+                processors[i] = new org.supercsv.cellprocessor.Optional(listProcessor);
+                continue;
+            }
+            Class<?> type = getFieldType(clazz, fieldName);
+            if (type == int.class || type == Integer.class) {
+                processors[i] = new org.supercsv.cellprocessor.Optional(new ParseInt());
+            } else if (type == long.class || type == Long.class) {
+                processors[i] = new org.supercsv.cellprocessor.Optional(new ParseLong());
+            } else if (type == double.class || type == Double.class ||
+                    type == float.class || type == Float.class) {
+                processors[i] = new org.supercsv.cellprocessor.Optional(new ParseDouble());
+            } else if (type == java.math.BigDecimal.class) {
+                processors[i] = new org.supercsv.cellprocessor.Optional(new ParseBigDecimal());
+            } else {
+                processors[i] = new org.supercsv.cellprocessor.Optional();
+            }
+        }
+        return processors;
+    }
+
+    private Class<?> getFieldType(Class<?> clazz, String name) {
+        String clean = name.replace("[0]", "");
+        Class<?> current = clazz;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(clean).getType();
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    public class ListCellProcessor extends CellProcessorAdaptor {
+
+        protected int i;
+
+        public Object execute(Object value, CsvContext context) {
+            validateInputNotNull(value, context);
+
+            if (value instanceof List) {
+                List list = ((List) value);
+                if (i >= list.size()) {
+                    return next.execute("", context);
+                } else {
+                    return next.execute(((List) value).get(i), context);
+                }
+
+            } else {
+                return next.execute(value, context);
+            }
+        }
+
+        public void setIndex(int index) {
+            this.i = index;
+        }
     }
 
     public <T extends UnversionedBaseModel> ImportResult<T> importCSV(
@@ -231,8 +299,8 @@ public class CSVImportHelper {
 
             beanReader.configureBeanMapping(repo.getPersistentClass(), fieldMapping);
 
-            CellProcessor[] processors = new CellProcessor[fieldMapping.length];
-            // TODO: Configure appropriate CellProcessors based on field types
+            ListCellProcessor listProcessor = new ListCellProcessor();
+            CellProcessor[] processors = buildProcessors(repo.getPersistentClass(), requestedColumns, listProcessor);
 
            result = importFlatProperty(repo, beanReader, processors, failedRecordHandler);
 

--- a/framework/src/test/java/com/e2eq/framework/api/csv/TestCSVFeatures.java
+++ b/framework/src/test/java/com/e2eq/framework/api/csv/TestCSVFeatures.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.supercsv.cellprocessor.CellProcessorAdaptor;
 import org.supercsv.cellprocessor.Optional;
 import org.supercsv.cellprocessor.constraint.NotNull;
+import org.supercsv.cellprocessor.ParseInt;
+import org.supercsv.cellprocessor.ParseBigDecimal;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.io.dozer.CsvDozerBeanReader;
 import org.supercsv.io.dozer.CsvDozerBeanWriter;
@@ -47,11 +49,15 @@ public class TestCSVFeatures extends BaseRepoTest {
                         .testField1("value1")
                         .testList(List.of("value2", "value3"))
                         .displayName("testDisplayName")
+                        .numberField(1)
+                        .decimalField(new java.math.BigDecimal("10.5"))
                         .build(),
                 CSVModel.builder()
                         .testField1("value4")
                         .testList(List.of("value5", "value6"))
                         .displayName("testDisplayName2")
+                        .numberField(2)
+                        .decimalField(new java.math.BigDecimal("20.5"))
                         .build()
         );
     }
@@ -126,7 +132,9 @@ public class TestCSVFeatures extends BaseRepoTest {
         Map<String, String> headerToFieldMap = Map.of(
                 "f1", "testField1",
                 "a1", "testList",
-                "ds", "displayName"
+                "ds", "displayName",
+                "num", "numberField",
+                "dec", "decimalField"
         );
         String nestedProperty = null;
 
@@ -169,13 +177,13 @@ public class TestCSVFeatures extends BaseRepoTest {
                 getRecords(),
                 null,
                 ',',
-                List.of("testField1", "testList", "displayName"),
+                List.of("testField1", "testList", "displayName", "numberField", "decimalField"),
                 "QUOTE_ALL_COLUMNS",
                 '"',
                 Charset.forName("UTF-8"),
                 true,
                 true,
-                List.of("a1","a2","a3"),
+                List.of("a1","a2","a3","a4","a5"),
                 null);
 
         streamingOutput.write(System.out);
@@ -183,8 +191,8 @@ public class TestCSVFeatures extends BaseRepoTest {
 
     @Test
     public void testSuperCSVImport() throws IOException {
-        final String[] FIELD_MAPPING = {"refName", "displayName", "testField", "testField2", "testField3", "testList[0]"};
-        final String[] PREFERRED_FIELD_MAPPING = {"ID", "NAME", "testField", "testField2", "testField3", "testListField1"};
+        final String[] FIELD_MAPPING = {"refName", "displayName", "testField", "testField2", "testField3", "testList[0]", "numberField", "decimalField"};
+        final String[] PREFERRED_FIELD_MAPPING = {"ID", "NAME", "testField", "testField2", "testField3", "testListField1", "numberField", "decimalField"};
 
         final CellProcessor[] processors = new CellProcessor[]{
           new NotNull(),
@@ -192,7 +200,9 @@ public class TestCSVFeatures extends BaseRepoTest {
           new NotNull(),
           new Optional(),
           new Optional(),
-          new Optional()
+          new Optional(),
+          new ParseInt(),
+          new ParseBigDecimal()
         };
 
         ICsvDozerBeanReader beanReader=null;
@@ -231,7 +241,7 @@ public class TestCSVFeatures extends BaseRepoTest {
                ',',
                '"',
                false,
-               List.of("refName", "displayName", "testField", "testField2", "testField3", "testList[0]"),
+               List.of("refName", "displayName", "testField", "testField2", "testField3", "testList[0]", "numberField", "decimalField"),
                chosenCharset,
                false,
                "QUOTE_WHERE_ESSENTIAL",
@@ -262,7 +272,7 @@ public class TestCSVFeatures extends BaseRepoTest {
                     ',',
                     '"',
                     false,
-                    List.of("refName", "displayName", "testField", "testField2", "testField3", "testList[0]"),
+                    List.of("refName", "displayName", "testField", "testField2", "testField3", "testList[0]", "numberField", "decimalField"),
                     chosenCharset,
                     false,
                     "QUOTE_WHERE_ESSENTIAL",

--- a/framework/src/test/java/com/e2eq/framework/test/CSVModel.java
+++ b/framework/src/test/java/com/e2eq/framework/test/CSVModel.java
@@ -24,6 +24,8 @@ public class CSVModel extends BaseModel {
     protected String testField3;
     protected List<String> testList;
     protected Map<String, String> testMap;
+    protected int numberField;
+    protected java.math.BigDecimal decimalField;
 
 
     @Override

--- a/framework/src/test/resources/testData/TestImportCSV.csv
+++ b/framework/src/test/resources/testData/TestImportCSV.csv
@@ -1,4 +1,4 @@
-ID,NAME,testField,testField2,testField3,testList1
-test1,test1,field1,field2,field3,list1
-test2,test2,field3,field4,field5,list1
-test3,test3,field6,field7,field8,list1
+ID,NAME,testField,testField2,testField3,testList1,numberField,decimalField
+test1,test1,field1,field2,field3,list1,1,10.5
+test2,test2,field3,field4,field5,list1,2,20.5
+test3,test3,field6,field7,field8,list1,3,30.5


### PR DESCRIPTION
## Summary
- implement processor building based on field types for CSV import/export
- add numeric fields to CSVModel and update CSV dataset
- adjust CSV unit tests for numeric and decimal fields

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4303e160832696a05898809312d0