### PR TITLE
Fix text substitution parity in in-memory query listener

### DIFF
--- a/quantum-docs/src/docs/ai-docs/TEXT_SEARCH_QUERY_LANGUAGE_DESIGN.md
+++ b/quantum-docs/src/docs/ai-docs/TEXT_SEARCH_QUERY_LANGUAGE_DESIGN.md
@@ -1,0 +1,120 @@
+# Design: Text Search in BIAPI Query Language
+
+## Overview
+This document proposes adding MongoDB text search support to the existing BIAPI (ANTLR) query language so that `$text` queries can be composed with other filters (eq/in/regex/etc.) and remain consistent across Morphia (database-side) and in-memory evaluation paths. The intent is to keep the grammar backwards compatible, introduce a clear syntax for text search, and ensure validation and execution parity across listeners.
+
+## Goals
+- Add a **text search expression** to the BIAPI grammar that composes with existing `&&`/`||` logic.
+- Translate the new expression to MongoDB `$text` via Morphia filters.
+- Provide a deterministic in-memory fallback for test and policy evaluation.
+- Preserve existing query semantics and avoid breaking changes.
+
+## Non-Goals
+- Replacing the existing regex/wildcard search semantics.
+- Supporting multiple `$text` expressions in a single query (MongoDB limitation).
+- Implementing Atlas Search or advanced scoring/ranking features.
+
+## Proposed Syntax
+Introduce a function-style expression:
+
+```
+text("search terms")
+```
+
+### Examples
+```
+text("john doe") && status:Assigned
+(text("priority")) || ownerId:@@5f3b...
+text(${"query"}) && type:^ ["user", "group"]
+```
+
+### Rationale
+- Mirrors existing function-style expressions (`hasEdge`, `expand`).
+- Avoids ambiguity with field-based comparisons.
+- Natural mapping to MongoDB `$text`, which does not target a single field.
+
+## Grammar Changes (BIAPIQuery.g4)
+Add a `textExpr` to `allowedExpr` and introduce a `TEXT` token:
+
+```antlr
+allowedExpr: ... | textExpr;
+textExpr: TEXT LPAREN value=(STRING|QUOTED_STRING|VARIABLE) RPAREN;
+TEXT: 'text';
+```
+
+> NOTE: Ensure the new token does not conflict with existing `STRING` tokenization rules.
+
+## Listener Updates
+
+### Morphia Query Translation
+File: `quantum-morphia-repos/.../QueryToFilterListener.java`
+- Add `enterTextExpr(...)` handler.
+- Build `Filters.text(value)` and push onto the filter stack.
+- Enforce **single text clause** per query. If a second text clause is encountered, raise a validation error.
+
+### Query Validation (Morphia)
+File: `quantum-morphia-repos/.../ValidatingQueryToFilterListener.java`
+- Track if a text expression has been seen.
+- Throw a validation error on the second occurrence.
+
+### In-Memory Predicate
+File: `quantum-framework/.../QueryToPredicateJsonListener.java`
+- Define a fallback evaluation method for `text(...)`.
+- Implement `text("foo bar")` as **tokenized contains-any** across all textual values in the JSON payload.
+- Perform case-insensitive matches.
+
+### In-Memory Validation
+File: `quantum-framework/.../ValidatingQueryToPredicateJsonListener.java`
+- Reject multiple `text(...)` occurrences (same rule as Morphia).
+
+## Execution Semantics
+
+### MongoDB / Morphia
+- Text search is case-insensitive by default (MongoDB behavior).
+- `$text` can be combined with other filters using `Filters.and(...)` or implicit AND in the top-level query.
+- MongoDB supports only **one `$text` expression** per query.
+
+### In-Memory Behavior
+- Behavior should be clearly documented to avoid mismatches with MongoDB tokenization.
+- Split search string into tokens by whitespace and require **any token match**.
+- Perform case-insensitive matches across textual values in the JSON payload.
+
+## Index Requirements
+- MongoDB allows **one text index per collection**, which can cover multiple fields.
+- The index must be provisioned via existing Morphia annotations and/or migration tooling.
+- Ensure documentation includes example index configuration and notes about weights.
+
+## API / Configuration Hooks (Future)
+- Consider a config entry (e.g., `quantum.query.textSearch.fields`) to restrict in-memory evaluation to a specific field list.
+- Optionally allow per-query overrides via a `TextSearchConfig` object passed into `QueryPredicates.compilePredicate(...)`.
+
+## Validation Rules
+- Allow `text(...)` inside parentheses and in compound expressions.
+- Reject multiple `text(...)` expressions in a single query.
+- Reject empty search strings.
+
+## Documentation Updates
+- Add `text(...)` to the query language guide with syntax and examples.
+- Document limitations (single text clause, MongoDB tokenization differences).
+- Mention index requirements and example Morphia annotations.
+
+## Testing Plan
+1. **Grammar tests**
+   - Parse `text("foo")` alone and with `&&`/`||` operators.
+2. **Morphia listener tests**
+   - Ensure `text("foo") && status:Active` produces `Filters.text` combined with `Filters.eq`.
+   - Ensure duplicate `text(...)` is rejected.
+3. **In-memory predicate tests**
+   - Verify case-insensitive token matching across configured fields.
+   - Validate rejection of duplicate `text(...)`.
+
+## Rollout Plan
+1. Update grammar + regenerate ANTLR artifacts if needed.
+2. Implement Morphia translation and validation.
+3. Implement in-memory predicate + validation.
+4. Update docs and add tests.
+
+## Open Questions
+- Should we allow phrase search with quotes to map to MongoDB phrase semantics?
+- Should we expose `language` or `caseSensitive` flags for text search?
+- How should field selection for in-memory evaluation be configured or overridden?

