### PR TITLE
Add hierarchy filter improvements with legacy behavior preserved

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/HierarchyResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/HierarchyResource.java
@@ -92,4 +92,39 @@ public class HierarchyResource<
         }
         return Response.ok(dto).build();
     }
+
+    /**
+     * Gets the effective filter string for a hierarchy node.
+     * This includes all accumulated dynamic filters AND static ID constraints
+     * from the path (root to node). This is the complete filter that would be
+     * applied when querying objects for this node.
+     *
+     * @param id the ObjectId of the hierarchy node
+     * @return JSON response containing the effective filter string
+     */
+    @GET
+    @Path("/{id}/effective-filter")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getEffectiveFilter(@PathParam("id") String id) {
+        ObjectId oid;
+        try {
+            oid = new ObjectId(id);
+        } catch (IllegalArgumentException ex) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "Invalid id format"))
+                    .build();
+        }
+
+        try {
+            String effectiveFilter = repo.getEffectiveFilterForNode(oid);
+            return Response.ok(Map.of(
+                    "nodeId", id,
+                    "effectiveFilter", effectiveFilter != null ? effectiveFilter : ""
+            )).build();
+        } catch (NotFoundException ex) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(Map.of("error", "Hierarchy node not found for id: " + id))
+                    .build();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add support for mixed static/dynamic lists in hierarchy filter accumulation
- Add REST API endpoint `GET /{id}/effective-filter` to get the effective filter string for a hierarchy node
- Make legacy behavior the default (backward compatible), new filter accumulation is opt-in via `accumulateFilters=true` flag

## Changes

### Mixed Static/Dynamic List Handling
When a parent has a static list (e.g., 10 locations) and a child has a dynamic filter, the child's filter is now properly ANDed with an IN clause constraining results to the parent's static IDs.

- Add `AccumulatedConstraint` helper class to track both dynamic filters and static ID constraints
- Add `buildAccumulatedConstraint()` method to walk hierarchy path and collect constraints
- Static lists in the path constrain all descendant queries to those IDs
- Multiple static lists along the path are intersected

### REST API for Effective Filter
New endpoint `GET /{id}/effective-filter` returns the complete effective filter string for a node:
```json
{
  "nodeId": "507f1f77bcf86cd799439011",
  "effectiveFilter": "(status:active) && (_id:^[id1,id2,id3])"
}
```

### Legacy Behavior Preserved
- `accumulateFilters=false` (default): Legacy behavior - each node's filter applied independently
- `accumulateFilters=true`: New behavior - filters accumulated along the path

This ensures backward compatibility - existing code continues to work exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)