### PR TITLE
Add completion task support

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,35 @@ a certain realm.
 
 
 
+
+## Completion Tasks
+
+The framework exposes endpoints to manage groups of completion tasks.
+
+### Creating a group
+
+```bash
+curl -X POST http://localhost:8080/integration/completionTaskGroup/create \
+     -H "Content-Type: application/json" \
+     -d '{"refName":"demo","displayName":"Demo group"}'
+```
+
+### Adding a task to a group
+
+```bash
+curl -X POST http://localhost:8080/integration/completionTask/create/{groupId} \
+     -H "Content-Type: application/json" \
+     -d '{"refName":"task1","displayName":"First task"}'
+```
+
+### Checking task status
+
+```bash
+curl http://localhost:8080/integration/completionTask/id/{taskId}
+```
+
+### Subscribing for completion events
+
+```bash
+curl http://localhost:8080/integration/completionTaskGroup/subscribe/{groupId}
+```

--- a/framework/src/main/java/com/e2eq/framework/model/persistent/morphia/CompletionTaskGroupRepo.java
+++ b/framework/src/main/java/com/e2eq/framework/model/persistent/morphia/CompletionTaskGroupRepo.java
@@ -1,0 +1,38 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.persistent.tasks.CompletionTaskGroup;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.MultiEmitter;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Repository for {@link CompletionTaskGroup} entities.  Provides simple
+ * subscription support so that interested parties can be notified when a task
+ * in the group completes.
+ */
+@ApplicationScoped
+public class CompletionTaskGroupRepo extends MorphiaRepo<CompletionTaskGroup> {
+
+    private final Map<String, MultiEmitter<? super String>> emitters = new ConcurrentHashMap<>();
+
+    public CompletionTaskGroup createGroup(CompletionTaskGroup group) {
+        group.setStatus(CompletionTaskGroup.Status.NEW);
+        group.setCreatedDate(new java.util.Date());
+        return save(group);
+    }
+
+    public Multi<String> subscribe(String groupId) {
+        return Multi.createFrom().emitter(emitter -> emitters.put(groupId, emitter))
+                .onTermination().invoke(() -> emitters.remove(groupId));
+    }
+
+    public void notifyGroup(String groupId, String message) {
+        MultiEmitter<? super String> emitter = emitters.get(groupId);
+        if (emitter != null) {
+            emitter.emit(message);
+        }
+    }
+}

--- a/framework/src/main/java/com/e2eq/framework/model/persistent/morphia/CompletionTaskRepo.java
+++ b/framework/src/main/java/com/e2eq/framework/model/persistent/morphia/CompletionTaskRepo.java
@@ -1,0 +1,45 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.persistent.tasks.CompletionTask;
+import com.e2eq.framework.model.persistent.tasks.CompletionTaskGroup;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+/**
+ * Repository for {@link CompletionTask} entities.  Basic helper methods are
+ * provided to create tasks and mark them as completed.
+ */
+@ApplicationScoped
+public class CompletionTaskRepo extends MorphiaRepo<CompletionTask> {
+
+    @Inject
+    CompletionTaskGroupRepo groupRepo;
+
+    public CompletionTask createTask(CompletionTask task, String groupId) {
+        if (groupId != null) {
+            Optional<CompletionTaskGroup> group = groupRepo.findById(groupId);
+            group.ifPresent(task::setGroup);
+        }
+        task.setStatus(CompletionTask.Status.PENDING);
+        task.setCreatedDate(new java.util.Date());
+        return save(task);
+    }
+
+    public Optional<CompletionTask> completeTask(String id, CompletionTask.Status status, String result) {
+        Optional<CompletionTask> opt = findById(id);
+        if (opt.isPresent()) {
+            CompletionTask task = opt.get();
+            task.setStatus(status);
+            task.setCompletedDate(new java.util.Date());
+            task.setResult(result);
+            save(task);
+            if (task.getGroup() != null) {
+                groupRepo.notifyGroup(task.getGroup().getId().toString(), "task:" + id + ":" + status);
+            }
+            return Optional.of(task);
+        }
+        return Optional.empty();
+    }
+}

--- a/framework/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTask.java
+++ b/framework/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTask.java
@@ -1,0 +1,55 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import com.e2eq.framework.model.persistent.base.BaseModel;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Reference;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Date;
+
+/**
+ * Simple task entity that can be tracked until completion.
+ */
+@Entity("completionTask")
+@RegisterForReflection
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class CompletionTask extends BaseModel {
+
+    public enum Status {
+        PENDING,
+        RUNNING,
+        SUCCESS,
+        FAILED
+    }
+
+    @Reference
+    protected CompletionTaskGroup group;
+
+    protected String details;
+
+    protected Status status;
+
+    protected Date createdDate;
+    protected Date completedDate;
+
+    protected String result;
+
+    @Override
+    public String bmFunctionalArea() {
+        return "TASK";
+    }
+
+    @Override
+    public String bmFunctionalDomain() {
+        return "COMPLETION_TASK";
+    }
+}

