### PR TITLE
Implement context push/pop for SecurityUtils

### DIFF
--- a/framework/src/main/java/com/e2eq/framework/rest/resources/MigrationResource.java
+++ b/framework/src/main/java/com/e2eq/framework/rest/resources/MigrationResource.java
@@ -173,7 +173,7 @@ public class MigrationResource {
                    Log.infof("----Running migrations for system realm:%s---- ", realm);
                    migrationService.runAllUnRunMigrations(realm, emitter);
                }finally {
-                   securityUtils.clearSecurityContext();
+                   securityUtils.popSecurityContext();
                }
 
                 emitter.complete();
@@ -201,7 +201,7 @@ public class MigrationResource {
                         migrationService.runAllUnRunMigrations(securityUtils.getDefaultRealm(), emitter);
                     }
                 } finally {
-                    securityUtils.clearSecurityContext();
+                    securityUtils.popSecurityContext();
                 }
 
                 emitter.complete();
@@ -223,7 +223,7 @@ public class MigrationResource {
                     Log.info("----Running migrations for realm:---- " + realm);
                     migrationService.runAllUnRunMigrations(realm, emitter);
                 } finally {
-                    securityUtils.clearSecurityContext();
+                    securityUtils.popSecurityContext();
                 }
 
                 emitter.complete();


### PR DESCRIPTION
## Summary
- push the current security context to thread-local stacks in `SecurityUtils`
- add `popSecurityContext` to restore previous values
- switch `MigrationResource` to push/pop the context

## Testing
- `apt-get update` *(fails: repository not signed)*
- `./mvnw -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e56b425848326aa86888e2fd58cda