--- a/quantum-docs/src/docs/asciidoc/user-guide/query-language.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/query-language.adoc
@@ -71,6 +71,23 @@ name:w?dget          # single character wildcard
 name:"WIDGET"        # may or may not match "widget"
 ----
 
+==== Text Search
+
+[source]
+----
+# Full-text search (requires MongoDB text index)
+text("priority escalation")
+
+# Combine text search with other filters
+text("priority escalation") && status:"OPEN"
+----
+
+Notes:
+
+- `text(...)` maps to MongoDB `$text` queries and is case-insensitive by default.
+- MongoDB allows only one `text(...)` clause per query.
+- Text search must be backed by a text index on the target collection.
+
 ==== Numeric Ranges
 
 [source]
@@ -352,6 +369,7 @@ Key characteristics:
 - Output type: Morphia Filter
 - Execution: database-side (MongoDB)
 - Semantics: identical to grammar (comparisons, IN/NIN, exists, null, regex with wildcards, elemMatch, boolean &&/||/!!)
+- Text search: `text("...")` is supported when a collection has a text index; only one text clause is allowed per query.
 - Variable expansion: supports ${vars} and single-variable IN list expansion (e.g., [${ids}] can expand to a collection/array or a comma-separated string)
 
 Example:

--- a/quantum-framework/src/test/java/com/e2eq/framework/api/grammar/TestGrammar.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/api/grammar/TestGrammar.java
@@ -198,4 +198,16 @@ public class TestGrammar {
          parser.query();
       }
    }
+
+   @Test
+   public void testTextSearchSingleClause() {
+      Filter f = MorphiaUtils.convertToFilter("text(\"priority escalation\")&&status:OPEN", UserProfile.class);
+      assertNotNull(f);
+   }
+
+   @Test
+   public void testTextSearchDuplicateClauseRejected() {
+      assertThrows(IllegalStateException.class,
+              () -> MorphiaUtils.convertToFilter("text(\"one\")&&text(\"two\")", UserProfile.class));
+   }
 }

--- a/quantum-framework/src/test/resources/testQueryStrings.txt
+++ b/quantum-framework/src/test/resources/testQueryStrings.txt
@@ -163,3 +163,7 @@ field:"*15"" LAPTOP SLEEVE-Black Twill*"
 
 #--Has Edge
 hasEdge(placedInOrg, ORG-ACME)
