### PR TITLE
Add AES-256-GCM encryption-at-rest for managed secrets

### DIFF
--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/crypto/EncryptedValue.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/crypto/EncryptedValue.java
@@ -1,0 +1,27 @@
+package com.e2eq.framework.secrets.crypto;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Holds the result of an AES-256-GCM encryption operation.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RegisterForReflection
+public class EncryptedValue {
+
+    /** Base64-encoded ciphertext (includes GCM auth tag). */
+    private String ciphertext;
+
+    /** Base64-encoded 12-byte initialization vector. */
+    private String iv;
+
+    /** The KEK version that was used for encryption. */
+    private int keyVersion;
+}

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/crypto/SecretEncryptor.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/crypto/SecretEncryptor.java
@@ -1,0 +1,228 @@
+package com.e2eq.framework.secrets.crypto;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * AES-256-GCM encryption/decryption service with key-rotation support.
+ *
+ * <p>Key Encryption Keys (KEKs) are read from MicroProfile Config:
+ * <ul>
+ *   <li>{@code quantum.secrets.kek.active-version} — the key version used for new encryptions (default 1)</li>
+ *   <li>{@code quantum.secrets.kek.v1}, {@code quantum.secrets.kek.v2}, ... — Base64-encoded 256-bit keys</li>
+ * </ul>
+ */
+@ApplicationScoped
+@RegisterForReflection
+public class SecretEncryptor {
+
+    private static final Logger LOG = Logger.getLogger(SecretEncryptor.class);
+
+    private static final String ALGORITHM = "AES";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final int GCM_IV_LENGTH_BYTES = 12;
+
+    @ConfigProperty(name = "quantum.secrets.kek.active-version", defaultValue = "1")
+    int activeKeyVersion;
+
+    @ConfigProperty(name = "quantum.secrets.kek.v1")
+    Optional<String> kekV1;
+
+    @ConfigProperty(name = "quantum.secrets.kek.v2")
+    Optional<String> kekV2;
+
+    @ConfigProperty(name = "quantum.secrets.kek.v3")
+    Optional<String> kekV3;
+
+    @ConfigProperty(name = "quantum.secrets.kek.v4")
+    Optional<String> kekV4;
+
+    @ConfigProperty(name = "quantum.secrets.kek.v5")
+    Optional<String> kekV5;
+
+    private final Map<Integer, SecretKey> keys = new ConcurrentHashMap<>();
+    private final SecureRandom secureRandom = new SecureRandom();
+    private boolean keysAvailable = false;
+
+    @PostConstruct
+    void init() {
+        registerKey(1, kekV1);
+        registerKey(2, kekV2);
+        registerKey(3, kekV3);
+        registerKey(4, kekV4);
+        registerKey(5, kekV5);
+
+        if (keys.isEmpty()) {
+            LOG.warn("No KEKs configured — encryption/decryption will be unavailable until "
+                    + "quantum.secrets.kek.v<N> properties are set in application.properties.");
+            keysAvailable = false;
+            return;
+        }
+
+        if (!keys.containsKey(activeKeyVersion)) {
+            LOG.warnf("Active KEK version %d is not configured. Available versions: %s. "
+                    + "Encryption/decryption will be unavailable until quantum.secrets.kek.v%d is set.",
+                    activeKeyVersion, keys.keySet(), activeKeyVersion);
+            keysAvailable = false;
+            return;
+        }
+
+        keysAvailable = true;
+        LOG.infof("SecretEncryptor initialised — %d key(s) loaded, active version = %d",
+                keys.size(), activeKeyVersion);
+    }
+
+    /**
+     * Returns whether encryption keys are properly configured and available.
+     *
+     * @return {@code true} if KEKs are loaded and the active version is present
+     */
+    public boolean isKeysAvailable() {
+        return keysAvailable;
+    }
+
+    /**
+     * Returns the currently active key version used for new encryptions.
+     */
+    public int getActiveKeyVersion() {
+        return activeKeyVersion;
+    }
+
+    /**
+     * Encrypts plaintext using AES-256-GCM with the active key version.
+     *
+     * @param plaintext the value to encrypt
+     * @return an {@link EncryptedValue} containing Base64-encoded ciphertext, IV, and key version
+     */
+    public EncryptedValue encrypt(String plaintext) {
+        if (!keysAvailable) {
+            throw new SecretEncryptionException(
+                    "No KEK configured. Set quantum.secrets.kek.v" + activeKeyVersion
+                    + " in application.properties.");
+        }
+        if (plaintext == null || plaintext.isEmpty()) {
+            throw new IllegalArgumentException("Plaintext must not be null or empty");
+        }
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH_BYTES];
+            secureRandom.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, resolveKey(activeKeyVersion), gcmSpec);
+
+            byte[] ciphertextBytes = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+
+            return EncryptedValue.builder()
+                    .ciphertext(Base64.getEncoder().encodeToString(ciphertextBytes))
+                    .iv(Base64.getEncoder().encodeToString(iv))
+                    .keyVersion(activeKeyVersion)
+                    .build();
+        } catch (Exception e) {
+            throw new SecretEncryptionException("Encryption failed", e);
+        }
+    }
+
+    /**
+     * Decrypts a previously encrypted value.
+     *
+     * @param ciphertext  Base64-encoded ciphertext
+     * @param iv          Base64-encoded initialization vector
+     * @param keyVersion  the KEK version that was used to encrypt
+     * @return the decrypted plaintext
+     */
+    public String decrypt(String ciphertext, String iv, int keyVersion) {
+        if (!keysAvailable) {
+            throw new SecretEncryptionException(
+                    "No KEK configured. Set quantum.secrets.kek.v" + activeKeyVersion
+                    + " in application.properties.");
+        }
+        if (ciphertext == null || iv == null) {
+            throw new IllegalArgumentException("Ciphertext and IV must not be null");
+        }
+        try {
+            byte[] ivBytes = Base64.getDecoder().decode(iv);
+            byte[] ciphertextBytes = Base64.getDecoder().decode(ciphertext);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, ivBytes);
+            cipher.init(Cipher.DECRYPT_MODE, resolveKey(keyVersion), gcmSpec);
+
+            byte[] plaintextBytes = cipher.doFinal(ciphertextBytes);
+            return new String(plaintextBytes, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new SecretEncryptionException("Decryption failed for key version " + keyVersion, e);
+        }
+    }
+
+    /**
+     * Re-encrypts a value from one key version to another.
+     * Decrypts with {@code fromVersion}, then encrypts with {@code toVersion}.
+     *
+     * @param ciphertext   Base64-encoded ciphertext
+     * @param iv           Base64-encoded initialization vector
+     * @param fromVersion  the current key version
+     * @param toVersion    the target key version
+     * @return a new {@link EncryptedValue} encrypted under {@code toVersion}
+     */
+    public EncryptedValue reEncrypt(String ciphertext, String iv, int fromVersion, int toVersion) {
+        String plaintext = decrypt(ciphertext, iv, fromVersion);
+        // Temporarily override active version to encrypt with the target version
+        int originalActive = this.activeKeyVersion;
+        try {
+            this.activeKeyVersion = toVersion;
+            return encrypt(plaintext);
+        } finally {
+            this.activeKeyVersion = originalActive;
+        }
+    }
+
+    // ---- internal helpers ----
+
+    private SecretKey resolveKey(int version) {
+        SecretKey key = keys.get(version);
+        if (key == null) {
+            throw new SecretEncryptionException("No KEK configured for version " + version);
+        }
+        return key;
+    }
+
+    private void registerKey(int version, Optional<String> base64Key) {
+        base64Key.ifPresent(encoded -> {
+            byte[] decoded = Base64.getDecoder().decode(encoded);
+            if (decoded.length != 32) {
+                throw new IllegalStateException(
+                        "KEK v" + version + " must be exactly 256 bits (32 bytes), got " + decoded.length);
+            }
+            keys.put(version, new SecretKeySpec(decoded, ALGORITHM));
+        });
+    }
+
+    /**
+     * Runtime exception for encryption/decryption failures.
+     */
+    public static class SecretEncryptionException extends RuntimeException {
+        public SecretEncryptionException(String message) {
+            super(message);
+        }
+
+        public SecretEncryptionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/crypto/SecretsMigrationService.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/crypto/SecretsMigrationService.java
@@ -1,0 +1,147 @@
+package com.e2eq.framework.secrets.crypto;
+
+import com.e2eq.framework.model.persistent.morphia.RealmRepo;
+import com.e2eq.framework.model.security.Realm;
+import com.e2eq.framework.secrets.model.ManagedSecret;
+import com.e2eq.framework.secrets.model.ManagedSecretRepo;
+import com.e2eq.framework.util.EnvConfigUtils;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service to migrate existing plaintext secrets to AES-256-GCM encryption.
+ *
+ * <p>Existing {@link ManagedSecret} documents stored before encryption was introduced
+ * have {@code iv == null} and {@code keyVersion == 0}. Their {@code valueEncrypted}
+ * field contains the raw plaintext. This service detects those documents, encrypts
+ * the plaintext with the active KEK, and updates the document in-place.</p>
+ */
+@ApplicationScoped
+public class SecretsMigrationService {
+
+    private static final Logger LOG = Logger.getLogger(SecretsMigrationService.class);
+
+    @Inject
+    ManagedSecretRepo secretRepo;
+
+    @Inject
+    SecretEncryptor encryptor;
+
+    @Inject
+    RealmRepo realmRepo;
+
+    @Inject
+    EnvConfigUtils envConfigUtils;
+
+    /**
+     * Migrate plaintext secrets across ALL realms.
+     *
+     * @return per-realm migration results
+     */
+    public Map<String, RealmMigrationResult> migrateAllRealms() {
+        String systemRealm = envConfigUtils.getSystemRealm();
+        List<Realm> allRealms = realmRepo.getAllListWithIgnoreRules(systemRealm);
+
+        LOG.infof("Starting secrets migration across %d realm(s)", allRealms.size());
+
+        Map<String, RealmMigrationResult> results = new LinkedHashMap<>();
+        for (Realm realm : allRealms) {
+            String realmId = realm.getDatabaseName();
+            try {
+                RealmMigrationResult result = migrateRealm(realmId);
+                results.put(realmId, result);
+                LOG.infof("Realm '%s': migrated=%d, skipped=%d, failed=%d",
+                        realmId, result.migrated, result.skipped, result.failed);
+            } catch (Exception e) {
+                LOG.errorf(e, "Failed to migrate realm '%s'", realmId);
+                results.put(realmId, new RealmMigrationResult(0, 0, 0, e.getMessage()));
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Migrate plaintext secrets for a single realm.
+     *
+     * @param realmId the realm (database name) to migrate
+     * @return migration result counts
+     */
+    public RealmMigrationResult migrateRealm(String realmId) {
+        List<ManagedSecret> secrets = secretRepo.findAll(realmId, null);
+
+        int migrated = 0;
+        int skipped = 0;
+        int failed = 0;
+
+        for (ManagedSecret secret : secrets) {
+            // Detect plaintext: iv is null means this was never encrypted
+            if (secret.getIv() != null && !secret.getIv().isEmpty()) {
+                // Already encrypted
+                skipped++;
+                continue;
+            }
+
+            if (secret.getValueEncrypted() == null || secret.getValueEncrypted().isEmpty()) {
+                // No value to migrate
+                skipped++;
+                continue;
+            }
+
+            try {
+                // The current valueEncrypted IS the plaintext — encrypt it
+                String plaintext = secret.getValueEncrypted();
+                EncryptedValue encrypted = encryptor.encrypt(plaintext);
+
+                secret.setValueEncrypted(encrypted.getCiphertext());
+                secret.setIv(encrypted.getIv());
+                secret.setKeyVersion(encrypted.getKeyVersion());
+
+                secretRepo.save(realmId, secret);
+                migrated++;
+            } catch (Exception e) {
+                LOG.errorf(e, "Failed to migrate secret '%s' in realm '%s'",
+                        secret.getRefName(), realmId);
+                failed++;
+            }
+        }
+
+        return new RealmMigrationResult(migrated, skipped, failed, null);
+    }
+
+    /**
+     * Generates a cryptographically secure 256-bit AES key, Base64-encoded.
+     * This is a utility for operators to generate KEK values for configuration.
+     *
+     * @return Base64-encoded 256-bit key
+     */
+    public static String generateKek() {
+        byte[] key = new byte[32]; // 256 bits
+        new SecureRandom().nextBytes(key);
+        return Base64.getEncoder().encodeToString(key);
+    }
+
+    /**
+     * Result of migrating secrets in a single realm.
+     */
+    public static class RealmMigrationResult {
+        public final int migrated;
+        public final int skipped;
+        public final int failed;
+        public final String error;
+
+        public RealmMigrationResult(int migrated, int skipped, int failed, String error) {
+            this.migrated = migrated;
+            this.skipped = skipped;
+            this.failed = failed;
+            this.error = error;
+        }
+    }
+}

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/model/ManagedSecret.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/model/ManagedSecret.java
@@ -27,10 +27,21 @@ public class ManagedSecret extends FullBaseModel {
     private boolean realmDefault;
 
     /**
-     * Placeholder field name retained for forward compatibility with a stronger
-     * encryption-at-rest implementation.
+     * AES-256-GCM encrypted ciphertext (Base64-encoded).
+     * Encrypted using the KEK identified by {@link #keyVersion}.
      */
     private String valueEncrypted;
+
+    /**
+     * Base64-encoded 12-byte initialization vector used for GCM encryption.
+     */
+    private String iv;
+
+    /**
+     * The KEK version that was used to encrypt {@link #valueEncrypted}.
+     * Enables key rotation — old secrets can be re-encrypted to a newer key.
+     */
+    private int keyVersion;
 
     public boolean isConfigured() {
         return valueEncrypted != null && !valueEncrypted.isBlank();

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/ManagedSecretResource.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/ManagedSecretResource.java
@@ -1,9 +1,12 @@
 package com.e2eq.framework.secrets.rest;
 
+import com.e2eq.framework.secrets.crypto.EncryptedValue;
+import com.e2eq.framework.secrets.crypto.SecretEncryptor;
 import com.e2eq.framework.secrets.model.ManagedSecret;
 import com.e2eq.framework.secrets.model.ManagedSecretRepo;
 import com.e2eq.framework.secrets.rest.dto.ManagedSecretCreateUpdateRequest;
 import com.e2eq.framework.secrets.rest.dto.ManagedSecretResponse;
+import com.e2eq.framework.secrets.rest.dto.SecretRotationResponse;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -17,8 +20,10 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
 
 import java.util.List;
+import java.util.Map;
 
 @Path("/settings/secrets")
 @Produces(MediaType.APPLICATION_JSON)
@@ -26,10 +31,14 @@ import java.util.List;
 @RolesAllowed({"tenantAdmin", "platformAdmin", "admin", "system"})
 public class ManagedSecretResource {
 
-    private final ManagedSecretRepo repo;
+    private static final Logger LOG = Logger.getLogger(ManagedSecretResource.class);
 
-    public ManagedSecretResource(ManagedSecretRepo repo) {
+    private final ManagedSecretRepo repo;
+    private final SecretEncryptor encryptor;
+
+    public ManagedSecretResource(ManagedSecretRepo repo, SecretEncryptor encryptor) {
         this.repo = repo;
+        this.encryptor = encryptor;
     }
 
     @GET
@@ -49,6 +58,44 @@ public class ManagedSecretResource {
         ManagedSecret secret = repo.findByRefName(realmId, refName)
                 .orElseThrow(() -> new NotFoundException("Secret not found: " + refName));
         return Response.ok(toResponse(secret)).build();
+    }
+
+    /**
+     * Returns the decrypted plaintext value of a secret.
+     * Intended for internal service consumption only.
+     */
+    @GET
+    @Path("{refName}/value")
+    @RolesAllowed({"tenantAdmin", "platformAdmin", "admin", "system"})
+    public Response getValue(@PathParam("refName") String refName) {
+        String realmId = repo.getSecurityContextRealmId();
+        ManagedSecret secret = repo.findByRefName(realmId, refName)
+                .orElseThrow(() -> new NotFoundException("Secret not found: " + refName));
+
+        if (!secret.isConfigured()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(Map.of("error", "Secret has no value configured"))
+                    .build();
+        }
+
+        // Legacy plaintext secret (pre-migration): iv is null, keyVersion is 0
+        if (secret.getIv() == null || secret.getIv().isEmpty()) {
+            return Response.ok(Map.of("value", secret.getValueEncrypted())).build();
+        }
+
+        if (!encryptor.isKeysAvailable()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "Encryption keys not configured — cannot decrypt secret"))
+                    .build();
+        }
+
+        String plaintext = encryptor.decrypt(
+                secret.getValueEncrypted(),
+                secret.getIv(),
+                secret.getKeyVersion()
+        );
+
+        return Response.ok(Map.of("value", plaintext)).build();
     }
 
     @POST
@@ -90,6 +137,74 @@ public class ManagedSecretResource {
         return Response.noContent().build();
     }
 
+    /**
+     * Re-encrypts all secrets in the current realm from their current key version
+     * to the active key version. Secrets already on the active version are skipped.
+     */
+    @POST
+    @Path("rotate-keys")
+    @RolesAllowed({"platformAdmin", "admin", "system"})
+    public Response rotateKeys() {
+        if (!encryptor.isKeysAvailable()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "Encryption keys not configured — cannot rotate"))
+                    .build();
+        }
+
+        String realmId = repo.getSecurityContextRealmId();
+        int activeVersion = encryptor.getActiveKeyVersion();
+
+        List<ManagedSecret> allSecrets = repo.findAll(realmId, null);
+
+        int rotated = 0;
+        int skipped = 0;
+        int failed = 0;
+
+        for (ManagedSecret secret : allSecrets) {
+            if (!secret.isConfigured()) {
+                skipped++;
+                continue;
+            }
+
+            if (secret.getKeyVersion() == activeVersion) {
+                skipped++;
+                continue;
+            }
+
+            try {
+                EncryptedValue reEncrypted = encryptor.reEncrypt(
+                        secret.getValueEncrypted(),
+                        secret.getIv(),
+                        secret.getKeyVersion(),
+                        activeVersion
+                );
+                secret.setValueEncrypted(reEncrypted.getCiphertext());
+                secret.setIv(reEncrypted.getIv());
+                secret.setKeyVersion(reEncrypted.getKeyVersion());
+                repo.save(realmId, secret);
+                rotated++;
+            } catch (Exception e) {
+                LOG.errorf(e, "Failed to rotate secret '%s' from key v%d to v%d",
+                        secret.getRefName(), secret.getKeyVersion(), activeVersion);
+                failed++;
+            }
+        }
+
+        LOG.infof("Key rotation complete for realm '%s': rotated=%d, skipped=%d, failed=%d, activeVersion=%d",
+                realmId, rotated, skipped, failed, activeVersion);
+
+        SecretRotationResponse result = SecretRotationResponse.builder()
+                .rotated(rotated)
+                .skipped(skipped)
+                .failed(failed)
+                .activeKeyVersion(activeVersion)
+                .build();
+
+        return Response.ok(result).build();
+    }
+
+    // ---- helpers ----
+
     private static ManagedSecretResponse toResponse(ManagedSecret secret) {
         return ManagedSecretResponse.builder()
                 .refName(secret.getRefName())
@@ -99,10 +214,11 @@ public class ManagedSecretResource {
                 .providerType(secret.getProviderType())
                 .realmDefault(secret.isRealmDefault())
                 .configured(secret.isConfigured())
+                .keyVersion(secret.isConfigured() ? secret.getKeyVersion() : null)
                 .build();
     }
 
-    private static void apply(ManagedSecret secret, ManagedSecretCreateUpdateRequest request, boolean create) {
+    private void apply(ManagedSecret secret, ManagedSecretCreateUpdateRequest request, boolean create) {
         if (create && request.getRefName() != null) {
             secret.setRefName(request.getRefName());
         }
@@ -122,7 +238,17 @@ public class ManagedSecretResource {
             secret.setRealmDefault(request.getRealmDefault());
         }
         if (request.getValue() != null && !request.getValue().isBlank()) {
-            secret.setValueEncrypted(request.getValue());
+            if (encryptor.isKeysAvailable()) {
+                EncryptedValue encrypted = encryptor.encrypt(request.getValue());
+                secret.setValueEncrypted(encrypted.getCiphertext());
+                secret.setIv(encrypted.getIv());
+                secret.setKeyVersion(encrypted.getKeyVersion());
+            } else {
+                // No KEKs configured yet — store as plaintext (will be migrated later)
+                LOG.warn("KEKs not configured — storing secret as plaintext. "
+                        + "Run migration after configuring quantum.secrets.kek.v1");
+                secret.setValueEncrypted(request.getValue());
+            }
         }
     }
 }

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/SecretsMigrationResource.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/SecretsMigrationResource.java
@@ -1,0 +1,126 @@
+package com.e2eq.framework.secrets.rest;
+
+import com.e2eq.framework.secrets.crypto.SecretsMigrationService;
+import com.e2eq.framework.secrets.crypto.SecretsMigrationService.RealmMigrationResult;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Admin-only endpoints for secrets encryption migration and KEK management.
+ *
+ * <h3>Migration workflow:</h3>
+ * <ol>
+ *   <li>Generate a KEK: {@code POST /settings/secrets/admin/generate-kek}</li>
+ *   <li>Configure it in {@code application.properties}: {@code quantum.secrets.kek.v1=<base64-key>}</li>
+ *   <li>Restart the application</li>
+ *   <li>Run migration: {@code POST /settings/secrets/admin/migrate} (all realms)
+ *       or {@code POST /settings/secrets/admin/migrate/{realmId}} (single realm)</li>
+ * </ol>
+ */
+@Path("/settings/secrets/admin")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed({"platformAdmin", "admin", "system"})
+public class SecretsMigrationResource {
+
+    private static final Logger LOG = Logger.getLogger(SecretsMigrationResource.class);
+
+    private final SecretsMigrationService migrationService;
+
+    public SecretsMigrationResource(SecretsMigrationService migrationService) {
+        this.migrationService = migrationService;
+    }
+
+    /**
+     * Generates a new 256-bit AES key (Base64-encoded) suitable for use as a KEK.
+     * The key is NOT automatically stored — it must be manually added to configuration.
+     *
+     * @return the generated key
+     */
+    @POST
+    @Path("generate-kek")
+    public Response generateKek() {
+        String kek = SecretsMigrationService.generateKek();
+        Map<String, String> result = new LinkedHashMap<>();
+        result.put("key", kek);
+        result.put("algorithm", "AES-256");
+        result.put("encoding", "Base64");
+        result.put("instruction", "Add to application.properties as quantum.secrets.kek.v<N>=<key>");
+        LOG.info("Generated new KEK — must be configured in application.properties before use");
+        return Response.ok(result).build();
+    }
+
+    /**
+     * Migrates plaintext secrets to encrypted form across ALL realms.
+     * Secrets that are already encrypted (iv is non-null) are skipped.
+     *
+     * @return per-realm migration results
+     */
+    @POST
+    @Path("migrate")
+    public Response migrateAllRealms() {
+        LOG.info("Starting plaintext-to-encrypted migration for all realms");
+        Map<String, RealmMigrationResult> results = migrationService.migrateAllRealms();
+
+        // Build response
+        Map<String, Object> response = new LinkedHashMap<>();
+        int totalMigrated = 0;
+        int totalSkipped = 0;
+        int totalFailed = 0;
+
+        Map<String, Object> realmDetails = new LinkedHashMap<>();
+        for (Map.Entry<String, RealmMigrationResult> entry : results.entrySet()) {
+            RealmMigrationResult r = entry.getValue();
+            totalMigrated += r.migrated;
+            totalSkipped += r.skipped;
+            totalFailed += r.failed;
+
+            Map<String, Object> detail = new LinkedHashMap<>();
+            detail.put("migrated", r.migrated);
+            detail.put("skipped", r.skipped);
+            detail.put("failed", r.failed);
+            if (r.error != null) {
+                detail.put("error", r.error);
+            }
+            realmDetails.put(entry.getKey(), detail);
+        }
+
+        response.put("totalMigrated", totalMigrated);
+        response.put("totalSkipped", totalSkipped);
+        response.put("totalFailed", totalFailed);
+        response.put("realmCount", results.size());
+        response.put("realms", realmDetails);
+
+        return Response.ok(response).build();
+    }
+
+    /**
+     * Migrates plaintext secrets to encrypted form for a single realm.
+     *
+     * @param realmId the realm/database to migrate
+     * @return migration results
+     */
+    @POST
+    @Path("migrate/{realmId}")
+    public Response migrateRealm(@PathParam("realmId") String realmId) {
+        LOG.infof("Starting plaintext-to-encrypted migration for realm '%s'", realmId);
+        RealmMigrationResult result = migrationService.migrateRealm(realmId);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("realm", realmId);
+        response.put("migrated", result.migrated);
+        response.put("skipped", result.skipped);
+        response.put("failed", result.failed);
+        if (result.error != null) {
+            response.put("error", result.error);
+        }
+
+        return Response.ok(response).build();
+    }
+}

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/dto/ManagedSecretResponse.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/dto/ManagedSecretResponse.java
@@ -20,4 +20,5 @@ public class ManagedSecretResponse {
     private String providerType;
     private Boolean realmDefault;
     private Boolean configured;
+    private Integer keyVersion;
 }

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/dto/SecretRotationResponse.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/dto/SecretRotationResponse.java
@@ -1,0 +1,30 @@
+package com.e2eq.framework.secrets.rest.dto;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response DTO for the bulk key-rotation endpoint.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RegisterForReflection
+public class SecretRotationResponse {
+
+    /** Number of secrets successfully re-encrypted. */
+    private int rotated;
+
+    /** Number of secrets already on the active key version (skipped). */
+    private int skipped;
+
+    /** Number of secrets that failed re-encryption. */
+    private int failed;
+
+    /** The active key version that secrets were rotated to. */
+    private int activeKeyVersion;
+}


### PR DESCRIPTION
## Summary

- **AES-256-GCM encryption** for `ManagedSecret.valueEncrypted` with versioned KEKs via MicroProfile Config (`quantum.secrets.kek.v1` through `v5`)
- **Fail-safe startup**: application boots without KEKs configured — secrets module logs a warning and falls back to plaintext storage until keys are provisioned
- **Cross-realm migration service**: detects plaintext secrets (`iv=null`, `keyVersion=0`) across all tenant databases and encrypts them in-place
- **Admin REST endpoints** at `/settings/secrets/admin/`:
  - `POST /generate-kek` — generates a 256-bit AES key (Base64) for configuration
  - `POST /migrate` — migrates all realms from plaintext to encrypted
  - `POST /migrate/{realmId}` — migrates a single realm
- **Key rotation** via existing `POST /settings/secrets/rotate-keys` — re-encrypts from old to active key version
- **Legacy compatibility**: `GET /{refName}/value` returns plaintext directly for unmigrated secrets

## Migration Workflow

1. Generate KEK: `POST /settings/secrets/admin/generate-kek`
2. Add to config: `quantum.secrets.kek.v1=<base64-key>`
3. Restart application
4. Run migration: `POST /settings/secrets/admin/migrate`

## Files Changed

| File | Change |
|------|--------|
| `crypto/SecretEncryptor.java` | New — AES-256-GCM service with key rotation |
| `crypto/EncryptedValue.java` | New — encryption result DTO |
| `crypto/SecretsMigrationService.java` | New — cross-realm plaintext→encrypted migration |
| `rest/SecretsMigrationResource.java` | New — admin endpoints for KEK gen + migration |
| `rest/dto/SecretRotationResponse.java` | New — rotation result DTO |
| `model/ManagedSecret.java` | Added `iv`, `keyVersion` fields |
| `rest/ManagedSecretResource.java` | Encrypt on write, decrypt on read, legacy fallback |
| `rest/dto/ManagedSecretResponse.java` | Added `keyVersion` field |

## Test plan

- [ ] Verify application starts without KEKs configured (no crash)
- [ ] Create a secret via POST — stored as plaintext when no KEK
- [ ] Configure KEK v1 and restart
- [ ] Create a secret — verify `iv` and `keyVersion` populated in MongoDB
- [ ] GET `/{refName}/value` — returns decrypted plaintext
- [ ] Run `POST /admin/migrate` — converts plaintext secrets to encrypted
- [ ] Verify round-trip: encrypted value decrypts to original
- [ ] Configure KEK v2, run `POST /rotate-keys` — verify re-encryption

🤖 Generated with [Claude Code](https://claude.com/claude-code)