### PR TITLE
Add policy YAML import API and share rule parsing

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PolicyResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PolicyResource.java
@@ -2,17 +2,37 @@ package com.e2eq.framework.rest.resources;
 
 import com.e2eq.framework.model.persistent.morphia.PolicyRepo;
 import com.e2eq.framework.model.security.Policy;
+import com.e2eq.framework.model.security.Rule;
 import com.e2eq.framework.securityrules.RuleContext;
+import com.e2eq.framework.securityrules.io.YamlPolicyItem;
+import com.e2eq.framework.securityrules.io.YamlPolicyLoader;
+import com.e2eq.framework.securityrules.io.YamlRuleMapper;
+import com.e2eq.framework.util.SecurityUtils;
 import jakarta.inject.Inject;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Path("/security/permission/policies")
 public class PolicyResource extends BaseResource<Policy, PolicyRepo>{
    @Inject
    RuleContext ruleContext;
+
+   @Inject
+   SecurityUtils securityUtils;
 
    protected PolicyResource (PolicyRepo repo) {
       super(repo);
@@ -25,4 +45,151 @@ public class PolicyResource extends BaseResource<Policy, PolicyRepo>{
       ruleContext.reloadFromRepo(effectiveRealm);
       return Response.ok().build();
    }
+
+   @POST
+   @Path("/import")
+   @Consumes({MediaType.TEXT_PLAIN, "application/yaml", "text/yaml"})
+   @Produces(MediaType.APPLICATION_JSON)
+   @RolesAllowed("admin")
+   public Response importPolicies(@HeaderParam("X-Realm") String realm, String yamlPayload) {
+      String effectiveRealm = (realm == null || realm.isBlank()) ? ruleContext.getDefaultRealm() : realm;
+
+      if (yamlPayload == null || yamlPayload.isBlank()) {
+         return Response.status(Response.Status.BAD_REQUEST)
+                 .entity(Map.of("error", "YAML payload is required"))
+                 .build();
+      }
+
+      List<YamlPolicyItem> yamlPolicies;
+      try {
+         YamlPolicyLoader loader = new YamlPolicyLoader();
+         yamlPolicies = loader.load(yamlPayload);
+      } catch (IOException ex) {
+         return Response.status(Response.Status.BAD_REQUEST)
+                 .entity(Map.of(
+                         "error", "Malformed YAML",
+                         "details", ex.getMessage()))
+                 .build();
+      }
+
+      List<Map<String, Object>> created = new ArrayList<>();
+      List<Map<String, Object>> updated = new ArrayList<>();
+      List<Map<String, Object>> errors = new ArrayList<>();
+
+      int row = 0;
+      for (YamlPolicyItem item : yamlPolicies) {
+         row++;
+         if (item == null) {
+            errors.add(errorEntry(row, null, "Entry was null"));
+            continue;
+         }
+
+         String refName = item.refName;
+         try {
+            PolicyImportResult result = upsertPolicy(effectiveRealm, item);
+            Map<String, Object> entry = successEntry(result.policy(), row, result.created());
+            if (result.created()) {
+               created.add(entry);
+            } else {
+               updated.add(entry);
+            }
+         } catch (IllegalArgumentException ex) {
+            errors.add(errorEntry(row, refName, ex.getMessage()));
+         } catch (Exception ex) {
+            errors.add(errorEntry(row, refName, "Failed to import policy: " + ex.getMessage()));
+         }
+      }
+
+      if (!created.isEmpty() || !updated.isEmpty()) {
+         ruleContext.reloadFromRepo(effectiveRealm);
+      }
+
+      Map<String, Object> response = new LinkedHashMap<>();
+      response.put("realm", effectiveRealm);
+      response.put("totalProcessed", yamlPolicies.size());
+      response.put("createdCount", created.size());
+      response.put("updatedCount", updated.size());
+      response.put("errorCount", errors.size());
+      response.put("created", created);
+      response.put("updated", updated);
+      response.put("errors", errors);
+
+      return Response.ok(response).build();
+   }
+
+   private PolicyImportResult upsertPolicy(String realm, YamlPolicyItem item) {
+      if (item.refName == null || item.refName.isBlank()) {
+         throw new IllegalArgumentException("refName is required");
+      }
+      if (item.principalId == null || item.principalId.isBlank()) {
+         throw new IllegalArgumentException("principalId is required");
+      }
+
+      Optional<Policy> existing = repo.findByRefName(realm, item.refName);
+      Policy policy = existing.orElseGet(Policy::new);
+      boolean created = existing.isEmpty();
+
+      policy.setRefName(item.refName);
+      policy.setDisplayName((item.displayName != null && !item.displayName.isBlank()) ? item.displayName : item.refName);
+      policy.setDescription(item.description);
+      policy.setPrincipalId(item.principalId);
+      policy.setPrincipalType(resolvePrincipalType(item.principalType, existing.map(Policy::getPrincipalType).orElse(null)));
+
+      if (policy.getDataDomain() == null) {
+         policy.setDataDomain(securityUtils.getSystemDataDomain());
+      }
+
+      List<Rule> rules;
+      if (item.rules != null && !item.rules.isEmpty()) {
+         rules = YamlRuleMapper.toRules(item.rules);
+      } else if (item.legacyRules != null && !item.legacyRules.isEmpty()) {
+         List<Rule> copy = new ArrayList<>();
+         for (Rule r : item.legacyRules) {
+            if (r != null) {
+               copy.add(r);
+            }
+         }
+         rules = copy;
+      } else {
+         rules = Collections.emptyList();
+      }
+      policy.setRules(new ArrayList<>(rules));
+
+      repo.save(realm, policy);
+
+      return new PolicyImportResult(policy, created);
+   }
+
+   private Policy.PrincipalType resolvePrincipalType(String raw, Policy.PrincipalType existing) {
+      if (raw == null || raw.isBlank()) {
+         return existing != null ? existing : Policy.PrincipalType.ROLE;
+      }
+      try {
+         return Policy.PrincipalType.valueOf(raw.trim().toUpperCase());
+      } catch (IllegalArgumentException ex) {
+         throw new IllegalArgumentException("Invalid principalType '" + raw + "'");
+      }
+   }
+
+   private Map<String, Object> successEntry(Policy policy, int row, boolean created) {
+      Map<String, Object> entry = new LinkedHashMap<>();
+      entry.put("row", row);
+      entry.put("refName", policy.getRefName());
+      entry.put("principalId", policy.getPrincipalId());
+      entry.put("ruleCount", policy.getRules() != null ? policy.getRules().size() : 0);
+      entry.put("status", created ? "created" : "updated");
+      return entry;
+   }
+
+   private Map<String, Object> errorEntry(int row, String refName, String message) {
+      Map<String, Object> entry = new LinkedHashMap<>();
+      entry.put("row", row);
+      if (refName != null) {
+         entry.put("refName", refName);
+      }
+      entry.put("error", message);
+      return entry;
+   }
+
+   private record PolicyImportResult(Policy policy, boolean created) {}
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlPolicyFile.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlPolicyFile.java
@@ -1,0 +1,13 @@
+package com.e2eq.framework.securityrules.io;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class YamlPolicyFile {
+
+    @JsonProperty("policies")
+    public List<YamlPolicyItem> policies;
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlPolicyItem.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlPolicyItem.java
@@ -1,0 +1,29 @@
+package com.e2eq.framework.securityrules.io;
+
+import com.e2eq.framework.model.security.Rule;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class YamlPolicyItem {
+
+    public String refName;
+    public String displayName;
+    public String description;
+
+    public String principalId;
+
+    /** principalType maps to {@link com.e2eq.framework.model.security.Policy.PrincipalType}. */
+    public String principalType;
+
+    @JsonProperty("rules")
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public List<YamlRule> rules;
+
+    @JsonIgnore
+    public List<Rule> legacyRules;
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlPolicyLoader.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlPolicyLoader.java
@@ -1,0 +1,124 @@
+package com.e2eq.framework.securityrules.io;
+
+import com.e2eq.framework.model.security.Policy;
+import com.e2eq.framework.model.security.Rule;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+
+public final class YamlPolicyLoader {
+
+    private final ObjectMapper mapper;
+
+    public YamlPolicyLoader() {
+        this.mapper = new ObjectMapper(new YAMLFactory())
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+    }
+
+    public List<YamlPolicyItem> load(Path yamlPath) throws IOException {
+        if (yamlPath == null || !Files.exists(yamlPath)) {
+            return Collections.emptyList();
+        }
+        try (InputStream is = Files.newInputStream(yamlPath)) {
+            return load(is);
+        }
+    }
+
+    public List<YamlPolicyItem> load(InputStream yamlStream) throws IOException {
+        if (yamlStream == null) {
+            return Collections.emptyList();
+        }
+        byte[] data = yamlStream.readAllBytes();
+        if (data.length == 0) {
+            return Collections.emptyList();
+        }
+
+        IOException lastError = null;
+        boolean parsed = false;
+
+        // Structured format: { policies: [ ... ] }
+        try (InputStream structured = new ByteArrayInputStream(data)) {
+            YamlPolicyFile file = mapper.readValue(structured, YamlPolicyFile.class);
+            parsed = true;
+            if (file != null && file.policies != null && !file.policies.isEmpty()) {
+                return file.policies;
+            }
+        } catch (IOException ex) {
+            lastError = ex;
+        }
+
+        // Direct list of YamlPolicyItem definitions
+        try (InputStream direct = new ByteArrayInputStream(data)) {
+            CollectionType yamlList = mapper.getTypeFactory()
+                    .constructCollectionType(ArrayList.class, YamlPolicyItem.class);
+            List<YamlPolicyItem> items = mapper.readValue(direct, yamlList);
+            parsed = true;
+            if (items != null && !items.isEmpty()) {
+                return items;
+            }
+        } catch (IOException ex) {
+            lastError = ex;
+        }
+
+        // Legacy format: List<Policy> with embedded Rule definitions
+        try (InputStream legacy = new ByteArrayInputStream(data)) {
+            CollectionType policyList = mapper.getTypeFactory()
+                    .constructCollectionType(ArrayList.class, Policy.class);
+            List<Policy> policies = mapper.readValue(legacy, policyList);
+            parsed = true;
+            if (policies != null && !policies.isEmpty()) {
+                List<YamlPolicyItem> converted = new ArrayList<>(policies.size());
+                for (Policy p : policies) {
+                    if (p == null) continue;
+                    YamlPolicyItem item = new YamlPolicyItem();
+                    item.refName = p.getRefName();
+                    item.displayName = p.getDisplayName();
+                    item.description = p.getDescription();
+                    item.principalId = p.getPrincipalId();
+                    item.principalType = p.getPrincipalType() != null ? p.getPrincipalType().name() : null;
+                    if (p.getRules() != null && !p.getRules().isEmpty()) {
+                        List<Rule> copy = new ArrayList<>();
+                        for (Rule r : p.getRules()) {
+                            if (r != null) {
+                                copy.add(r);
+                            }
+                        }
+                        if (!copy.isEmpty()) {
+                            item.legacyRules = copy;
+                        }
+                    }
+                    converted.add(item);
+                }
+                return converted;
+            }
+        } catch (IOException ex) {
+            lastError = ex;
+        }
+
+        if (!parsed && lastError != null) {
+            throw lastError;
+        }
+
+        return Collections.emptyList();
+    }
+
+    public List<YamlPolicyItem> load(String yamlContent) throws IOException {
+        if (yamlContent == null || yamlContent.isBlank()) {
+            return Collections.emptyList();
+        }
+        try (InputStream is = new ByteArrayInputStream(yamlContent.getBytes(StandardCharsets.UTF_8))) {
+            return load(is);
+        }
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlRuleLoader.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlRuleLoader.java
@@ -1,16 +1,11 @@
 package com.e2eq.framework.securityrules.io;
 
-import com.e2eq.framework.model.securityrules.FilterJoinOp;
 import com.e2eq.framework.model.security.Rule;
-import com.e2eq.framework.model.securityrules.RuleEffect;
-import com.e2eq.framework.model.securityrules.SecurityURI;
-import com.e2eq.framework.model.securityrules.SecurityURIHeader;
-import com.e2eq.framework.securityrules.CompositeSecurityURIHeader;
-import com.e2eq.framework.securityrules.RuleExpander;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -18,6 +13,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.type.CollectionType;
 
 public final class YamlRuleLoader {
 
@@ -31,56 +28,33 @@ public final class YamlRuleLoader {
     public List<Rule> load(Path yamlPath) throws IOException {
         if (yamlPath == null || !Files.exists(yamlPath)) return Collections.emptyList();
         try (InputStream is = Files.newInputStream(yamlPath)) {
-            YamlRuleFile file = mapper.readValue(is, YamlRuleFile.class);
-            return toRules(file);
+            return load(is);
         }
     }
 
     public List<Rule> load(InputStream yamlStream) throws IOException {
         if (yamlStream == null) return Collections.emptyList();
-        YamlRuleFile file = mapper.readValue(yamlStream, YamlRuleFile.class);
-        return toRules(file);
-    }
-
-    private List<Rule> toRules(YamlRuleFile file) {
-        if (file == null || file.rules == null || file.rules.isEmpty()) return Collections.emptyList();
-
-        List<Rule> out = new ArrayList<>();
-        for (YamlRule yr : file.rules) {
-            CompositeSecurityURIHeader ch = new CompositeSecurityURIHeader(
-                    yr.identities, yr.areas, yr.functionalDomains, yr.actions);
-
-            // Build placeholder header; actual values set during expansion
-            SecurityURIHeader placeholderHeader = new SecurityURIHeader();
-            SecurityURI uri = new SecurityURI(placeholderHeader,
-                    yr.body != null ? yr.body.clone() : new com.e2eq.framework.model.securityrules.SecurityURIBody());
-
-            Rule template = new Rule.Builder()
-                    .withName(yr.name)
-                    .withDescription(yr.description)
-                    .withSecurityURI(uri)
-                    .withPreconditionScript(yr.preconditionScript)
-                    .withPostconditionScript(yr.postconditionScript)
-                    .withEffect(parseEffect(yr.effect))
-                    .withPriority(yr.priority != null ? yr.priority : Rule.DEFAULT_PRIORITY)
-                    .withFinalRule(Boolean.TRUE.equals(yr.finalRule))
-                    .withAndFilterString(yr.andFilterString)
-                    .withOrFilterString(yr.orFilterString)
-                    .withJoinOp(parseJoinOp(yr.joinOp))
-                    .build();
-
-            out.addAll(RuleExpander.expand(template, ch));
+        byte[] data = yamlStream.readAllBytes();
+        if (data.length == 0) {
+            return Collections.emptyList();
         }
-        return out;
-    }
 
-    private static RuleEffect parseEffect(String s) {
-        if (s == null || s.isBlank()) return RuleEffect.DENY; // default
-        return RuleEffect.valueOf(s.trim().toUpperCase());
-    }
+        // Attempt structured rule format first (rules array with header axes)
+        try (InputStream structured = new ByteArrayInputStream(data)) {
+            YamlRuleFile file = mapper.readValue(structured, YamlRuleFile.class);
+            List<Rule> converted = YamlRuleMapper.toRules(file != null ? file.rules : null);
+            if (!converted.isEmpty()) {
+                return converted;
+            }
+        } catch (IOException ignore) {
+            // fall through to legacy parsing
+        }
 
-    private static FilterJoinOp parseJoinOp(String s) {
-        if (s == null || s.isBlank()) return null;
-        return FilterJoinOp.valueOf(s.trim().toUpperCase());
+        // Fallback to legacy List<Rule> format
+        try (InputStream legacy = new ByteArrayInputStream(data)) {
+            CollectionType listType = mapper.getTypeFactory()
+                    .constructCollectionType(ArrayList.class, Rule.class);
+            return mapper.readValue(legacy, listType);
+        }
     }
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlRuleMapper.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/securityrules/io/YamlRuleMapper.java
@@ -1,0 +1,76 @@
+package com.e2eq.framework.securityrules.io;
+
+import com.e2eq.framework.model.security.Rule;
+import com.e2eq.framework.model.securityrules.FilterJoinOp;
+import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.SecurityURI;
+import com.e2eq.framework.model.securityrules.SecurityURIHeader;
+import com.e2eq.framework.securityrules.CompositeSecurityURIHeader;
+import com.e2eq.framework.securityrules.RuleExpander;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility for converting YAML representations of rules into fully expanded {@link Rule} instances.
+ * The conversion logic is shared between the CLI tooling and REST resources so that both
+ * code paths interpret YAML payloads consistently.
+ */
+public final class YamlRuleMapper {
+
+    private YamlRuleMapper() {
+    }
+
+    public static List<Rule> toRules(List<YamlRule> yamlRules) {
+        if (yamlRules == null || yamlRules.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Rule> out = new ArrayList<>();
+        for (YamlRule yr : yamlRules) {
+            if (yr == null) {
+                continue;
+            }
+
+            CompositeSecurityURIHeader ch = new CompositeSecurityURIHeader(
+                    yr.identities, yr.areas, yr.functionalDomains, yr.actions);
+
+            // Build placeholder header; actual values set during expansion
+            SecurityURIHeader placeholderHeader = new SecurityURIHeader();
+            SecurityURI uri = new SecurityURI(placeholderHeader,
+                    yr.body != null ? yr.body.clone() : new com.e2eq.framework.model.securityrules.SecurityURIBody());
+
+            Rule template = new Rule.Builder()
+                    .withName(yr.name)
+                    .withDescription(yr.description)
+                    .withSecurityURI(uri)
+                    .withPreconditionScript(yr.preconditionScript)
+                    .withPostconditionScript(yr.postconditionScript)
+                    .withEffect(parseEffect(yr.effect))
+                    .withPriority(yr.priority != null ? yr.priority : Rule.DEFAULT_PRIORITY)
+                    .withFinalRule(Boolean.TRUE.equals(yr.finalRule))
+                    .withAndFilterString(yr.andFilterString)
+                    .withOrFilterString(yr.orFilterString)
+                    .withJoinOp(parseJoinOp(yr.joinOp))
+                    .build();
+
+            out.addAll(RuleExpander.expand(template, ch));
+        }
+        return out;
+    }
+
+    private static RuleEffect parseEffect(String s) {
+        if (s == null || s.isBlank()) {
+            return RuleEffect.DENY; // default
+        }
+        return RuleEffect.valueOf(s.trim().toUpperCase());
+    }
+
+    private static FilterJoinOp parseJoinOp(String s) {
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        return FilterJoinOp.valueOf(s.trim().toUpperCase());
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/tools/RulesYamlToJsonl.java
+++ b/quantum-framework/src/main/java/com/e2eq/tools/RulesYamlToJsonl.java
@@ -1,9 +1,8 @@
 package com.e2eq.tools;
 
 import com.e2eq.framework.model.security.Rule;
+import com.e2eq.framework.securityrules.io.YamlRuleLoader;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.CollectionType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -12,7 +11,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -46,12 +44,10 @@ public final class RulesYamlToJsonl {
         }
 
         // 1) Read YAML into List<Rule>
-        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-        CollectionType listType = yamlMapper.getTypeFactory()
-                .constructCollectionType(ArrayList.class, Rule.class);
         List<Rule> rules;
         try {
-            rules = yamlMapper.readValue(Files.newInputStream(input), listType);
+            YamlRuleLoader loader = new YamlRuleLoader();
+            rules = loader.load(input);
         } catch (IOException e) {
             System.err.printf("Failed to read/parse YAML from %s: %s%n", input.toAbsolutePath(), e.getMessage());
             throw e;


### PR DESCRIPTION
## Summary
- add an admin-only `/security/permission/policies/import` endpoint that ingests YAML, reports per-row outcomes, and refreshes the rule context
- add reusable YAML loaders/mappers so both the REST endpoint and CLI support legacy and structured rule/policy formats

## Testing
- mvn -pl quantum-framework -am -DskipTests compile *(fails: unable to download Quarkus BOM from Maven Central – HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916285377248326b91acdb2f4d4ea0f)