### PR TITLE
Make ontology visualization endpoint optional

### DIFF
--- a/quantum-ontology-core/pom.xml
+++ b/quantum-ontology-core/pom.xml
@@ -16,6 +16,40 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.2</version>

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/rest/OntologyResource.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/rest/OntologyResource.java
@@ -1,0 +1,30 @@
+package com.e2eq.ontology.rest;
+
+import com.e2eq.ontology.rest.dto.OntologyVisualizationPayload;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/ontology")
+@RolesAllowed({"admin", "user"})
+@Tag(name = "ontology", description = "Ontology metadata and visualization helpers")
+public class OntologyResource {
+
+    private final OntologyVisualizationService visualizationService;
+
+    @Inject
+    public OntologyResource(OntologyVisualizationService visualizationService) {
+        this.visualizationService = visualizationService;
+    }
+
+    @GET
+    @Path("/visualization")
+    @Produces(MediaType.APPLICATION_JSON)
+    public OntologyVisualizationPayload getVisualization() {
+        return visualizationService.buildVisualization();
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/rest/OntologyVisualizationService.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/rest/OntologyVisualizationService.java
@@ -1,0 +1,84 @@
+package com.e2eq.ontology.rest;
+
+import com.e2eq.ontology.core.OntologyRegistry;
+import com.e2eq.ontology.rest.dto.OntologyVisualizationPayload;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class OntologyVisualizationService {
+
+    private final OntologyRegistry.TBox tbox;
+
+    @Inject
+    public OntologyVisualizationService(OntologyRegistry.TBox tbox) {
+        this.tbox = Objects.requireNonNull(tbox, "tbox");
+    }
+
+    public OntologyVisualizationPayload buildVisualization() {
+        Map<String, OntologyRegistry.ClassDef> classDefs = tbox.classes() != null ? tbox.classes() : Map.of();
+        Map<String, OntologyRegistry.PropertyDef> propertyDefs = tbox.properties() != null ? tbox.properties() : Map.of();
+        List<OntologyRegistry.PropertyChainDef> propertyChains = tbox.propertyChains() != null ? tbox.propertyChains() : List.of();
+
+        List<OntologyVisualizationPayload.Node> nodes = classDefs.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new OntologyVisualizationPayload.Node(
+                        entry.getKey(),
+                        "class",
+                        toSortedList(entry.getValue().parents()),
+                        toSortedList(entry.getValue().disjointWith()),
+                        toSortedList(entry.getValue().sameAs())
+                ))
+                .collect(Collectors.toList());
+
+        Map<String, List<List<String>>> chainsByProperty = new HashMap<>();
+        List<OntologyVisualizationPayload.Rule> rules = new ArrayList<>();
+        for (OntologyRegistry.PropertyChainDef chain : propertyChains) {
+            List<String> steps = chain.chain() != null ? List.copyOf(chain.chain()) : List.of();
+            rules.add(new OntologyVisualizationPayload.Rule(steps, chain.implies()));
+            chainsByProperty.computeIfAbsent(chain.implies(), key -> new ArrayList<>()).add(steps);
+        }
+
+        List<OntologyVisualizationPayload.Link> links = propertyDefs.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    OntologyRegistry.PropertyDef def = entry.getValue();
+                    List<List<String>> chains = chainsByProperty.getOrDefault(entry.getKey(), List.of());
+                    String domain = def.domain().orElse(null);
+                    String range = def.range().orElse(null);
+                    return new OntologyVisualizationPayload.Link(
+                            entry.getKey(),
+                            domain,
+                            range,
+                            chains.isEmpty() ? "property" : "derived",
+                            domain,
+                            range,
+                            def.inverse(),
+                            def.inverseOf().orElse(null),
+                            def.transitive(),
+                            chains
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new OntologyVisualizationPayload(List.copyOf(nodes), List.copyOf(links), List.copyOf(rules));
+    }
+
+    private static List<String> toSortedList(Set<String> values) {
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+        return values.stream()
+                .sorted(Comparator.naturalOrder())
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/rest/dto/OntologyVisualizationPayload.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/rest/dto/OntologyVisualizationPayload.java
@@ -1,0 +1,65 @@
+package com.e2eq.ontology.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Data transfer object representing a JointJS friendly view of an ontology.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record OntologyVisualizationPayload(
+        List<Node> nodes,
+        List<Link> links,
+        List<Rule> rules
+) {
+
+    public OntologyVisualizationPayload {
+        nodes = nodes == null ? List.of() : List.copyOf(nodes);
+        links = links == null ? List.of() : List.copyOf(links);
+        rules = rules == null ? List.of() : List.copyOf(rules);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Node(
+            String id,
+            String type,
+            List<String> parents,
+            List<String> disjointWith,
+            List<String> sameAs
+    ) {
+        public Node {
+            parents = parents == null ? List.of() : List.copyOf(parents);
+            disjointWith = disjointWith == null ? List.of() : List.copyOf(disjointWith);
+            sameAs = sameAs == null ? List.of() : List.copyOf(sameAs);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Link(
+            String id,
+            String source,
+            String target,
+            String kind,
+            String domain,
+            String range,
+            Boolean inverse,
+            String inverseOf,
+            Boolean transitive,
+            List<List<String>> rules
+    ) {
+        public Link {
+            rules = rules == null ? List.of() : List.copyOf(rules);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Rule(
+            List<String> chain,
+            String implies
+    ) {
+        public Rule {
+            chain = chain == null ? List.of() : List.copyOf(chain);
+        }
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/runtime/OntologyRegistryProducer.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/runtime/OntologyRegistryProducer.java
@@ -1,0 +1,155 @@
+package com.e2eq.ontology.runtime;
+
+import com.e2eq.ontology.core.OntologyRegistry;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Loads the ontology TBox definition from the classpath and exposes both the raw
+ * {@link OntologyRegistry.TBox} and an {@link OntologyRegistry} backed by it for
+ * injection across the application. Placed in the ontology module so that
+ * applications only gain the CDI beans when they depend on the module.
+ */
+@ApplicationScoped
+public class OntologyRegistryProducer {
+
+    private final ObjectMapper objectMapper;
+    private final String tboxLocation;
+
+    private OntologyRegistry.TBox tbox;
+    private OntologyRegistry registry;
+
+    @Inject
+    public OntologyRegistryProducer(ObjectMapper objectMapper,
+                                    @ConfigProperty(name = "quantum.ontology.tbox", defaultValue = "ontology/tbox.json")
+                                    String tboxLocation) {
+        this.objectMapper = objectMapper;
+        this.tboxLocation = tboxLocation;
+    }
+
+    @PostConstruct
+    void init() {
+        this.tbox = loadTBox();
+        this.registry = OntologyRegistry.inMemory(tbox);
+    }
+
+    @Produces
+    public OntologyRegistry.TBox tbox() {
+        return tbox;
+    }
+
+    @Produces
+    public OntologyRegistry registry() {
+        return registry;
+    }
+
+    private OntologyRegistry.TBox loadTBox() {
+        try (InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(tboxLocation)) {
+            if (stream == null) {
+                throw new IllegalStateException("Unable to locate ontology TBox resource at " + tboxLocation);
+            }
+            RawTBox raw = objectMapper.readValue(stream, RawTBox.class);
+            return toTBox(raw);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load ontology TBox from " + tboxLocation, e);
+        }
+    }
+
+    private OntologyRegistry.TBox toTBox(RawTBox raw) {
+        Map<String, OntologyRegistry.ClassDef> classes = new HashMap<>();
+        if (raw.classes != null) {
+            raw.classes.forEach((name, def) -> {
+                Set<String> parents = toSet(def != null ? def.parents : null);
+                Set<String> disjointWith = toSet(def != null ? def.disjointWith : null);
+                Set<String> sameAs = toSet(def != null ? def.sameAs : null);
+                classes.put(name, new OntologyRegistry.ClassDef(name, parents, disjointWith, sameAs));
+            });
+        }
+
+        Map<String, OntologyRegistry.PropertyDef> properties = new HashMap<>();
+        if (raw.properties != null) {
+            raw.properties.forEach((name, def) -> {
+                if (def == null) {
+                    def = new RawPropertyDef();
+                }
+                Optional<String> domain = optional(def.domain);
+                Optional<String> range = optional(def.range);
+                Optional<String> inverseOf = optional(def.inverseOf);
+                boolean inverse = Boolean.TRUE.equals(def.inverse);
+                boolean transitive = Boolean.TRUE.equals(def.transitive);
+                properties.put(name, new OntologyRegistry.PropertyDef(name, domain, range, inverse, inverseOf, transitive));
+            });
+        }
+
+        List<OntologyRegistry.PropertyChainDef> chains = new ArrayList<>();
+        if (raw.propertyChains != null) {
+            for (RawPropertyChainDef def : raw.propertyChains) {
+                if (def == null || def.implies == null || def.implies.isBlank()) {
+                    continue;
+                }
+                List<String> chain = def.chain != null
+                        ? def.chain.stream().filter(Objects::nonNull).toList()
+                        : List.of();
+                chains.add(new OntologyRegistry.PropertyChainDef(chain, def.implies));
+            }
+        }
+
+        return new OntologyRegistry.TBox(Map.copyOf(classes), Map.copyOf(properties), List.copyOf(chains));
+    }
+
+    private static Optional<String> optional(String value) {
+        return value == null || value.isBlank() ? Optional.empty() : Optional.of(value);
+    }
+
+    private static Set<String> toSet(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Set.of();
+        }
+        return Set.copyOf(new HashSet<>(values));
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class RawTBox {
+        Map<String, RawClassDef> classes;
+        Map<String, RawPropertyDef> properties;
+        List<RawPropertyChainDef> propertyChains;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class RawClassDef {
+        List<String> parents;
+        List<String> disjointWith;
+        List<String> sameAs;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class RawPropertyDef {
+        String domain;
+        String range;
+        Boolean inverse;
+        String inverseOf;
+        Boolean transitive;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class RawPropertyChainDef {
+        List<String> chain;
+        String implies;
+    }
+}


### PR DESCRIPTION
## Summary
- move the ontology visualization resource, service, DTO, and registry producer into the ontology module so the REST API is only present when that module is on the classpath
- add the CDI/JAX-RS/Jackson dependencies the ontology module needs and drop the framework module's dependency on quantum-ontology-core

## Testing
- mvn -pl quantum-framework -am -DskipTests compile *(fails: could not download Quarkus BOMs from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f70ee01e648326ba645b326aff9d56