+
+#-- Text search
+text("priority escalation")
+text("priority escalation")&&status:"OPEN"

--- a/quantum-models/src/main/antlr4/com/e2eq/framework/grammar/BIAPIQuery.g4
+++ b/quantum-models/src/main/antlr4/com/e2eq/framework/grammar/BIAPIQuery.g4
@@ -3,7 +3,7 @@ grammar BIAPIQuery;
 query: (exprGroup | compoundExpr) (exprOp (exprGroup | compoundExpr))*;
 exprGroup: lp=LPAREN (exprGroup | compoundExpr) (exprOp (exprGroup | compoundExpr))* rp=RPAREN;
 compoundExpr: allowedExpr (exprOp allowedExpr)*;
-allowedExpr:   inExpr |  basicExpr |  nullExpr | existsExpr | booleanExpr | notExpr | regexExpr | elemMatchExpr | hasEdgeExpr | hasIncomingEdgeExpr | expandExpr;
+allowedExpr:   inExpr |  basicExpr |  nullExpr | existsExpr | booleanExpr | notExpr | regexExpr | elemMatchExpr | hasEdgeExpr | hasIncomingEdgeExpr | expandExpr | textExpr;
 exprOp: op=(AND | OR);
 existsExpr: field=STRING op=EXISTS;
 booleanExpr: field=STRING op=(EQ | NEQ) value=(TRUE | FALSE);
@@ -47,10 +47,12 @@ hasIncomingEdgeExpr: HASINCOMGINEDGE LPAREN predicate=(STRING|QUOTED_STRING|VARI
 // Support simple dotted paths and optional array wildcards [*] between segments.
 // Tokens come in as: STRING ('[' '*' ']')? (STRING ('[' '*' ']')? )*
 expandExpr: EXPAND LPAREN head=(STRING|VARIABLE) (LBRKT WILDCARD RBRKT)? ((seg=(STRING|VARIABLE)) (LBRKT WILDCARD RBRKT)? )* RPAREN;
+textExpr: TEXT LPAREN value=(STRING|QUOTED_STRING|VARIABLE) RPAREN;
 
 HASEDGE: 'hasEdge';
 HASINCOMGINEDGE: 'hasIncomingEdge';
 EXPAND: 'expand';
+TEXT: 'text';
 
 // Operators
 EQ: ':';


### PR DESCRIPTION
### Motivation
- Fix a parity bug where the in-memory listener did not apply a provided `StringSubstitutor` to `text(...)` and quoted string tokens when `variableMap` was null, causing `${...}` patterns to be substituted by Morphia but not in-memory evaluation.

### Description
- Change `resolveTextValue` in `QueryToPredicateJsonListener` to use `sub != null` for substitution instead of checking `variableMap != null`, aligning behavior with `QueryToFilterListener`.

### Testing
- Ran `mvn -pl quantum-framework -Dtest=QueryToPredicateJsonListenerTest test`, which could not complete because Maven failed to download Quarkus BOMs (HTTP 403 from repo.maven.apache.org), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d183c7348326b66ae4e61ae3f6e1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces first-class full-text search in the BIAPI query language via `text("...")`, with parity across database and in-memory execution.
> 
> - Grammar: adds `textExpr` and `TEXT` token in `BIAPIQuery.g4`
> - Morphia listener: implements `enterTextExpr` -> `Filters.text(...)`; validates a single `text(...)` clause per query
> - In-memory listener: implements `enterTextExpr` with case-insensitive, tokenized contains-any matching across all textual JSON values; enforces single `text(...)`; applies `StringSubstitutor` to `text(...)` values
> - Docs: new design doc and user-guide section for text search with examples and limitations
> - Tests: new/updated tests for grammar parsing, Morphia filter generation, in-memory behavior, and duplicate-clause rejection; sample queries updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2427a68377d67eef3f3f590616ad593ca4120e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->