### PR TITLE
few more updates

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SeedAdminResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SeedAdminResource.java
@@ -18,6 +18,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -30,6 +35,7 @@ import java.util.stream.Collectors;
 @Produces(MediaType.APPLICATION_JSON)
 @RolesAllowed({"admin", "system"})
 @ApplicationScoped
+@Tag(name = "seeds-admin", description = "Inspect, manage, and apply seed packs and archetypes")
 public class SeedAdminResource {
 
     @Inject
@@ -46,6 +52,9 @@ public class SeedAdminResource {
 
     @GET
     @Path("/pending/{realm}")
+    @Operation(summary = "List pending seed packs", description = "Returns seed packs that have new or updated datasets not yet applied to the given realm.")
+    @APIResponse(responseCode = "200", description = "Pending seed packs",
+            content = @Content(schema = @Schema(implementation = PendingSeedPack[].class)))
     public List<PendingSeedPack> listPending(@PathParam("realm") String realm,
                                              @QueryParam("filter") String filterCsv) {
         SeedContext context = buildSeedContext(realm);
@@ -73,6 +82,9 @@ public class SeedAdminResource {
 
     @GET
     @Path("/history/{realm}")
+    @Operation(summary = "Seed application history", description = "Returns the history of seed pack applications for the given realm.")
+    @APIResponse(responseCode = "200", description = "Seed history entries",
+            content = @Content(schema = @Schema(implementation = HistoryEntry[].class)))
     public List<HistoryEntry> history(@PathParam("realm") String realm) {
         if (!(seedRegistry instanceof MorphiaSeedRegistry morphiaRegistry)) {
             throw new InternalServerErrorException("SeedRegistry is not MorphiaSeedRegistry");
@@ -94,6 +106,9 @@ public class SeedAdminResource {
 
     @POST
     @Path("/apply/{realm}")
+    @Operation(summary = "Apply all pending seed packs", description = "Discovers and applies all pending seed packs for the given realm.")
+    @APIResponse(responseCode = "200", description = "Names of applied seed packs",
+            content = @Content(schema = @Schema(implementation = ApplyResult.class)))
     public ApplyResult applyAll(@PathParam("realm") String realm,
                                 @QueryParam("filter") String filterCsv) {
         SeedContext context = buildSeedContext(realm);
@@ -114,8 +129,58 @@ public class SeedAdminResource {
         return result;
     }
 
+    @GET
+    @Path("/archetypes/{realm}")
+    @Operation(summary = "List available seed archetypes", description = "Returns archetypes defined in seed pack manifests that are applicable to the given realm.")
+    @APIResponse(responseCode = "200", description = "Available archetypes",
+            content = @Content(schema = @Schema(implementation = ArchetypeInfo[].class)))
+    public List<ArchetypeInfo> listArchetypes(@PathParam("realm") String realm) {
+        SeedContext context = buildSeedContext(realm);
+        List<SeedPackDescriptor> descriptors;
+        try {
+            descriptors = seedDiscoveryService.discoverSeedPacks(context);
+        } catch (IOException e) {
+            throw new InternalServerErrorException("Failed to discover seed packs: " + e.getMessage());
+        }
+
+        descriptors = seedDiscoveryService.filterByScope(descriptors, context);
+        List<ArchetypeInfo> archetypes = new ArrayList<>();
+        for (SeedPackDescriptor d : descriptors) {
+            for (SeedPackManifest.Archetype a : d.getManifest().getArchetypes()) {
+                ArchetypeInfo info = new ArchetypeInfo();
+                info.name = a.getName();
+                info.seedPack = d.getManifest().getSeedPack();
+                info.version = d.getManifest().getVersion();
+                info.includes = a.getIncludeRefs().stream()
+                        .map(SeedPackRef::getName)
+                        .toList();
+                archetypes.add(info);
+            }
+        }
+        archetypes.sort(Comparator.comparing(a -> a.name));
+        return archetypes;
+    }
+
+    @POST
+    @Path("/archetypes/{realm}/{archetypeName}/apply")
+    @Operation(summary = "Apply a seed archetype", description = "Applies the named archetype, seeding all packs it includes into the given realm.")
+    @APIResponse(responseCode = "200", description = "Applied archetype name",
+            content = @Content(schema = @Schema(implementation = ApplyResult.class)))
+    public ApplyResult applyArchetype(@PathParam("realm") String realm,
+                                      @PathParam("archetypeName") String archetypeName) {
+        SeedContext context = buildSeedContext(realm);
+        seedLoaderService.applyArchetype(context, archetypeName);
+        ApplyResult result = new ApplyResult();
+        result.applied = List.of(archetypeName);
+        return result;
+    }
+
     @POST
     @Path("/{realm}/{seedPack}/apply")
+    @Operation(summary = "Apply a single seed pack", description = "Applies the latest version of the specified seed pack to the given realm.")
+    @APIResponse(responseCode = "200", description = "Applied seed pack name",
+            content = @Content(schema = @Schema(implementation = ApplyResult.class)))
+    @APIResponse(responseCode = "404", description = "Seed pack not found or not applicable to this realm")
     public ApplyResult applyOne(@PathParam("realm") String realm,
                                 @PathParam("seedPack") String seedPack) {
         SeedContext context = buildSeedContext(realm);
@@ -198,15 +263,26 @@ public class SeedAdminResource {
     }
 
     // ----- DTOs -----
+
+    @Schema(description = "A seed pack with datasets pending application")
     public static final class PendingSeedPack {
+        @Schema(description = "Composite identifier: seedPack@version", example = "qa-test-locations@1.0.0")
         public String seedId;
+        @Schema(description = "Seed pack name", example = "qa-test-locations")
         public String seedPack;
+        @Schema(description = "Seed pack version", example = "1.0.0")
         public String version;
+        @Schema(description = "Datasets within this pack that are pending")
         public List<PendingDataset> datasets;
     }
+
+    @Schema(description = "A single dataset file within a pending seed pack")
     public static final class PendingDataset {
+        @Schema(description = "Target MongoDB collection", example = "location")
         public String collection;
+        @Schema(description = "Dataset file name", example = "test-locations.jsonl")
         public String file;
+        @Schema(description = "SHA-256 checksum of the dataset file")
         public String checksum;
         public PendingDataset() {}
         public PendingDataset(String collection, String file, String checksum) {
@@ -215,15 +291,38 @@ public class SeedAdminResource {
             this.checksum = checksum;
         }
     }
+
+    @Schema(description = "Record of a previously applied seed dataset")
     public static final class HistoryEntry {
+        @Schema(description = "Seed pack name", example = "qa-test-locations")
         public String seedPack;
+        @Schema(description = "Seed pack version", example = "1.0.0")
         public String version;
+        @Schema(description = "Dataset file name", example = "test-locations.jsonl")
         public String dataset;
+        @Schema(description = "Checksum at time of application")
         public String checksum;
+        @Schema(description = "Number of records applied")
         public Integer records;
+        @Schema(description = "ISO-8601 timestamp when the dataset was applied")
         public String appliedAt;
     }
+
+    @Schema(description = "Result of a seed apply operation")
     public static final class ApplyResult {
+        @Schema(description = "Names of seed packs or archetypes that were applied")
         public List<String> applied;
+    }
+
+    @Schema(description = "Metadata for a seed archetype defined in a seed pack manifest")
+    public static final class ArchetypeInfo {
+        @Schema(description = "Archetype name as defined in the manifest", example = "qa-full-harness")
+        public String name;
+        @Schema(description = "Seed pack that defines this archetype", example = "qa-harness")
+        public String seedPack;
+        @Schema(description = "Seed pack version", example = "1.0.0")
+        public String version;
+        @Schema(description = "Ordered list of seed pack names included in this archetype")
+        public List<String> includes;
     }
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/seed/MorphiaSeedRepository.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/seed/MorphiaSeedRepository.java
@@ -649,7 +649,7 @@ public class MorphiaSeedRepository implements SeedRepository {
     private Class<? extends UnversionedBaseModel> resolveTargetModelClass(SeedPackManifest.ReferenceBinding binding, Field field) {
         if (binding.getTargetModelClass() != null && !binding.getTargetModelClass().isBlank()) {
             try {
-                Class<?> loaded = Class.forName(binding.getTargetModelClass());
+                Class<?> loaded = Class.forName(binding.getTargetModelClass(), true, Thread.currentThread().getContextClassLoader());
                 if (!UnversionedBaseModel.class.isAssignableFrom(loaded)) {
                     throw new SeedLoadingException("Reference target model class " + binding.getTargetModelClass() + " is not a UnversionedBaseModel");
                 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedLoader.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedLoader.java
@@ -629,7 +629,7 @@ public final class SeedLoader {
             return;
         }
         try {
-            Class<?> cls = Class.forName(mc);
+            Class<?> cls = Class.forName(mc, true, Thread.currentThread().getContextClassLoader());
             // Try Morphia @Entity annotation
             try {
                 dev.morphia.annotations.Entity ann = cls.getAnnotation(dev.morphia.annotations.Entity.class);

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedReferenceBindings.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedReferenceBindings.java
@@ -76,7 +76,7 @@ final class SeedReferenceBindings {
             return null;
         }
         try {
-            return Class.forName(modelClassName);
+            return Class.forName(modelClassName, true, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw new SeedLoadingException("Unable to load modelClass " + modelClassName + " while resolving seed reference bindings", e);
         }

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SmartSeedLoader.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SmartSeedLoader.java
@@ -63,8 +63,9 @@ public class SmartSeedLoader {
       }
 
       // 3. Resolve Repo & Class
-      Class<?> modelClass = Class.forName(dataset.getModelClass());
-      Class<?> repoClass = Class.forName(dataset.getRepoClass());
+      ClassLoader cl = Thread.currentThread().getContextClassLoader();
+      Class<?> modelClass = Class.forName(dataset.getModelClass(), true, cl);
+      Class<?> repoClass = Class.forName(dataset.getRepoClass(), true, cl);
       // Dynamic CDI lookup - finds the bean instance
       BaseMorphiaRepo repo = (BaseMorphiaRepo) Arc.container().select(repoClass).get();
 


### PR DESCRIPTION
## Problem

The seed admin API lacked endpoints for inspecting and applying seed archetypes, and `Class.forName()` calls throughout the seed subsystem used the default classloader, which fails under Quarkus's thread-context classloading model. Additionally, the seed admin REST endpoints had no OpenAPI annotations, making them invisible in the Swagger UI.

## Solution

Added archetype list/apply endpoints, switched all `Class.forName` calls to use `Thread.currentThread().getContextClassLoader()`, and annotated every endpoint and DTO with OpenAPI metadata.

## Change Highlights

- New `GET /archetypes/{realm}` endpoint to list available seed archetypes from manifests
- New `POST /archetypes/{realm}/{archetypeName}/apply` endpoint to apply a named archetype
- Added `@Tag`, `@Operation`, `@APIResponse`, and `@Schema` annotations to all `SeedAdminResource` endpoints and DTOs
- Fixed `Class.forName()` in `MorphiaSeedRepository`, `SeedLoader`, `SeedReferenceBindings`, and `SmartSeedLoader` to use the thread-context classloader

## Testing

- Build passes (`mvn clean install -DskipTests` succeeded)
- Manual verification of archetype discovery and application against a running instance