--- a/framework/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTaskGroup.java
+++ b/framework/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTaskGroup.java
@@ -1,0 +1,51 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import com.e2eq.framework.model.persistent.base.BaseModel;
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Date;
+
+/**
+ * Represents a grouping of {@link CompletionTask}s.  It can be used to
+ * coordinate the execution and completion of multiple tasks.
+ */
+@Entity("completionTaskGroup")
+@RegisterForReflection
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class CompletionTaskGroup extends BaseModel {
+
+    public enum Status {
+        NEW,
+        RUNNING,
+        COMPLETE
+    }
+
+    /** Human readable description of the group */
+    protected String description;
+
+    /** Current processing status of the group */
+    protected Status status;
+
+    protected Date createdDate;
+    protected Date completedDate;
+
+    @Override
+    public String bmFunctionalArea() {
+        return "TASK";
+    }
+
+    @Override
+    public String bmFunctionalDomain() {
+        return "COMPLETION_TASK_GROUP";
+    }
+}

--- a/framework/src/main/java/com/e2eq/framework/rest/resources/CompletionTaskGroupResource.java
+++ b/framework/src/main/java/com/e2eq/framework/rest/resources/CompletionTaskGroupResource.java
@@ -1,0 +1,50 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.model.persistent.morphia.CompletionTaskGroupRepo;
+import com.e2eq.framework.model.persistent.tasks.CompletionTaskGroup;
+import io.smallrye.mutiny.Multi;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+
+@Path("/integration/completionTaskGroup")
+@RolesAllowed({"user","admin"})
+public class CompletionTaskGroupResource extends BaseResource<CompletionTaskGroup, CompletionTaskGroupRepo> {
+
+    public CompletionTaskGroupResource(CompletionTaskGroupRepo repo) {
+        super(repo);
+    }
+
+    @POST
+    @Path("create")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public CompletionTaskGroup createGroup(CompletionTaskGroup group) {
+        return repo.createGroup(group);
+    }
+
+    @GET
+    @Path("subscribe/{id}")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void subscribe(@PathParam("id") String id, SseEventSink sink, Sse sse) {
+        Multi<String> stream = repo.subscribe(id);
+        stream.subscribe().with(item -> {
+            if (!sink.isClosed()) {
+                sink.send(sse.newEvent(item));
+            }
+        },
+        failure -> {
+            if (!sink.isClosed()) {
+                sink.send(sse.newEvent("Error: " + failure.getMessage()));
+                sink.close();
+            }
+        },
+        () -> {
+            if (!sink.isClosed()) {
+                sink.close();
+            }
+        });
+    }
+}

--- a/framework/src/main/java/com/e2eq/framework/rest/resources/CompletionTaskResource.java
+++ b/framework/src/main/java/com/e2eq/framework/rest/resources/CompletionTaskResource.java
@@ -1,0 +1,37 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.model.persistent.morphia.CompletionTaskRepo;
+import com.e2eq.framework.model.persistent.tasks.CompletionTask;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Optional;
+
+@Path("/integration/completionTask")
+@RolesAllowed({"user","admin"})
+public class CompletionTaskResource extends BaseResource<CompletionTask, CompletionTaskRepo> {
+
+    public CompletionTaskResource(CompletionTaskRepo repo) {
+        super(repo);
+    }
+
+    @POST
+    @Path("create/{groupId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public CompletionTask createTask(@PathParam("groupId") String groupId, CompletionTask task) {
+        return repo.createTask(task, groupId);
+    }
+
+    @PUT
+    @Path("complete/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response completeTask(@PathParam("id") String id,
+                                 @QueryParam("status") String status,
+                                 @QueryParam("result") String result) {
+        Optional<CompletionTask> t = repo.completeTask(id, CompletionTask.Status.valueOf(status), result);
+        return t.map(Response::ok).orElseGet(() -> Response.status(Response.Status.NOT_FOUND)).build();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `CompletionTask` and `CompletionTaskGroup` models
- implement repositories for creating and updating tasks
- expose REST resources to create groups, tasks, and subscribe for SSE events
- document new endpoints

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68812e9d6c708326ba52d627d2728c6a