### PR TITLE
feat: support $elemMatch in query grammar

### DIFF
--- a/quantum-framework/src/test/java/com/e2eq/framework/api/grammar/TestGrammar.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/api/grammar/TestGrammar.java
@@ -165,8 +165,16 @@ public class TestGrammar {
       f = MorphiaUtils.convertToFilter(dateTimeTsString, UserProfile.class);
       Log.infof("Value:%s", f.getValue());
 
-      dateTimeTsString = "field1:>2022-01-01T12:00:00Z";
+      dateTimeTsString = "field1:>2022-01-01T12:00:00Z"; 
       f = MorphiaUtils.convertToFilter(dateTimeTsString, UserProfile.class);
       Log.infof("Value:%s", f.getValue());
+   }
+
+   @Test
+   public void testElemMatchFilter() {
+      String queryString = "arrayField:{subField:1&&otherSub:2}";
+      Filter f = MorphiaUtils.convertToFilter(queryString, UserProfile.class);
+      assertNotNull(f);
+      assertEquals("arrayField", f.getField());
    }
 }

--- a/quantum-framework/src/test/resources/testQueryStrings.txt
+++ b/quantum-framework/src/test/resources/testQueryStrings.txt
@@ -67,6 +67,9 @@ field.subfield:^[67648ff00fb5e63655b172f9,67648ff00fb5e63655b172f6]
 field.subfield.subsubfield:^[deepvalue1,deepvalue2]
 
 
+#-- ElemMatch operator tests
+arrayField:{subField:1&&otherSub:2}
+
 #-- Combination of Operators
 (field:1&&field2:2)||field3:3
 field1:1&&(field2:2||field3:3)

--- a/quantum-models/src/main/antlr4/com/e2eq/framework/grammar/BIAPIQuery.g4
+++ b/quantum-models/src/main/antlr4/com/e2eq/framework/grammar/BIAPIQuery.g4
@@ -3,7 +3,7 @@ grammar BIAPIQuery;
 query: (exprGroup | compoundExpr) (exprOp (exprGroup | compoundExpr))*;
 exprGroup: lp=LPAREN (exprGroup | compoundExpr) (exprOp (exprGroup | compoundExpr))* rp=RPAREN;
 compoundExpr: allowedExpr (exprOp allowedExpr)*;
-allowedExpr: inExpr |  basicExpr |  nullExpr | existsExpr | booleanExpr | notExpr | regexExpr ;
+allowedExpr: elemMatchExpr | inExpr |  basicExpr |  nullExpr | existsExpr | booleanExpr | notExpr | regexExpr ;
 exprOp: op=(AND | OR);
 existsExpr: field=STRING op=EXISTS;
 booleanExpr: field=STRING op=(EQ | NEQ) value=(TRUE | FALSE);
@@ -33,6 +33,8 @@ regex: ((leftW=WILDCARD value=STRING rightW=WILDCARD)
 regexExpr: field=STRING op=(EQ | NEQ) regex;
 
 nullExpr: field=STRING op=(EQ | NEQ) value=NULL;
+
+elemMatchExpr: field=STRING op=EQ lp=LBRCE nested=query rp=RBRCE;
 
 
 // Operators

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListener.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListener.java
@@ -11,6 +11,7 @@ import dev.morphia.query.filters.Filters;
 import io.quarkus.logging.Log;
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.text.StringSubstitutor;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
@@ -315,6 +316,15 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
 
         Filter f = Filters.in(ctx.field.getText(), values);
 
+        filterStack.push(f);
+    }
+
+    @Override
+    public void enterElemMatchExpr(BIAPIQueryParser.ElemMatchExprContext ctx) {
+        QueryToFilterListener listener = new QueryToFilterListener(variableMap, sub, modelClass);
+        ParseTreeWalker walker = new ParseTreeWalker();
+        walker.walk(listener, ctx.nested);
+        Filter f = Filters.elemMatch(ctx.field.getText(), listener.getFilter());
         filterStack.push(f);
     }
 


### PR DESCRIPTION
## Summary
- extend BIAPIQuery grammar with `elemMatch` expressions
- convert parsed `elemMatch` to Morphia `$elemMatch` filters
- add tests covering `elemMatch` query handling

## Testing
- ⚠️ `mvn -q test` *(fails: Non-resolvable import POM: io.quarkus.platform:quarkus-bom:3.17.7)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9c37fa508326bc68435df57a50f9