### PR TITLE
Add hierarchy visitor utility

### DIFF
--- a/framework/src/main/java/com/e2eq/framework/model/persistent/morphia/HierarchicalRepo.java
+++ b/framework/src/main/java/com/e2eq/framework/model/persistent/morphia/HierarchicalRepo.java
@@ -209,4 +209,28 @@ public abstract class HierarchicalRepo<
         return getAllObjectsForHierarchy(ohiearchyNode.get());
     }
 
+    /**
+     * Visits each child in the hierarchy starting with the supplied identifier.
+     *
+     * @param objectId the id of the hierarchy node to start traversal from
+     * @param visitor  the visitor that will be invoked for each child id
+     */
+    public void visitHierarchy(ObjectId objectId, HierarchyVisitor visitor) {
+        Objects.requireNonNull(objectId, "objectId can not be null for visitHierarchy method");
+        Objects.requireNonNull(visitor, "visitor can not be null for visitHierarchy method");
+        List<T> children = getAllChildren(objectId);
+        if (children != null) {
+            for (T child : children) {
+                if (child != null && child.getId() != null) {
+                    visitor.visit(child.getId());
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface HierarchyVisitor {
+        void visit(ObjectId id);
+    }
+
 }

--- a/framework/src/test/java/com/e2eq/framework/persistent/TestHierarchyVisitor.java
+++ b/framework/src/test/java/com/e2eq/framework/persistent/TestHierarchyVisitor.java
@@ -1,0 +1,45 @@
+package com.e2eq.framework.persistent;
+
+import com.e2eq.framework.model.securityrules.SecuritySession;
+import com.e2eq.framework.test.MenuHierarchyModel;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@QuarkusTest
+public class TestHierarchyVisitor extends BaseRepoTest {
+
+    @Inject
+    MenuHierarchyRepo hierarchyRepo;
+
+    @Test
+    public void testVisitHierarchy() {
+        try (SecuritySession ss = new SecuritySession(pContext, rContext)) {
+            MenuHierarchyModel root = new MenuHierarchyModel();
+            root.setRefName("visitRoot");
+            root = hierarchyRepo.save(root);
+
+            MenuHierarchyModel child1 = new MenuHierarchyModel();
+            child1.setRefName("visitChild1");
+            child1.setParent(root.createEntityReference());
+            child1 = hierarchyRepo.save(child1);
+
+            MenuHierarchyModel child2 = new MenuHierarchyModel();
+            child2.setRefName("visitChild2");
+            child2.setParent(root.createEntityReference());
+            child2 = hierarchyRepo.save(child2);
+
+            List<ObjectId> visited = new ArrayList<>();
+            hierarchyRepo.visitHierarchy(root.getId(), visited::add);
+
+            Assertions.assertEquals(2, visited.size());
+            Assertions.assertTrue(visited.contains(child1.getId()));
+            Assertions.assertTrue(visited.contains(child2.getId()));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `visitHierarchy` method in `HierarchicalRepo`
- introduce `HierarchyVisitor` functional interface

## Testing
- `mvn -q -DskipITs test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688283035e008326bea1924b2a16c840