### PR TITLE
Calculated relations: M1+M2+M3 implementation

### DIFF
--- a/quantum-docs/src/docs/asciidoc/design/calculated-relations-roadmap.adoc
+++ b/quantum-docs/src/docs/asciidoc/design/calculated-relations-roadmap.adoc
@@ -1,0 +1,339 @@
+= Calculated Relations — Design and Roadmap
+
+*Status:* Draft, targeted at the `1.4.0-SNAPSHOT` line.
+*Owners:* Ontology team.
+*Scope:* `quantum-ontology-core`, `quantum-ontology-mongo`, `quantum-ontology-policy-bridge`, `quantum-cli`, `quantum-docs`.
+
+This document captures a forward-looking design for the *calculated relations*
+subsystem (computed/derived ontology edges). It collects the gaps observed in
+the current implementation, proposes targeted enhancements, and sequences them
+into a phased roadmap.
+
+For a usage-level introduction to ontology relationships, see
+`user-guide/ontology.adoc`. For the territory/location reference
+implementation, see `implementing-territory-location-edges.md`.
+
+== Background
+
+The framework distinguishes three ways edges enter `ontology_edges`:
+
+[cols="1,1,1,3", options="header"]
+|===
+|Kind |`inferred` |`derived` |Source
+
+|Explicit
+|false
+|false
+|`@OntologyProperty` annotation or YAML triple
+
+|Inferred
+|true
+|false
+|`ForwardChainingReasoner` (transitive, symmetric, subPropertyOf, chains)
+
+|Derived (calculated)
+|false
+|true
+|`ComputedEdgeProvider` SPI implementations
+|===
+
+The flags live on `EdgeRecord` (`quantum-ontology-core/.../EdgeRecord.java`).
+
+Calculated edges are produced by CDI beans extending
+`ComputedEdgeProvider<S>` (or its specialization `HierarchyListEdgeProvider<S, H, T>`),
+discovered via `ComputedEdgeRegistry`, and triggered post-persist by
+`OntologyWriteHook`. Each edge carries a `ComputedEdgeProvenance` record
+(`providerId`, `hierarchyPath`, `resolvedLists`, `computedAt`).
+
+== Problem Statement
+
+Calculated relations work, but the current implementation has rough edges that
+will become painful as the number of providers and the size of materialized
+edge sets grow:
+
+. *Eager-only materialization.* Every relevant entity write recomputes and
+  rewrites the full edge set for affected sources. There is no compute-on-read
+  or cached tier.
+. *Silent staleness.* Providers that declare `getDependencyTypes()` but leave
+  `getAffectedSourceIds()` returning the default empty set will quietly skip
+  invalidation. There is no startup-time validation and no runtime warning.
+. *No declarative path for the common shape.* The "source assigned to
+  hierarchy node, node carries list of targets" pattern is implemented by
+  hand in every provider, even though `HierarchyListEdgeProvider` already
+  shapes the structure.
+. *No automatic cycle/depth guards in compute.* The reasoner caps iteration
+  at 10, but provider-side compute relies on the implementer to terminate.
+. *Provenance bloat.* Per-edge provenance maps are stored inline on every
+  `EdgeRecord`, inflating the working set for high-fanout providers.
+. *No bulk recompute / reconciliation tool.* When provider logic changes,
+  there is no first-class way to reprocess existing sources.
+. *No metrics surface.* Per-provider invocation count, duration, and
+  add/remove deltas are not exposed.
+. *Heavy test setup.* Provider unit tests require Mongo and full repo wiring.
+
+== Goals
+
+* Reduce write-amplification for high-fanout providers without changing the
+  read API.
+* Make staleness bugs hard to introduce — fail loud, not silent.
+* Lower the cost of authoring a new calculated relation for the common case
+  to roughly "fill out a YAML block".
+* Give operators visibility (metrics) and a recovery path (recompute CLI).
+* Keep the existing `ComputedEdgeProvider` contract as the escape hatch;
+  do not break callers.
+
+== Non-Goals
+
+* A full SPARQL/OWL query layer. The expression DSL stays narrow.
+* Replacing the reasoner. Inferred edges remain the reasoner's domain.
+* Cross-realm or cross-tenant edge sharing.
+
+== Design
+
+=== D1. Materialization Modes
+
+Add a `MaterializationMode` enum returned by a new
+`ComputedEdgeProvider#getMaterializationMode()` (default `EAGER`):
+
+[source,java]
+----
+public enum MaterializationMode {
+    EAGER,    // current behavior: write through to ontology_edges
+    LAZY,     // compute on read; cache with TTL
+    ONDEMAND  // never store; always compute via the repo facade
+}
+----
+
+`OntologyEdgeRepo` gains a thin facade that, for `LAZY`/`ONDEMAND` providers,
+short-circuits a `findBySrcAndP` to the provider rather than the collection.
+The `LAZY` cache lives in a `ComputedEdgeCache` (Caffeine, per-realm,
+TTL-configurable per provider). Cache invalidation reuses the existing
+`getAffectedSourceIds` machinery.
+
+*Acceptance:* an existing provider can opt into `LAZY` by overriding one
+method; reads return the same edges as before; writes that previously fanned
+out N edges no longer write any rows for that provider.
+
+=== D2. Dependency Validation and Loud Staleness
+
+Add startup-time validation in `ComputedEdgeRegistry`:
+
+. For each registered provider, walk `getDependencyTypes()`.
+. For each dependency type, check whether `getAffectedSourceIds(...)` for an
+  arbitrary id returns the default empty set *and* the method has not been
+  overridden (detected via reflection on the declaring class).
+. Log a `WARN` and emit a Micrometer counter `ontology.provider.staleness_risk`
+  tagged by `providerId` and `dependencyType`.
+
+Add an optional `@DependsOn` annotation that declaratively expresses the
+inverse-edge query for the common case:
+
+[source,java]
+----
+@DependsOn(type = Territory.class, via = "assignedTerritories", expand = ANCESTORS)
+@DependsOn(type = LocationList.class, via = "staticDynamicList")
+public class AssociateCanSeeLocationProvider extends HierarchyListEdgeProvider<...> { }
+----
+
+The registry derives `getAffectedSourceIds` from the annotation if the method
+has not been explicitly overridden.
+
+*Acceptance:* removing the override on a provider with `@DependsOn` keeps
+invalidation correct; removing both surfaces a warning at startup.
+
+=== D3. Declarative Hierarchy/List Edges
+
+Extend the YAML ontology schema to allow `computed:` definitions for the
+hierarchy+list pattern:
+
+[source,yaml]
+----
+computed:
+  - id: canSeeLocation
+    domain: Associate
+    range: Location
+    via:
+      hierarchy:
+        node: Territory
+        from: assignedTerritories     # field on Associate
+        expand: descendants            # descendants | ancestors | none
+      list:
+        field: locationLists           # field on Territory
+        mode: auto                     # auto | static | dynamic
+    dependsOn:
+      - type: Territory
+      - type: LocationList
+----
+
+A `YamlComputedEdgeProvider` implementation reads these blocks at boot and
+registers a synthetic provider per entry. Hand-rolled providers remain the
+escape hatch for everything that does not fit this shape.
+
+*Acceptance:* the territory/location reference example can be expressed
+entirely in YAML and produces edges identical to the hand-rolled provider
+under the existing integration tests.
+
+=== D4. Compute Guards
+
+Augment `ComputationContext` with:
+
+* `Set<String> visitedNodeIds` — automatically populated by
+  `HierarchyListEdgeProvider` during BFS; revisits short-circuit.
+* `int maxHierarchyDepth` (configurable, default 64).
+* `int maxComputedTargets` (configurable, default 50_000).
+
+When a guard trips, the provider returns the partial result, logs a `WARN`,
+and increments a counter tagged by provider. Bare `ComputedEdgeProvider`
+implementations get the same context and can opt in.
+
+*Acceptance:* a synthetic test with a cyclic Territory hierarchy completes
+without stack overflow and emits the expected warning counter.
+
+=== D5. Provenance Off the Hot Path
+
+Move per-edge provenance out of `EdgeRecord.prov` into a sibling collection
+`ontology_edge_provenance` keyed by edge `_id`. `EdgeRecord` retains a
+lightweight `provRef` (boolean: provenance available) and `providerId` for
+filtering.
+
+Graph REST endpoints accept `?withProv=true` to join provenance into the
+response. The policy bridge does not need provenance, so its hot path
+shrinks proportionally.
+
+*Acceptance:* an edge query with `withProv=false` returns documents whose
+average size is reduced by the previously-inlined provenance bytes; with
+`withProv=true` the response is byte-equivalent (modulo ordering) to today.
+
+Migration: a one-shot job copies existing `prov` maps to the side
+collection and clears the inline field.
+
+=== D6. Bulk Recompute CLI
+
+Add a `quantum-cli` verb:
+
+[source]
+----
+quantum ontology recompute \
+    --provider AssociateCanSeeLocationProvider \
+    --realm acme \
+    [--source-id <id>] [--dry-run] [--batch-size 500]
+----
+
+It iterates source entities (filtered to `--source-id` if given), runs the
+provider's `computeTargets`, diffs against current materialized edges, and
+applies (or reports, with `--dry-run`) the deltas. Output: per-source
+add/remove counts and a final summary.
+
+*Acceptance:* running with `--dry-run` after a no-op deploy reports zero
+deltas; running after a deliberate provider-logic change reports the
+expected diff.
+
+=== D7. Metrics
+
+Wrap `ComputedEdgeProvider#edges(...)` in a Micrometer timer and counters,
+tagged by `providerId`:
+
+* `ontology.provider.invocations` — counter
+* `ontology.provider.duration` — timer
+* `ontology.provider.targets_produced` — distribution summary
+* `ontology.provider.edges_added`, `ontology.provider.edges_removed` —
+  counters (emitted from the materializer diff path)
+
+Surfaced through the existing Quarkus Micrometer registry.
+
+*Acceptance:* `/q/metrics` exposes the counters with non-zero values after
+the integration test run.
+
+=== D8. Provider Test Kit
+
+Add `quantum-ontology-core/src/test-fixtures` (or a `test-jar`) module with:
+
+* `InMemoryHierarchyRepo<H>` — accepts a tree literal in tests.
+* `InMemoryListResolver<T>` — registered (listId → items) map.
+* `ComputedEdgeProviderHarness` — wires a provider against the fakes and
+  asserts target sets and provenance.
+
+The provider unit test for `AssociateCanSeeLocationProvider` is rewritten
+against the harness; the existing `TerritoryLocationPermissionIT` remains
+the integration coverage.
+
+*Acceptance:* the provider unit tests no longer depend on Mongo or Quarkus
+boot; they run in &lt;1s.
+
+== Roadmap
+
+The roadmap is organized into three sequential milestones inside the
+`1.4.0-SNAPSHOT` line. Each milestone is independently shippable.
+
+[cols="1,2,3,2,1", options="header"]
+|===
+|Milestone |Theme |Items |Risk |Target
+
+|*M1 — Safety Net*
+|Make staleness loud, give us metrics and a test kit before we change
+behavior.
+a|
+* D2 — Dependency validation and `@DependsOn`
+* D4 — Compute guards
+* D7 — Metrics
+* D8 — Provider Test Kit
+|Low. Additive only; no on-disk format change.
+|`1.4.0-SNAPSHOT` early
+
+|*M2 — Operability*
+|Recovery path and provenance footprint.
+a|
+* D6 — Bulk recompute CLI
+* D5 — Provenance off the hot path (with one-shot migration)
+|Medium. Migration touches existing data; gated by feature flag
+`quantum.ontology.provenance.split` (default off until validated).
+|`1.4.0-SNAPSHOT` mid
+
+|*M3 — Performance and Authoring*
+|Reduce write amplification and lower the cost of new providers.
+a|
+* D1 — Materialization modes (EAGER, LAZY, ONDEMAND)
+* D3 — Declarative computed edges in YAML
+|Medium-high. New code paths in the read layer; YAML schema additions.
+|`1.4.0-SNAPSHOT` late / branch handoff
+|===
+
+=== Sequencing Rationale
+
+* M1 ships first because its items are observability and validation. They
+  surface latent bugs that M2/M3 might otherwise hide.
+* M2 ships before M3 because D5 (provenance split) is a prerequisite for
+  honest cost comparisons of D1 (LAZY/ONDEMAND).
+* D3 is intentionally last; we want to validate the declarative shape
+  against real providers ported in M2/M3, not against speculative ones.
+
+== Backwards Compatibility
+
+* All `ComputedEdgeProvider` subclasses continue to compile and run unchanged.
+* The new `getMaterializationMode()` defaults to `EAGER`.
+* The new `@DependsOn` annotation is opt-in; missing annotations behave as today.
+* The provenance split is gated behind a feature flag; with the flag off,
+  `EdgeRecord.prov` continues to be populated inline.
+
+== Open Questions
+
+. Should `LAZY` results be cached per (source, predicate) or per source?
+  Per-source is simpler but invalidates more aggressively.
+. Where does `@DependsOn`-derived invalidation actually run the inverse
+  query — synchronously in the write hook, or via a lightweight worker?
+. For the YAML DSL, do we surface filters on the list step
+  (`list.filter: "active = true"`), or push that to the existing
+  static/dynamic list machinery?
+. Should the recompute CLI emit an idempotent ledger so re-runs converge,
+  or is the diff-and-apply path sufficient?
+
+These are deferred to the design discussion at the start of M1.
+
+== Out of Scope (For Now)
+
+* A general expression language for arbitrary computed edges (vs. just the
+  hierarchy+list shape). Tracked for a future major.
+* Cross-provider memoization (e.g. two providers walking the same Territory
+  tree share work). Plausible after M3 but not in this roadmap.
+* GraphQL-style on-the-fly traversal. Out of scope; use the existing graph
+  REST endpoints.

--- a/quantum-docs/src/docs/asciidoc/design/calculated-relations-roadmap.adoc
+++ b/quantum-docs/src/docs/asciidoc/design/calculated-relations-roadmap.adoc
@@ -1,8 +1,26 @@
 = Calculated Relations — Design and Roadmap
 
-*Status:* Draft, targeted at the `1.4.0-SNAPSHOT` line.
+*Status:* Implemented on `feature/ontology-enhancements` against `1.4.0-SNAPSHOT`.
 *Owners:* Ontology team.
 *Scope:* `quantum-ontology-core`, `quantum-ontology-mongo`, `quantum-ontology-policy-bridge`, `quantum-cli`, `quantum-docs`.
+
+[NOTE]
+====
+*Implementation status (initial pass):* All eight design items have landed.
+Per-item notes appear inline in the design and the roadmap table below. In
+short:
+
+* M1 (Safety Net): D7 metrics, D4 guards, D2 `@DependsOn` + validator, D8
+  test kit — all complete with unit tests in `quantum-ontology-core`.
+* M2 (Operability): D6 bulk recompute service + admin REST; D5 provenance
+  side-collection storage and migration runner. The CLI shim and the
+  upsert-path rewrite are explicitly deferred (see notes).
+* M3 (Performance / Authoring): D1 materialization modes (EAGER/LAZY/ONDEMAND)
+  with cache + read facade + write-hook honoring; D3 declarative `computed:`
+  YAML block + `DeclarativeComputedEdgeProvider`.
+
+Total new test coverage in `quantum-ontology-core`: 72 tests (was 53).
+====
 
 This document captures a forward-looking design for the *calculated relations*
 subsystem (computed/derived ontology edges). It collects the gaps observed in
@@ -92,6 +110,19 @@ edge sets grow:
 
 === D1. Materialization Modes
 
+[NOTE]
+.Status: implemented
+====
+* `MaterializationMode` enum at `quantum-ontology-core/.../core/MaterializationMode.java`.
+* `ComputedEdgeProvider#getMaterializationMode()` (default EAGER) and
+  `getCacheTtlSeconds()` hooks.
+* `ComputedEdgeCache` (per-process TTL'd map) at `quantum-ontology-core/.../core/ComputedEdgeCache.java`.
+* `OntologyWriteHook` skips non-EAGER providers at write time.
+* `ComputedEdgeReader` (in `quantum-ontology-mongo`) is the read-side
+  facade; `ComputedEdgeRecomputeHandler` punches the cache for LAZY and
+  no-ops for ONDEMAND on dependency changes.
+====
+
 Add a `MaterializationMode` enum returned by a new
 `ComputedEdgeProvider#getMaterializationMode()` (default `EAGER`):
 
@@ -115,6 +146,20 @@ method; reads return the same edges as before; writes that previously fanned
 out N edges no longer write any rows for that provider.
 
 === D2. Dependency Validation and Loud Staleness
+
+[NOTE]
+.Status: implemented
+====
+* `@DependsOn(type, via, expand)` (repeatable) at
+  `quantum-ontology-core/.../annotations/DependsOn.java`.
+* `ComputedEdgeProvider#getDependencyTypes()` derives its default from
+  `@DependsOn` declarations on the class hierarchy.
+* `ComputedEdgeStalenessValidator` is pure logic in core, unit-tested
+  without CDI.
+* `ComputedEdgeProviderAutoDiscovery` runs the validator at startup,
+  emits WARN logs, and bumps `OntologyMetrics.recordStalenessRisk` per
+  unhelped (provider, dependency-type) pair.
+====
 
 Add startup-time validation in `ComputedEdgeRegistry`:
 
@@ -142,6 +187,21 @@ has not been explicitly overridden.
 invalidation correct; removing both surfaces a warning at startup.
 
 === D3. Declarative Hierarchy/List Edges
+
+[NOTE]
+.Status: implemented
+====
+* YAML `computed:` block parsed by `YamlOntologyLoader.loadComputedSpecs()`
+  into `ComputedEdgeSpec` records.
+* `DeclarativeRuntime<S, H, T>` SPI for application-supplied entity
+  loading / hierarchy walk / list resolution.
+* `DeclarativeComputedEdgeProvider` extends `HierarchyListEdgeProvider`,
+  so the cycle/depth/target guards from D4 apply automatically.
+* End-to-end test: `DeclarativeComputedEdgeTest` loads a YAML spec and
+  produces the expected target set against in-memory fakes.
+* `dependsOn:` entries are surfaced via `declaredDependencyTypeNames()`;
+  applications resolve type strings to classes when registering a runtime.
+====
 
 Extend the YAML ontology schema to allow `computed:` definitions for the
 hierarchy+list pattern:
@@ -175,6 +235,20 @@ under the existing integration tests.
 
 === D4. Compute Guards
 
+[NOTE]
+.Status: implemented
+====
+* `ComputationContext` now tracks `visitedNodeIds`, configurable
+  `maxHierarchyDepth` (default 64) and `maxComputedTargets` (default
+  50_000), and a list of guard trips.
+* `HierarchyListEdgeProvider` short-circuits on cycle / depth / target
+  hits and records the trip. (Note: with the existing flat-descendants
+  API, `maxHierarchyDepth` is interpreted as max hierarchy nodes
+  processed, not tree depth — see HierarchyListGuardsTest.)
+* Trips flow into `OntologyMetrics.recordGuardTrip` per provider via the
+  static metrics hook on `ComputedEdgeProvider`.
+====
+
 Augment `ComputationContext` with:
 
 * `Set<String> visitedNodeIds` — automatically populated by
@@ -190,6 +264,22 @@ implementations get the same context and can opt in.
 without stack overflow and emits the expected warning counter.
 
 === D5. Provenance Off the Hot Path
+
+[NOTE]
+.Status: storage + migration implemented; upsert wiring deferred
+====
+* `OntologyEdgeProvenanceDoc` (collection `ontology_edge_provenance`),
+  `OntologyEdgeProvenanceRepo`, and `ProvenanceStore` strategy.
+* Feature flag `quantum.ontology.provenance.split` (default false). With
+  the flag off, behavior is unchanged.
+* `ProvenanceMigrationService.migrate(realm, dryRun)` is idempotent and
+  exposed at `POST /ontology/admin/provenance/migrate`.
+* *Deferred:* rewriting `OntologyMaterializer` and `OntologyEdgeRepo`
+  upsert paths to consult `ProvenanceStore` rather than setting `prov`
+  directly. Doing so without the integration-test environment risked
+  regressions; the storage and migration are the correct foundation
+  and can be wired in with full IT coverage in a follow-up.
+====
 
 Move per-edge provenance out of `EdgeRecord.prov` into a sibling collection
 `ontology_edge_provenance` keyed by edge `_id`. `EdgeRecord` retains a
@@ -208,6 +298,24 @@ Migration: a one-shot job copies existing `prov` maps to the side
 collection and clears the inline field.
 
 === D6. Bulk Recompute CLI
+
+[NOTE]
+.Status: service implemented; REST endpoint exposed; CLI shim deferred
+====
+* `BulkRecomputeService` walks all source entities for a provider via a
+  registered `SourceEntityEnumerator` SPI, recomputes target sets,
+  diffs against persisted edges, and either reports deltas (`dryRun=true`)
+  or re-applies via the existing `ComputedEdgeRecomputeHandler`.
+* Exposed at `POST /ontology/admin/recompute` with the original
+  request/response shape.
+* `GET /ontology/admin/metrics` exposes the `OntologyMetrics` snapshot.
+* *Deferred:* the picocli verb. `quantum-cli` already binds
+  `@TopCommand` to `ServiceTokenCLI`; quarkus-picocli only allows one
+  top command, so adding a sibling would either restructure the
+  existing CLI invocation or require a parallel jar. The REST endpoint
+  is the canonical entry point; a thin CLI wrapper that posts to it
+  can land separately.
+====
 
 Add a `quantum-cli` verb:
 
@@ -230,6 +338,22 @@ expected diff.
 
 === D7. Metrics
 
+[NOTE]
+.Status: implemented (in-process; Micrometer bridge follow-up)
+====
+* `OntologyMetrics` is a dependency-free `@ApplicationScoped` bean in
+  `quantum-ontology-core`. Per-provider counters: invocations, total /
+  avg / max nanos, targets produced, edges added, edges removed, errors,
+  guard trips, staleness-risk-by-dependency.
+* Wired in `OntologyWriteHook` (timing per provider invocation) and
+  `OntologyMaterializer` (added/removed deltas via `prov.providerId`
+  inspection).
+* Snapshot exposed at `GET /ontology/admin/metrics`.
+* *Follow-up:* a Micrometer bridge (subscribe to `OntologyMetrics`
+  snapshots and emit gauges/counters) is intentionally separate so
+  `quantum-ontology-core` stays free of the Micrometer dependency.
+====
+
 Wrap `ComputedEdgeProvider#edges(...)` in a Micrometer timer and counters,
 tagged by `providerId`:
 
@@ -245,6 +369,24 @@ Surfaced through the existing Quarkus Micrometer registry.
 the integration test run.
 
 === D8. Provider Test Kit
+
+[NOTE]
+.Status: implemented
+====
+* `com.e2eq.ontology.testkit.InMemoryHierarchy<H, T>` builds a fluent
+  fake hierarchy with parent/child links and per-node list items; its
+  `descendants(nodeId)` matches the `HierarchyListEdgeProvider`
+  flat-descendants contract.
+* `com.e2eq.ontology.testkit.ComputedEdgeProviderHarness` invokes any
+  `ComputedEdgeProvider` against a fake `DataDomainInfo` and returns a
+  `Result` with `targetIds()` and `providerIds()` helpers.
+* Sample test (`TestKitSampleTest`) declares a hierarchy + provider in
+  ~80 lines with no Mongo and no Quarkus boot.
+* Drive-by fix: `extractId`, `extractNodeId`, and `extractNodeRefName`
+  now `setAccessible(true)` on the reflected `getId/getRefName` methods,
+  so providers work against package-private fixtures and
+  reflection-loaded classes.
+====
 
 Add `quantum-ontology-core/src/test-fixtures` (or a `test-jar`) module with:
 
@@ -265,9 +407,9 @@ boot; they run in &lt;1s.
 The roadmap is organized into three sequential milestones inside the
 `1.4.0-SNAPSHOT` line. Each milestone is independently shippable.
 
-[cols="1,2,3,2,1", options="header"]
+[cols="1,2,3,2,1,1", options="header"]
 |===
-|Milestone |Theme |Items |Risk |Target
+|Milestone |Theme |Items |Risk |Target |Status
 
 |*M1 — Safety Net*
 |Make staleness loud, give us metrics and a test kit before we change
@@ -279,15 +421,17 @@ a|
 * D8 — Provider Test Kit
 |Low. Additive only; no on-disk format change.
 |`1.4.0-SNAPSHOT` early
+|Done
 
 |*M2 — Operability*
 |Recovery path and provenance footprint.
 a|
-* D6 — Bulk recompute CLI
-* D5 — Provenance off the hot path (with one-shot migration)
+* D6 — Bulk recompute (REST; CLI shim deferred)
+* D5 — Provenance side collection + migration (upsert wiring deferred)
 |Medium. Migration touches existing data; gated by feature flag
 `quantum.ontology.provenance.split` (default off until validated).
 |`1.4.0-SNAPSHOT` mid
+|Done (with documented deferrals)
 
 |*M3 — Performance and Authoring*
 |Reduce write amplification and lower the cost of new providers.
@@ -296,6 +440,7 @@ a|
 * D3 — Declarative computed edges in YAML
 |Medium-high. New code paths in the read layer; YAML schema additions.
 |`1.4.0-SNAPSHOT` late / branch handoff
+|Done
 |===
 
 === Sequencing Rationale

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/annotations/DependsOn.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/annotations/DependsOn.java
@@ -1,0 +1,54 @@
+package com.e2eq.ontology.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Declares that a {@code ComputedEdgeProvider} reads from another entity type
+ * during its computation.
+ *
+ * <p>Two effects:</p>
+ * <ul>
+ *   <li>The annotated type is auto-registered as a dependency type, so changes
+ *       to it can trigger recomputation. This populates
+ *       {@code ComputedEdgeProvider.getDependencyTypes()} when the method is
+ *       not overridden.</li>
+ *   <li>The optional {@link #via} field on the source entity, combined with
+ *       {@link #expand}, gives enough information for a future inverse-query
+ *       resolver to derive {@code getAffectedSourceIds()} without each provider
+ *       reimplementing it. Today the framework uses this metadata for
+ *       startup-time validation: providers declaring dependencies but missing
+ *       both an override and a usable {@code @DependsOn} get a WARN.</li>
+ * </ul>
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Repeatable(DependsOnList.class)
+public @interface DependsOn {
+
+    /** Entity type this provider reads. */
+    Class<?> type();
+
+    /**
+     * Optional field name on the source entity that references {@link #type}.
+     * Used by the inverse-query resolver. Empty means "no inverse-query hint";
+     * the provider must override {@code getAffectedSourceIds} itself.
+     */
+    String via() default "";
+
+    /** Hierarchy expansion direction for inverse-query resolution. */
+    Expand expand() default Expand.NONE;
+
+    enum Expand {
+        /** No traversal beyond direct references. */
+        NONE,
+        /** Walk parent links from the changed entity. */
+        ANCESTORS,
+        /** Walk child links from the changed entity. */
+        DESCENDANTS
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/annotations/DependsOnList.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/annotations/DependsOnList.java
@@ -1,0 +1,14 @@
+package com.e2eq.ontology.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/** Container annotation for repeatable {@link DependsOn}. */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface DependsOnList {
+    DependsOn[] value();
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeCache.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeCache.java
@@ -1,0 +1,92 @@
+package com.e2eq.ontology.core;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Per-process TTL'd cache for {@link MaterializationMode#LAZY} computed edges.
+ *
+ * <p>Keyed by ({@code providerId}, {@code realm}, {@code tenant}, {@code sourceId}).
+ * Values are immutable {@code List<Reasoner.Edge>}.</p>
+ *
+ * <p>Implementation is intentionally a simple ConcurrentHashMap with
+ * lazy-eviction on read; we don't pull in Caffeine here to keep
+ * {@code quantum-ontology-core} dependency-free. The hot path is amortized
+ * O(1) and entries are bounded by the live key set + TTL.</p>
+ */
+@ApplicationScoped
+public class ComputedEdgeCache {
+
+    private final Map<Key, Entry> entries = new ConcurrentHashMap<>();
+    private final AtomicLong hits = new AtomicLong();
+    private final AtomicLong misses = new AtomicLong();
+    private final AtomicLong evictions = new AtomicLong();
+
+    public Optional<List<Reasoner.Edge>> get(Key key) {
+        Entry e = entries.get(key);
+        if (e == null) {
+            misses.incrementAndGet();
+            return Optional.empty();
+        }
+        if (e.isExpired()) {
+            entries.remove(key, e);
+            evictions.incrementAndGet();
+            misses.incrementAndGet();
+            return Optional.empty();
+        }
+        hits.incrementAndGet();
+        return Optional.of(e.edges);
+    }
+
+    public void put(Key key, List<Reasoner.Edge> edges, long ttlSeconds) {
+        long expiresAtMillis = ttlSeconds > 0
+                ? System.currentTimeMillis() + ttlSeconds * 1000L
+                : Long.MAX_VALUE;
+        entries.put(key, new Entry(List.copyOf(edges), expiresAtMillis));
+    }
+
+    public void invalidate(Key key) {
+        if (entries.remove(key) != null) evictions.incrementAndGet();
+    }
+
+    public int invalidateProvider(String providerId) {
+        int n = 0;
+        for (Iterator<Key> it = entries.keySet().iterator(); it.hasNext(); ) {
+            Key k = it.next();
+            if (Objects.equals(k.providerId, providerId)) {
+                it.remove();
+                n++;
+            }
+        }
+        evictions.addAndGet(n);
+        return n;
+    }
+
+    public void clear() {
+        evictions.addAndGet(entries.size());
+        entries.clear();
+    }
+
+    public Map<String, Long> stats() {
+        Map<String, Long> m = new LinkedHashMap<>();
+        m.put("size", (long) entries.size());
+        m.put("hits", hits.get());
+        m.put("misses", misses.get());
+        m.put("evictions", evictions.get());
+        return m;
+    }
+
+    public record Key(String providerId, String realm, String tenant, String sourceId) {}
+
+    private static final class Entry {
+        final List<Reasoner.Edge> edges;
+        final long expiresAtMillis;
+        Entry(List<Reasoner.Edge> edges, long expiresAtMillis) {
+            this.edges = edges; this.expiresAtMillis = expiresAtMillis;
+        }
+        boolean isExpired() { return System.currentTimeMillis() >= expiresAtMillis; }
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeCache.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeCache.java
@@ -79,7 +79,18 @@ public class ComputedEdgeCache {
         return m;
     }
 
-    public record Key(String providerId, String realm, String tenant, String sourceId) {}
+    /**
+     * Cache key. Includes the full DataDomain scope so two requests sharing a
+     * tenant id but different orgRefName / accountNum / dataSegment do not
+     * collide (the underlying edge repo scopes by all four fields).
+     */
+    public record Key(String providerId,
+                      String realm,
+                      String orgRefName,
+                      String accountNum,
+                      String tenantId,
+                      int dataSegment,
+                      String sourceId) {}
 
     private static final class Entry {
         final List<Reasoner.Edge> edges;

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
@@ -288,9 +288,10 @@ public abstract class ComputedEdgeProvider<S> implements OntologyEdgeProvider {
      * @return entity ID as string
      */
     protected String extractId(S entity) {
-        // Use reflection to find getId() method
         try {
             var method = entity.getClass().getMethod("getId");
+            // Allow invocation on package-private holders (test fixtures, inner classes).
+            method.setAccessible(true);
             Object id = method.invoke(entity);
             return id != null ? id.toString() : null;
         } catch (Exception e) {

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
@@ -84,6 +84,25 @@ public abstract class ComputedEdgeProvider<S> implements OntologyEdgeProvider {
     }
 
     /**
+     * How the framework should handle the edges this provider produces.
+     * Default is {@link MaterializationMode#EAGER}.
+     *
+     * @see MaterializationMode
+     */
+    public MaterializationMode getMaterializationMode() {
+        return MaterializationMode.EAGER;
+    }
+
+    /**
+     * Optional TTL hint for {@link MaterializationMode#LAZY} providers.
+     * Returned in seconds. {@code 0} or negative means "no expiration"
+     * (entries live until invalidated by a dependency change).
+     */
+    public long getCacheTtlSeconds() {
+        return 0;
+    }
+
+    /**
      * The source entity type this provider handles.
      *
      * @return class of the source entity

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
@@ -1,5 +1,6 @@
 package com.e2eq.ontology.core;
 
+import com.e2eq.ontology.annotations.DependsOn;
 import com.e2eq.ontology.annotations.OntologyClass;
 import com.e2eq.ontology.metrics.OntologyMetrics;
 import com.e2eq.ontology.spi.OntologyEdgeProvider;
@@ -151,15 +152,30 @@ public abstract class ComputedEdgeProvider<S> implements OntologyEdgeProvider {
      * Returns the entity types that, when modified, should trigger recomputation
      * of edges from this provider.
      *
-     * <p>For example, if Associate→canSeeLocation depends on Territory and LocationList,
-     * this method should return {@code Set.of(Territory.class, LocationList.class)}.</p>
-     *
-     * <p>Override this method to enable incremental updates when dependencies change.</p>
-     *
-     * @return set of dependency entity types (empty by default)
+     * <p>By default this is the union of {@link DependsOn#type()} values declared
+     * on the provider class (and its superclasses). Override to add types that
+     * cannot be expressed declaratively, or to suppress declared ones.</p>
      */
     public Set<Class<?>> getDependencyTypes() {
-        return Set.of();
+        return dependsOnDeclarations().stream()
+                .map(DependsOn::type)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Resolved {@link DependsOn} declarations on this provider's class hierarchy.
+     * Used by {@code getDependencyTypes()} and by the startup validator.
+     */
+    public final List<DependsOn> dependsOnDeclarations() {
+        List<DependsOn> out = new ArrayList<>();
+        Class<?> c = getClass();
+        while (c != null && c != Object.class) {
+            // getAnnotationsByType already unwraps the @DependsOnList container.
+            DependsOn[] direct = c.getAnnotationsByType(DependsOn.class);
+            if (direct != null) Collections.addAll(out, direct);
+            c = c.getSuperclass();
+        }
+        return out;
     }
 
     /**

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProvider.java
@@ -1,9 +1,11 @@
 package com.e2eq.ontology.core;
 
 import com.e2eq.ontology.annotations.OntologyClass;
+import com.e2eq.ontology.metrics.OntologyMetrics;
 import com.e2eq.ontology.spi.OntologyEdgeProvider;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Base class for computing ontology edges that require complex multi-step logic
@@ -52,6 +54,23 @@ import java.util.*;
  * @param <S> the source entity type
  */
 public abstract class ComputedEdgeProvider<S> implements OntologyEdgeProvider {
+
+    /**
+     * Optional process-wide metrics sink for computed edges.
+     *
+     * <p>Set during application startup (e.g. by a CDI observer) so that the
+     * base class can record guard trips without depending on CDI here. When
+     * unset (the test path), guard trips are silently ignored.</p>
+     */
+    private static final AtomicReference<OntologyMetrics> METRICS = new AtomicReference<>();
+
+    public static void setMetrics(OntologyMetrics metrics) {
+        METRICS.set(metrics);
+    }
+
+    protected static OntologyMetrics metrics() {
+        return METRICS.get();
+    }
 
     /**
      * Unique identifier for this provider, used in provenance tracking.
@@ -183,6 +202,13 @@ public abstract class ComputedEdgeProvider<S> implements OntologyEdgeProvider {
         ComputationContext context = new ComputationContext(realmId, domain, getProviderId());
         Set<ComputedTarget> targets = computeTargets(context, source);
 
+        OntologyMetrics m = metrics();
+        if (m != null) {
+            for (String trip : context.getGuardTrips()) {
+                m.recordGuardTrip(getProviderId(), trip);
+            }
+        }
+
         return targets.stream()
             .map(target -> createEdge(sourceId, sourceTypeName, target))
             .toList();
@@ -264,14 +290,26 @@ public abstract class ComputedEdgeProvider<S> implements OntologyEdgeProvider {
 
     /**
      * Context for edge computation, providing access to realm, domain,
-     * and provenance tracking.
+     * provenance tracking, and traversal guards.
+     *
+     * <p>The context tracks visited hierarchy node IDs so providers can detect
+     * cycles, and exposes configurable caps on hierarchy depth and total
+     * computed targets. When a cap is hit, the context records the trip; the
+     * caller is expected to stop expanding.</p>
      */
     public static class ComputationContext {
+        public static final int DEFAULT_MAX_HIERARCHY_DEPTH = 64;
+        public static final int DEFAULT_MAX_COMPUTED_TARGETS = 50_000;
+
         private final String realmId;
         private final DataDomainInfo dataDomainInfo;
         private final String providerId;
         private final List<ComputedEdgeProvenance.HierarchyContribution> hierarchyPath = new ArrayList<>();
         private final List<ComputedEdgeProvenance.ListContribution> resolvedLists = new ArrayList<>();
+        private final Set<String> visitedNodeIds = new LinkedHashSet<>();
+        private final List<String> guardTrips = new ArrayList<>();
+        private int maxHierarchyDepth = DEFAULT_MAX_HIERARCHY_DEPTH;
+        private int maxComputedTargets = DEFAULT_MAX_COMPUTED_TARGETS;
 
         public ComputationContext(String realmId, DataDomainInfo dataDomainInfo, String providerId) {
             this.realmId = realmId;
@@ -282,6 +320,46 @@ public abstract class ComputedEdgeProvider<S> implements OntologyEdgeProvider {
         public String getRealmId() { return realmId; }
         public DataDomainInfo getDataDomainInfo() { return dataDomainInfo; }
         public String getProviderId() { return providerId; }
+
+        public int getMaxHierarchyDepth() { return maxHierarchyDepth; }
+        public void setMaxHierarchyDepth(int v) { this.maxHierarchyDepth = Math.max(1, v); }
+
+        public int getMaxComputedTargets() { return maxComputedTargets; }
+        public void setMaxComputedTargets(int v) { this.maxComputedTargets = Math.max(1, v); }
+
+        /**
+         * Mark the given node id as visited. Returns {@code true} if this is the
+         * first visit (caller may proceed), or {@code false} if the node has
+         * already been visited (caller should short-circuit to break a cycle).
+         */
+        public boolean visit(String nodeId) {
+            if (nodeId == null) return true;
+            return visitedNodeIds.add(nodeId);
+        }
+
+        public boolean wasVisited(String nodeId) {
+            return nodeId != null && visitedNodeIds.contains(nodeId);
+        }
+
+        public Set<String> getVisitedNodeIds() {
+            return Collections.unmodifiableSet(visitedNodeIds);
+        }
+
+        /**
+         * Record that a guard tripped. Names: {@code "cycle"}, {@code "maxDepth"},
+         * {@code "maxTargets"}.
+         */
+        public void recordGuardTrip(String guard) {
+            if (guard != null) guardTrips.add(guard);
+        }
+
+        public List<String> getGuardTrips() {
+            return Collections.unmodifiableList(guardTrips);
+        }
+
+        public boolean tripped(String guard) {
+            return guardTrips.contains(guard);
+        }
 
         /**
          * Record a hierarchy node contribution to provenance.

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProviderAutoDiscovery.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProviderAutoDiscovery.java
@@ -1,6 +1,7 @@
 package com.e2eq.ontology.core;
 
 import com.e2eq.ontology.annotations.OntologyClass;
+import com.e2eq.ontology.metrics.OntologyMetrics;
 import com.e2eq.ontology.spi.OntologyEdgeProvider;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
@@ -60,8 +61,12 @@ public class ComputedEdgeProviderAutoDiscovery {
     @Inject
     ComputedEdgeRegistry registry;
 
+    @Inject
+    OntologyMetrics metrics;
+
     @PostConstruct
     void discoverAndRegister() {
+        ComputedEdgeProvider.setMetrics(metrics);
         int registered = 0;
         int total = 0;
         List<String> warnings = new ArrayList<>();

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProviderAutoDiscovery.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeProviderAutoDiscovery.java
@@ -96,6 +96,11 @@ public class ComputedEdgeProviderAutoDiscovery {
                     registry.register(computedProvider);
                     registered++;
 
+                    // Staleness validation: every dependency type must have either an
+                    // override of getAffectedSourceIds OR a @DependsOn with a non-empty
+                    // 'via' (so the inverse-query resolver can derive it).
+                    validateStaleness(computedProvider, warnings);
+
                     if (hasOntologyClass) {
                         Log.infof("Auto-registered ComputedEdgeProvider: %s (source: %s, predicate: %s)",
                             computedProvider.getProviderId(),
@@ -121,6 +126,25 @@ public class ComputedEdgeProviderAutoDiscovery {
             Log.warnf("ComputedEdgeProvider auto-discovery complete: registered %d of %d OntologyEdgeProvider beans, " +
                 "%d provider(s) have configuration issues (see warnings above)",
                 registered, total, warnings.size());
+        }
+    }
+
+    private void validateStaleness(ComputedEdgeProvider<?> provider, List<String> warnings) {
+        ComputedEdgeStalenessValidator.ValidationResult vr =
+                ComputedEdgeStalenessValidator.validate(provider);
+        if (vr.ok()) return;
+
+        for (ComputedEdgeStalenessValidator.StalenessRisk risk : vr.risks()) {
+            String warning = String.format(
+                "Provider '%s' declares dependency on %s but %s. " +
+                "Changes to %s will NOT trigger recomputation; computed edges may go stale.",
+                risk.providerId(),
+                risk.dependencyType().getSimpleName(),
+                risk.reason(),
+                risk.dependencyType().getSimpleName());
+            warnings.add(warning);
+            Log.warnf(warning);
+            metrics.recordStalenessRisk(risk.providerId(), risk.dependencyType().getName());
         }
     }
 }

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeSpec.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeSpec.java
@@ -1,0 +1,44 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.annotations.DependsOn.Expand;
+
+import java.util.List;
+
+/**
+ * Pure-data representation of a declarative computed-edge definition loaded
+ * from YAML.
+ *
+ * <p>Example:</p>
+ * <pre>
+ * computed:
+ *   - id: canSeeLocation
+ *     domain: Associate
+ *     range: Location
+ *     via:
+ *       hierarchy:
+ *         node: Territory
+ *         from: assignedTerritories
+ *         expand: descendants     # descendants | ancestors | none
+ *       list:
+ *         field: locationLists
+ *         mode: auto              # auto | static | dynamic
+ *     dependsOn:
+ *       - { type: Territory }
+ *       - { type: LocationList }
+ * </pre>
+ *
+ * <p>Spec is consumed by {@code DeclarativeComputedEdgeProvider} together with
+ * an application-supplied {@code DeclarativeRuntime} that knows how to load
+ * entities and walk hierarchies.</p>
+ */
+public record ComputedEdgeSpec(
+        String id,
+        String domain,
+        String range,
+        Hierarchy hierarchy,
+        ListSpec list,
+        List<String> dependsOnTypes
+) {
+    public record Hierarchy(String nodeType, String fromField, Expand expand) {}
+    public record ListSpec(String field, String mode) {}
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeStalenessValidator.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/ComputedEdgeStalenessValidator.java
@@ -1,0 +1,71 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.annotations.DependsOn;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Pure-logic validator for computed-edge providers.
+ *
+ * <p>For each declared dependency type, the provider must either override
+ * {@link ComputedEdgeProvider#getAffectedSourceIds} or carry a
+ * {@link DependsOn} with a non-empty {@code via} hint. Otherwise changes to
+ * the dependency cannot invalidate the computed edges and they will go stale.</p>
+ *
+ * <p>Lives in core (no CDI) so it can be unit-tested without a container.</p>
+ */
+public final class ComputedEdgeStalenessValidator {
+
+    private ComputedEdgeStalenessValidator() {}
+
+    /** Result of validating one provider. */
+    public record ValidationResult(
+            String providerId,
+            List<StalenessRisk> risks
+    ) {
+        public boolean ok() { return risks.isEmpty(); }
+    }
+
+    public record StalenessRisk(String providerId, Class<?> dependencyType, String reason) {}
+
+    public static ValidationResult validate(ComputedEdgeProvider<?> provider) {
+        List<StalenessRisk> risks = new ArrayList<>();
+        Set<Class<?>> deps = provider.getDependencyTypes();
+        if (deps.isEmpty()) {
+            return new ValidationResult(provider.getProviderId(), risks);
+        }
+
+        boolean overrides = overridesGetAffectedSourceIds(provider.getClass());
+
+        Set<Class<?>> hasUsableHint = new HashSet<>();
+        for (DependsOn d : provider.dependsOnDeclarations()) {
+            if (d.via() != null && !d.via().isBlank()) hasUsableHint.add(d.type());
+        }
+
+        for (Class<?> dep : deps) {
+            if (overrides || hasUsableHint.contains(dep)) continue;
+            risks.add(new StalenessRisk(
+                    provider.getProviderId(), dep,
+                    "neither overrides getAffectedSourceIds() nor has @DependsOn(via=...)"));
+        }
+        return new ValidationResult(provider.getProviderId(), risks);
+    }
+
+    static boolean overridesGetAffectedSourceIds(Class<?> providerClass) {
+        Class<?> c = providerClass;
+        while (c != null && c != ComputedEdgeProvider.class) {
+            try {
+                c.getDeclaredMethod("getAffectedSourceIds",
+                        ComputedEdgeProvider.ComputationContext.class,
+                        Class.class, String.class);
+                return true;
+            } catch (NoSuchMethodException ignored) {
+                c = c.getSuperclass();
+            }
+        }
+        return false;
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/DeclarativeComputedEdgeProvider.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/DeclarativeComputedEdgeProvider.java
@@ -1,0 +1,75 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.annotations.DependsOn.Expand;
+
+import java.util.*;
+
+/**
+ * Generic {@link HierarchyListEdgeProvider} driven entirely by a
+ * {@link ComputedEdgeSpec} and an application-supplied {@link DeclarativeRuntime}.
+ *
+ * <p>This is the runtime that backs declarative {@code computed:} YAML entries.
+ * One provider instance is created per spec at startup; the framework's
+ * cycle/depth/target guards apply automatically because we extend
+ * {@code HierarchyListEdgeProvider}.</p>
+ */
+public final class DeclarativeComputedEdgeProvider<S, H, T>
+        extends HierarchyListEdgeProvider<S, H, T> {
+
+    private final ComputedEdgeSpec spec;
+    private final DeclarativeRuntime<S, H, T> runtime;
+
+    public DeclarativeComputedEdgeProvider(ComputedEdgeSpec spec, DeclarativeRuntime<S, H, T> runtime) {
+        this.spec = Objects.requireNonNull(spec);
+        this.runtime = Objects.requireNonNull(runtime);
+    }
+
+    @Override public String getProviderId() { return "declarative:" + spec.id(); }
+    @Override public Class<S> getSourceType() { return runtime.getSourceType(); }
+    @Override public String getPredicate() { return spec.id(); }
+    @Override public String getTargetTypeName() { return spec.range(); }
+    @Override protected String getHierarchyTypeName() {
+        return spec.hierarchy() != null ? spec.hierarchy().nodeType() : "Node";
+    }
+
+    @Override protected List<String> getAssignedNodeIds(S source) {
+        return runtime.assignedNodeIds(source);
+    }
+
+    @Override protected Optional<H> loadHierarchyNode(ComputationContext ctx, String nodeId) {
+        return runtime.loadHierarchyNode(nodeId);
+    }
+
+    @Override protected List<H> getChildNodes(ComputationContext ctx, String nodeId) {
+        Expand expand = spec.hierarchy() != null ? spec.hierarchy().expand() : Expand.NONE;
+        if (expand == Expand.NONE) return List.of();
+        return runtime.walkHierarchy(nodeId, expand);
+    }
+
+    @Override protected List<T> resolveListItems(ComputationContext ctx, H node) {
+        return runtime.resolveListItems(node);
+    }
+
+    @Override protected String extractTargetId(T target) {
+        return runtime.extractTargetId(target);
+    }
+
+    /**
+     * Dependencies declared in the spec. The application is responsible for
+     * resolving the type strings (e.g. "Territory") to actual classes; this
+     * method returns the spec's raw strings via the helper below.
+     */
+    public List<String> declaredDependencyTypeNames() {
+        return spec.dependsOnTypes() == null ? List.of() : List.copyOf(spec.dependsOnTypes());
+    }
+
+    @Override
+    public Set<Class<?>> getDependencyTypes() {
+        // The runtime doesn't have access to a class registry. Override in a
+        // subclass or wrap with a Set<Class<?>> at registration time if you
+        // need automatic dependency tracking by class.
+        return Set.of();
+    }
+
+    public ComputedEdgeSpec getSpec() { return spec; }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/DeclarativeRuntime.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/DeclarativeRuntime.java
@@ -1,0 +1,40 @@
+package com.e2eq.ontology.core;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Application-supplied runtime backing a {@link DeclarativeComputedEdgeProvider}.
+ *
+ * <p>The framework can parse a {@code computed:} YAML block into
+ * {@link ComputedEdgeSpec}s, but it cannot load entities by itself — that
+ * needs the application's repository wiring. Implement this for each spec
+ * (or a single multi-type implementation) and register it as a CDI bean.</p>
+ *
+ * @param <S> source type
+ * @param <H> hierarchy node type
+ * @param <T> target (list item) type
+ */
+public interface DeclarativeRuntime<S, H, T> {
+
+    /** True if this runtime backs the given spec. */
+    boolean supports(ComputedEdgeSpec spec);
+
+    /** Read the assigned hierarchy-node IDs from a source entity. */
+    List<String> assignedNodeIds(S source);
+
+    /** Load a hierarchy node by ID. */
+    Optional<H> loadHierarchyNode(String nodeId);
+
+    /** Walk the hierarchy according to {@link ComputedEdgeSpec.Hierarchy#expand()}. */
+    List<H> walkHierarchy(String nodeId, com.e2eq.ontology.annotations.DependsOn.Expand expand);
+
+    /** Resolve the items the node's list points at. */
+    List<T> resolveListItems(H node);
+
+    /** Stable string id for a target item. */
+    String extractTargetId(T target);
+
+    /** The class of the source type. */
+    Class<S> getSourceType();
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/HierarchyListEdgeProvider.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/HierarchyListEdgeProvider.java
@@ -248,31 +248,70 @@ public abstract class HierarchyListEdgeProvider<S, H, T> extends ComputedEdgePro
 
     @Override
     protected final Set<ComputedTarget> computeTargets(ComputationContext context, S source) {
-        // Map from targetId to accumulated provenance
         Map<String, ProvenanceAccumulator> targetProvenance = new LinkedHashMap<>();
 
         String sourceType = getSourceType().getSimpleName();
         String sourceId = extractId(source);
 
         List<String> assignedNodeIds = getAssignedNodeIds(source);
+        int hierarchyNodesProcessed = 0;
 
+        outer:
         for (String nodeId : assignedNodeIds) {
+            // Cycle guard: skip nodes we've already visited via another assignment.
+            if (!context.visit(nodeId)) {
+                context.recordGuardTrip("cycle");
+                LOG.log(Level.WARNING,
+                        "Provider {0}: cycle detected at node {1}; skipping",
+                        new Object[]{context.getProviderId(), nodeId});
+                continue;
+            }
+            if (++hierarchyNodesProcessed > context.getMaxHierarchyDepth()) {
+                context.recordGuardTrip("maxDepth");
+                LOG.log(Level.WARNING,
+                        "Provider {0}: maxHierarchyDepth ({1}) reached; truncating",
+                        new Object[]{context.getProviderId(), context.getMaxHierarchyDepth()});
+                break;
+            }
+
             Optional<H> nodeOpt = loadHierarchyNode(context, nodeId);
             if (nodeOpt.isEmpty()) continue;
 
-            H node = nodeOpt.get();
+            processNode(context, nodeOpt.get(), true, sourceType, sourceId, targetProvenance);
+            if (targetProvenance.size() >= context.getMaxComputedTargets()) {
+                context.recordGuardTrip("maxTargets");
+                LOG.log(Level.WARNING,
+                        "Provider {0}: maxTargets ({1}) reached; truncating",
+                        new Object[]{context.getProviderId(), context.getMaxComputedTargets()});
+                break outer;
+            }
 
-            // Process assigned node (direct assignment)
-            processNode(context, node, true, sourceType, sourceId, targetProvenance);
-
-            // Process child nodes (inherited)
-            List<H> children = getChildNodes(context, nodeId);
-            for (H child : children) {
+            // Inherited descendants. The flat-descendant API means depth here is
+            // really "how many hierarchy nodes have we processed in total".
+            for (H child : getChildNodes(context, nodeId)) {
+                String childId = extractNodeId(child);
+                if (!context.visit(childId)) {
+                    context.recordGuardTrip("cycle");
+                    continue;
+                }
+                if (++hierarchyNodesProcessed > context.getMaxHierarchyDepth()) {
+                    context.recordGuardTrip("maxDepth");
+                    LOG.log(Level.WARNING,
+                            "Provider {0}: maxHierarchyDepth ({1}) reached; truncating",
+                            new Object[]{context.getProviderId(), context.getMaxHierarchyDepth()});
+                    break outer;
+                }
                 processNode(context, child, false, sourceType, sourceId, targetProvenance);
+                if (targetProvenance.size() >= context.getMaxComputedTargets()) {
+                    context.recordGuardTrip("maxTargets");
+                    LOG.log(Level.WARNING,
+                            "Provider {0}: maxTargets ({1}) reached; truncating",
+                            new Object[]{context.getProviderId(), context.getMaxComputedTargets()});
+                    break outer;
+                }
             }
         }
 
-        // Convert to ComputedTarget set
         return targetProvenance.entrySet().stream()
             .map(e -> new ComputedTarget(e.getKey(), e.getValue().build(sourceType, sourceId)))
             .collect(Collectors.toSet());

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/HierarchyListEdgeProvider.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/HierarchyListEdgeProvider.java
@@ -140,6 +140,7 @@ public abstract class HierarchyListEdgeProvider<S, H, T> extends ComputedEdgePro
     protected String extractNodeId(H node) {
         try {
             var method = node.getClass().getMethod("getId");
+            method.setAccessible(true);
             Object id = method.invoke(node);
             return id != null ? id.toString() : null;
         } catch (Exception e) {
@@ -161,6 +162,7 @@ public abstract class HierarchyListEdgeProvider<S, H, T> extends ComputedEdgePro
     protected String extractNodeRefName(H node) {
         try {
             var method = node.getClass().getMethod("getRefName");
+            method.setAccessible(true);
             Object refName = method.invoke(node);
             return refName != null ? refName.toString() : null;
         } catch (NoSuchMethodException e) {

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/MaterializationMode.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/MaterializationMode.java
@@ -1,0 +1,24 @@
+package com.e2eq.ontology.core;
+
+/**
+ * How a {@code ComputedEdgeProvider}'s output is stored and read.
+ *
+ * <ul>
+ *   <li>{@link #EAGER} — the framework's historical behavior. Edges are
+ *       computed at the source-entity write boundary (see
+ *       {@code OntologyWriteHook}) and persisted to {@code ontology_edges} so
+ *       reads are pure database lookups.</li>
+ *   <li>{@link #LAZY} — edges are not persisted at write time. The first read
+ *       triggers a compute and the result is cached in
+ *       {@code ComputedEdgeCache} for {@link ComputedEdgeProvider#getCacheTtlSeconds()}.
+ *       A dependency change (or recomputation) invalidates the entry.</li>
+ *   <li>{@link #ONDEMAND} — never cached, never persisted. Every read calls the
+ *       provider. Choose this only for inexpensive providers where freshness
+ *       beats latency.</li>
+ * </ul>
+ */
+public enum MaterializationMode {
+    EAGER,
+    LAZY,
+    ONDEMAND
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/YamlOntologyLoader.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/YamlOntologyLoader.java
@@ -1,6 +1,7 @@
 package com.e2eq.ontology.core;
 
 import com.e2eq.ontology.core.OntologyRegistry.*;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.e2eq.ontology.annotations.RelationType;
@@ -19,8 +20,14 @@ import java.util.stream.Collectors;
 public final class YamlOntologyLoader {
 
     // DTOs mirroring YAML
-    public record YOntology(Integer version, List<YClass> classes, List<YProperty> properties, List<YChain> chains) {}
+    public record YOntology(Integer version, List<YClass> classes, List<YProperty> properties,
+                            List<YChain> chains, List<YComputed> computed) {}
     public record YClass(String id) {}
+    public record YComputed(String id, String domain, String range, YVia via, List<YDependsOn> dependsOn) {}
+    public record YVia(YHierarchy hierarchy, YList list) {}
+    public record YHierarchy(String node, String from, String expand) {}
+    public record YList(String field, String mode) {}
+    public record YDependsOn(String type) {}
     public record YProperty(
             String id,
             String domain,
@@ -37,7 +44,8 @@ public final class YamlOntologyLoader {
     ) {}
     public record YChain(List<String> chain, String implies) {}
 
-    private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     public TBox loadFromClasspath(String resourcePath) throws IOException {
         try (InputStream in = getClass().getResourceAsStream(resourcePath)) {
@@ -54,6 +62,62 @@ public final class YamlOntologyLoader {
 
     public TBox load(InputStream in) throws IOException {
         return toTBox(mapper.readValue(in, YOntology.class));
+    }
+
+    /**
+     * Parse out the {@code computed:} block from a YAML document. Returns an
+     * empty list if absent, so existing YAML files keep working.
+     */
+    public List<ComputedEdgeSpec> loadComputedSpecs(InputStream in) throws IOException {
+        return toComputedSpecs(mapper.readValue(in, YOntology.class));
+    }
+
+    public List<ComputedEdgeSpec> loadComputedSpecsFromClasspath(String resourcePath) throws IOException {
+        try (InputStream in = getClass().getResourceAsStream(resourcePath)) {
+            if (in == null) throw new IOException("Resource not found: " + resourcePath);
+            return loadComputedSpecs(in);
+        }
+    }
+
+    private List<ComputedEdgeSpec> toComputedSpecs(YOntology y) {
+        List<YComputed> raw = Optional.ofNullable(y.computed()).orElse(List.of());
+        List<ComputedEdgeSpec> out = new ArrayList<>(raw.size());
+        for (YComputed c : raw) {
+            ComputedEdgeSpec.Hierarchy h = null;
+            ComputedEdgeSpec.ListSpec l = null;
+            if (c.via() != null) {
+                if (c.via().hierarchy() != null) {
+                    com.e2eq.ontology.annotations.DependsOn.Expand expand =
+                            com.e2eq.ontology.annotations.DependsOn.Expand.NONE;
+                    String e = c.via().hierarchy().expand();
+                    if (e != null && !e.isBlank()) {
+                        try {
+                            expand = com.e2eq.ontology.annotations.DependsOn.Expand.valueOf(
+                                    e.trim().toUpperCase(Locale.ROOT));
+                        } catch (IllegalArgumentException iae) {
+                            throw new RuntimeException(
+                                    "Unknown hierarchy expand '" + e + "' for computed '" + c.id()
+                                    + "'. Expected one of NONE, ANCESTORS, DESCENDANTS.");
+                        }
+                    }
+                    h = new ComputedEdgeSpec.Hierarchy(
+                            c.via().hierarchy().node(),
+                            c.via().hierarchy().from(),
+                            expand);
+                }
+                if (c.via().list() != null) {
+                    l = new ComputedEdgeSpec.ListSpec(
+                            c.via().list().field(),
+                            c.via().list().mode() != null ? c.via().list().mode() : "auto");
+                }
+            }
+            List<String> deps = Optional.ofNullable(c.dependsOn()).orElse(List.of()).stream()
+                    .map(YDependsOn::type)
+                    .filter(Objects::nonNull)
+                    .toList();
+            out.add(new ComputedEdgeSpec(c.id(), c.domain(), c.range(), h, l, deps));
+        }
+        return out;
     }
 
     private TBox toTBox(YOntology y) {

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/metrics/OntologyMetrics.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/metrics/OntologyMetrics.java
@@ -1,0 +1,118 @@
+package com.e2eq.ontology.metrics;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Per-provider metrics for the ontology calculated-relations subsystem.
+ *
+ * <p>This bean accumulates counters and timing data for each
+ * {@code ComputedEdgeProvider}. It is intentionally dependency-free so it
+ * can live in {@code quantum-ontology-core}; downstream modules can bridge
+ * the snapshot to Micrometer/Prometheus if desired.</p>
+ */
+@ApplicationScoped
+public class OntologyMetrics {
+
+    private final Map<String, ProviderStats> byProvider = new ConcurrentHashMap<>();
+
+    public void recordProviderInvocation(String providerId, long durationNanos, int targetsProduced) {
+        ProviderStats s = stats(providerId);
+        s.invocations.incrementAndGet();
+        s.totalNanos.addAndGet(durationNanos);
+        s.targetsProduced.addAndGet(targetsProduced);
+        long max;
+        do {
+            max = s.maxNanos.get();
+            if (durationNanos <= max) break;
+        } while (!s.maxNanos.compareAndSet(max, durationNanos));
+    }
+
+    public void recordProviderError(String providerId) {
+        stats(providerId).errors.incrementAndGet();
+    }
+
+    public void recordEdgesAdded(String providerId, int count) {
+        if (count <= 0) return;
+        stats(providerId).edgesAdded.addAndGet(count);
+    }
+
+    public void recordEdgesRemoved(String providerId, int count) {
+        if (count <= 0) return;
+        stats(providerId).edgesRemoved.addAndGet(count);
+    }
+
+    public void recordStalenessRisk(String providerId, String dependencyType) {
+        stats(providerId).stalenessRiskByDependency
+                .computeIfAbsent(dependencyType, k -> new AtomicLong())
+                .incrementAndGet();
+    }
+
+    public void recordGuardTrip(String providerId, String guard) {
+        stats(providerId).guardTrips
+                .computeIfAbsent(guard, k -> new AtomicLong())
+                .incrementAndGet();
+    }
+
+    public Map<String, Map<String, Object>> snapshot() {
+        Map<String, Map<String, Object>> out = new LinkedHashMap<>();
+        for (Map.Entry<String, ProviderStats> e : byProvider.entrySet()) {
+            out.put(e.getKey(), e.getValue().snapshot());
+        }
+        return out;
+    }
+
+    public Map<String, Object> snapshotFor(String providerId) {
+        ProviderStats s = byProvider.get(providerId);
+        return s == null ? Map.of() : s.snapshot();
+    }
+
+    public void reset() {
+        byProvider.clear();
+    }
+
+    private ProviderStats stats(String providerId) {
+        return byProvider.computeIfAbsent(providerId, k -> new ProviderStats());
+    }
+
+    private static final class ProviderStats {
+        final AtomicLong invocations = new AtomicLong();
+        final AtomicLong totalNanos = new AtomicLong();
+        final AtomicLong maxNanos = new AtomicLong();
+        final AtomicLong targetsProduced = new AtomicLong();
+        final AtomicLong edgesAdded = new AtomicLong();
+        final AtomicLong edgesRemoved = new AtomicLong();
+        final AtomicLong errors = new AtomicLong();
+        final Map<String, AtomicLong> guardTrips = new ConcurrentHashMap<>();
+        final Map<String, AtomicLong> stalenessRiskByDependency = new ConcurrentHashMap<>();
+
+        Map<String, Object> snapshot() {
+            Map<String, Object> m = new LinkedHashMap<>();
+            long inv = invocations.get();
+            m.put("invocations", inv);
+            m.put("totalNanos", totalNanos.get());
+            m.put("avgNanos", inv == 0 ? 0L : totalNanos.get() / inv);
+            m.put("maxNanos", maxNanos.get());
+            m.put("targetsProduced", targetsProduced.get());
+            m.put("edgesAdded", edgesAdded.get());
+            m.put("edgesRemoved", edgesRemoved.get());
+            m.put("errors", errors.get());
+            m.put("guardTrips", flatten(guardTrips));
+            m.put("stalenessRiskByDependency", flatten(stalenessRiskByDependency));
+            return Collections.unmodifiableMap(m);
+        }
+
+        private static Map<String, Long> flatten(Map<String, AtomicLong> in) {
+            Map<String, Long> out = new LinkedHashMap<>();
+            for (Map.Entry<String, AtomicLong> e : in.entrySet()) {
+                out.put(e.getKey(), e.getValue().get());
+            }
+            return out;
+        }
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/testkit/ComputedEdgeProviderHarness.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/testkit/ComputedEdgeProviderHarness.java
@@ -1,0 +1,71 @@
+package com.e2eq.ontology.testkit;
+
+import com.e2eq.ontology.core.ComputedEdgeProvider;
+import com.e2eq.ontology.core.DataDomainInfo;
+import com.e2eq.ontology.core.Reasoner;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Test harness for invoking a {@link ComputedEdgeProvider} against a fake
+ * environment, then asserting on the produced edges and provenance.
+ *
+ * <p>Use the static {@link #run} helper for one-shot calls, or instantiate
+ * the harness if you want to share a {@code DataDomainInfo} across calls.</p>
+ */
+public final class ComputedEdgeProviderHarness {
+
+    public static final DataDomainInfo TEST_DOMAIN =
+            new DataDomainInfo("testOrg", "0000000001", "testTenant", 0);
+
+    private final String realmId;
+    private final DataDomainInfo domain;
+
+    public ComputedEdgeProviderHarness() {
+        this("test-realm", TEST_DOMAIN);
+    }
+
+    public ComputedEdgeProviderHarness(String realmId, DataDomainInfo domain) {
+        this.realmId = realmId;
+        this.domain = domain;
+    }
+
+    /** Invoke a provider's edges() and return the result. */
+    public <S> Result run(ComputedEdgeProvider<S> provider, Object source) {
+        List<Reasoner.Edge> edges = provider.edges(realmId, domain, source);
+        return new Result(edges);
+    }
+
+    /** Static convenience using TEST_DOMAIN. */
+    public static <S> Result invoke(ComputedEdgeProvider<S> provider, Object source) {
+        return new ComputedEdgeProviderHarness().run(provider, source);
+    }
+
+    /** Wrapper around the produced edges with handy assertion helpers. */
+    public static final class Result {
+        private final List<Reasoner.Edge> edges;
+
+        Result(List<Reasoner.Edge> edges) {
+            this.edges = List.copyOf(edges);
+        }
+
+        public List<Reasoner.Edge> edges() { return edges; }
+
+        public Set<String> targetIds() {
+            return edges.stream().map(Reasoner.Edge::dstId).collect(Collectors.toUnmodifiableSet());
+        }
+
+        /** All distinct providerIds recorded in provenance. */
+        public Set<String> providerIds() {
+            return edges.stream()
+                    .flatMap(e -> e.prov().stream())
+                    .map(p -> p.inputs() == null ? null : (String) p.inputs().get("providerId"))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toUnmodifiableSet());
+        }
+
+        public int size() { return edges.size(); }
+        public boolean isEmpty() { return edges.isEmpty(); }
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/testkit/InMemoryHierarchy.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/testkit/InMemoryHierarchy.java
@@ -1,0 +1,80 @@
+package com.e2eq.ontology.testkit;
+
+import java.util.*;
+
+/**
+ * In-memory hierarchy of nodes keyed by id. Designed for unit tests of
+ * {@link com.e2eq.ontology.core.HierarchyListEdgeProvider}.
+ *
+ * <p>The hierarchy holds:</p>
+ * <ul>
+ *   <li>nodes — the node objects themselves</li>
+ *   <li>parent → children edges (immediate)</li>
+ *   <li>node → list-of-targets (the list the node "owns")</li>
+ * </ul>
+ *
+ * <p>Methods return flat descendants on demand, matching the
+ * {@code HierarchyListEdgeProvider#getChildNodes} contract.</p>
+ *
+ * @param <H> hierarchy node type
+ * @param <T> target type
+ */
+public final class InMemoryHierarchy<H, T> {
+
+    public interface IdOf<X> { String id(X x); }
+
+    private final IdOf<H> idOf;
+    private final Map<String, H> nodes = new LinkedHashMap<>();
+    private final Map<String, List<String>> children = new LinkedHashMap<>();
+    private final Map<String, List<T>> listItems = new LinkedHashMap<>();
+
+    public InMemoryHierarchy(IdOf<H> idOf) {
+        this.idOf = Objects.requireNonNull(idOf);
+    }
+
+    /** Register a node. */
+    public InMemoryHierarchy<H, T> add(H node) {
+        nodes.put(idOf.id(node), node);
+        return this;
+    }
+
+    /** Register a parent → child relationship. */
+    public InMemoryHierarchy<H, T> link(H parent, H child) {
+        children.computeIfAbsent(idOf.id(parent), k -> new ArrayList<>()).add(idOf.id(child));
+        return this;
+    }
+
+    /** Set the list items the given node resolves to. */
+    @SafeVarargs
+    public final InMemoryHierarchy<H, T> items(H node, T... items) {
+        listItems.put(idOf.id(node), new ArrayList<>(Arrays.asList(items)));
+        return this;
+    }
+
+    public Optional<H> load(String nodeId) {
+        return Optional.ofNullable(nodes.get(nodeId));
+    }
+
+    /** Flat descendants (BFS) of the given node, deduped. */
+    public List<H> descendants(String rootId) {
+        List<H> out = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        Deque<String> queue = new ArrayDeque<>(children.getOrDefault(rootId, List.of()));
+        while (!queue.isEmpty()) {
+            String id = queue.removeFirst();
+            if (!seen.add(id)) continue;
+            H n = nodes.get(id);
+            if (n != null) out.add(n);
+            queue.addAll(children.getOrDefault(id, List.of()));
+        }
+        return out;
+    }
+
+    public List<T> itemsOf(String nodeId) {
+        return listItems.getOrDefault(nodeId, List.of());
+    }
+
+    public Set<String> nodeIds() {
+        return Collections.unmodifiableSet(nodes.keySet());
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/ComputedEdgeCacheTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/ComputedEdgeCacheTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ComputedEdgeCacheTest {
 
     private ComputedEdgeCache.Key key(String src) {
-        return new ComputedEdgeCache.Key("P1", "realm", "tenant", src);
+        return new ComputedEdgeCache.Key("P1", "realm", "org", "acct", "tenant", 0, src);
     }
 
     private List<Reasoner.Edge> edges(String dst) {
@@ -55,11 +55,11 @@ class ComputedEdgeCacheTest {
         ComputedEdgeCache c = new ComputedEdgeCache();
         c.put(key("s1"), edges("a"), 0);
         c.put(key("s2"), edges("b"), 0);
-        c.put(new ComputedEdgeCache.Key("Other", "r", "t", "s3"), edges("c"), 0);
+        c.put(new ComputedEdgeCache.Key("Other", "r", "o", "a", "t", 0, "s3"), edges("c"), 0);
         int n = c.invalidateProvider("P1");
         assertEquals(2, n);
         assertTrue(c.get(key("s1")).isEmpty());
-        assertTrue(c.get(new ComputedEdgeCache.Key("Other", "r", "t", "s3")).isPresent());
+        assertTrue(c.get(new ComputedEdgeCache.Key("Other", "r", "o", "a", "t", 0, "s3")).isPresent());
     }
 
     @Test
@@ -70,6 +70,20 @@ class ComputedEdgeCacheTest {
         c.clear();
         assertEquals(0L, c.stats().get("size"));
         assertEquals(2L, c.stats().get("evictions"));
+    }
+
+    @Test
+    void differingDataDomainFieldsDoNotCollide() {
+        ComputedEdgeCache c = new ComputedEdgeCache();
+        // Same provider/realm/tenant/source — different org and segment.
+        ComputedEdgeCache.Key k1 = new ComputedEdgeCache.Key("P1", "r", "orgA", "1", "t", 0, "s1");
+        ComputedEdgeCache.Key k2 = new ComputedEdgeCache.Key("P1", "r", "orgB", "1", "t", 0, "s1");
+        ComputedEdgeCache.Key k3 = new ComputedEdgeCache.Key("P1", "r", "orgA", "1", "t", 1, "s1");
+
+        c.put(k1, edges("a"), 0);
+        assertTrue(c.get(k2).isEmpty(), "different orgRefName must not hit");
+        assertTrue(c.get(k3).isEmpty(), "different dataSegment must not hit");
+        assertTrue(c.get(k1).isPresent());
     }
 
     @Test

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/ComputedEdgeCacheTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/ComputedEdgeCacheTest.java
@@ -1,0 +1,88 @@
+package com.e2eq.ontology.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ComputedEdgeCacheTest {
+
+    private ComputedEdgeCache.Key key(String src) {
+        return new ComputedEdgeCache.Key("P1", "realm", "tenant", src);
+    }
+
+    private List<Reasoner.Edge> edges(String dst) {
+        return List.of(new Reasoner.Edge("s1", "S", "p", dst, "T", false, Optional.empty()));
+    }
+
+    @Test
+    void putThenGetReturnsTheStoredValue() {
+        ComputedEdgeCache c = new ComputedEdgeCache();
+        c.put(key("s1"), edges("a"), 0);
+        Optional<List<Reasoner.Edge>> hit = c.get(key("s1"));
+        assertTrue(hit.isPresent());
+        assertEquals(1, hit.get().size());
+        assertEquals(1L, c.stats().get("hits"));
+    }
+
+    @Test
+    void unknownKeyMisses() {
+        ComputedEdgeCache c = new ComputedEdgeCache();
+        assertTrue(c.get(key("nope")).isEmpty());
+        assertEquals(1L, c.stats().get("misses"));
+    }
+
+    @Test
+    void zeroTtlMeansNoExpiration() {
+        ComputedEdgeCache c = new ComputedEdgeCache();
+        c.put(key("s1"), edges("a"), 0);
+        assertTrue(c.get(key("s1")).isPresent());
+    }
+
+    @Test
+    void invalidateRemovesEntry() {
+        ComputedEdgeCache c = new ComputedEdgeCache();
+        c.put(key("s1"), edges("a"), 0);
+        c.invalidate(key("s1"));
+        assertTrue(c.get(key("s1")).isEmpty());
+        assertEquals(1L, c.stats().get("evictions"));
+    }
+
+    @Test
+    void invalidateProviderRemovesAllForThatId() {
+        ComputedEdgeCache c = new ComputedEdgeCache();
+        c.put(key("s1"), edges("a"), 0);
+        c.put(key("s2"), edges("b"), 0);
+        c.put(new ComputedEdgeCache.Key("Other", "r", "t", "s3"), edges("c"), 0);
+        int n = c.invalidateProvider("P1");
+        assertEquals(2, n);
+        assertTrue(c.get(key("s1")).isEmpty());
+        assertTrue(c.get(new ComputedEdgeCache.Key("Other", "r", "t", "s3")).isPresent());
+    }
+
+    @Test
+    void clearEmptiesAndCountsEvictions() {
+        ComputedEdgeCache c = new ComputedEdgeCache();
+        c.put(key("s1"), edges("a"), 0);
+        c.put(key("s2"), edges("b"), 0);
+        c.clear();
+        assertEquals(0L, c.stats().get("size"));
+        assertEquals(2L, c.stats().get("evictions"));
+    }
+
+    @Test
+    void defaultMaterializationModeIsEager() {
+        // Verifies the default contract from ComputedEdgeProvider.
+        ComputedEdgeProvider<Object> p = new ComputedEdgeProvider<>() {
+            @Override public Class<Object> getSourceType() { return Object.class; }
+            @Override public String getPredicate() { return "p"; }
+            @Override public String getTargetTypeName() { return "T"; }
+            @Override protected java.util.Set<ComputedTarget> computeTargets(
+                    ComputationContext c, Object s) { return java.util.Set.of(); }
+        };
+        assertEquals(MaterializationMode.EAGER, p.getMaterializationMode());
+        assertEquals(0L, p.getCacheTtlSeconds());
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/ComputedEdgeStalenessValidatorTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/ComputedEdgeStalenessValidatorTest.java
@@ -1,0 +1,121 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.annotations.DependsOn;
+import com.e2eq.ontology.annotations.OntologyClass;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ComputedEdgeStalenessValidatorTest {
+
+    @OntologyClass(id = "Src") static class Src {}
+    static class Dep1 {}
+    static class Dep2 {}
+
+    /** No dependencies declared → always OK. */
+    static class NoDeps extends ComputedEdgeProvider<Src> {
+        @Override public Class<Src> getSourceType() { return Src.class; }
+        @Override public String getPredicate() { return "p"; }
+        @Override public String getTargetTypeName() { return "T"; }
+        @Override protected Set<ComputedTarget> computeTargets(ComputationContext c, Src s) { return Set.of(); }
+    }
+
+    /** Declares deps via override only, no override of getAffectedSourceIds → risk. */
+    static class DepsNoHelp extends ComputedEdgeProvider<Src> {
+        @Override public Class<Src> getSourceType() { return Src.class; }
+        @Override public String getPredicate() { return "p"; }
+        @Override public String getTargetTypeName() { return "T"; }
+        @Override public Set<Class<?>> getDependencyTypes() { return Set.of(Dep1.class, Dep2.class); }
+        @Override protected Set<ComputedTarget> computeTargets(ComputationContext c, Src s) { return Set.of(); }
+    }
+
+    /** Overrides getAffectedSourceIds → no risk even though deps declared. */
+    static class DepsWithOverride extends ComputedEdgeProvider<Src> {
+        @Override public Class<Src> getSourceType() { return Src.class; }
+        @Override public String getPredicate() { return "p"; }
+        @Override public String getTargetTypeName() { return "T"; }
+        @Override public Set<Class<?>> getDependencyTypes() { return Set.of(Dep1.class); }
+        @Override public Set<String> getAffectedSourceIds(ComputationContext c, Class<?> t, String id) {
+            return Set.of();
+        }
+        @Override protected Set<ComputedTarget> computeTargets(ComputationContext c, Src s) { return Set.of(); }
+    }
+
+    /** @DependsOn declares the type and a non-empty via → no risk. */
+    @DependsOn(type = Dep1.class, via = "depField")
+    static class DepsWithAnnotationVia extends ComputedEdgeProvider<Src> {
+        @Override public Class<Src> getSourceType() { return Src.class; }
+        @Override public String getPredicate() { return "p"; }
+        @Override public String getTargetTypeName() { return "T"; }
+        @Override protected Set<ComputedTarget> computeTargets(ComputationContext c, Src s) { return Set.of(); }
+    }
+
+    /** @DependsOn without via → risk (no inverse-query hint). */
+    @DependsOn(type = Dep1.class)
+    static class DepsAnnotationNoVia extends ComputedEdgeProvider<Src> {
+        @Override public Class<Src> getSourceType() { return Src.class; }
+        @Override public String getPredicate() { return "p"; }
+        @Override public String getTargetTypeName() { return "T"; }
+        @Override protected Set<ComputedTarget> computeTargets(ComputationContext c, Src s) { return Set.of(); }
+    }
+
+    @Test
+    void noDepsAlwaysOk() {
+        assertTrue(ComputedEdgeStalenessValidator.validate(new NoDeps()).ok());
+    }
+
+    @Test
+    void unhelpedDepsReportRisk() {
+        var r = ComputedEdgeStalenessValidator.validate(new DepsNoHelp());
+        assertFalse(r.ok());
+        assertEquals(2, r.risks().size());
+    }
+
+    @Test
+    void overrideSilencesAllDeps() {
+        assertTrue(ComputedEdgeStalenessValidator.validate(new DepsWithOverride()).ok());
+    }
+
+    @Test
+    void annotationWithViaIsSufficient() {
+        assertTrue(ComputedEdgeStalenessValidator.validate(new DepsWithAnnotationVia()).ok());
+    }
+
+    @Test
+    void annotationWithoutViaStillRisky() {
+        var r = ComputedEdgeStalenessValidator.validate(new DepsAnnotationNoVia());
+        assertFalse(r.ok());
+        Optional<ComputedEdgeStalenessValidator.StalenessRisk> first = r.risks().stream().findFirst();
+        assertTrue(first.isPresent());
+        assertEquals(Dep1.class, first.get().dependencyType());
+    }
+
+    @Test
+    void dependencyTypesDerivedFromAnnotations() {
+        Set<Class<?>> deps = new DepsWithAnnotationVia().getDependencyTypes();
+        assertEquals(Set.of(Dep1.class), deps);
+    }
+
+    @Test
+    void multipleAnnotationsAggregated() {
+        @DependsOn(type = Dep1.class, via = "f1")
+        @DependsOn(type = Dep2.class, via = "f2")
+        class Multi extends ComputedEdgeProvider<Src> {
+            @Override public Class<Src> getSourceType() { return Src.class; }
+            @Override public String getPredicate() { return "p"; }
+            @Override public String getTargetTypeName() { return "T"; }
+            @Override protected Set<ComputedTarget> computeTargets(ComputationContext c, Src s) { return Set.of(); }
+        }
+
+        Multi m = new Multi();
+        assertEquals(Set.of(Dep1.class, Dep2.class), m.getDependencyTypes());
+        assertTrue(ComputedEdgeStalenessValidator.validate(m).ok());
+
+        List<DependsOn> decls = m.dependsOnDeclarations();
+        assertEquals(2, decls.size());
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/DeclarativeComputedEdgeTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/DeclarativeComputedEdgeTest.java
@@ -1,0 +1,129 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.annotations.DependsOn.Expand;
+import com.e2eq.ontology.annotations.OntologyClass;
+import com.e2eq.ontology.testkit.ComputedEdgeProviderHarness;
+import com.e2eq.ontology.testkit.InMemoryHierarchy;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Loads a YAML containing a {@code computed:} block, builds a
+ * {@link DeclarativeComputedEdgeProvider} against in-memory fakes, and
+ * verifies edges round-trip end-to-end.
+ */
+class DeclarativeComputedEdgeTest {
+
+    @OntologyClass(id = "Associate")
+    public static class Associate {
+        public final String id;
+        public final List<String> assignedTerritoryIds;
+        public Associate(String id, List<String> ids) { this.id = id; this.assignedTerritoryIds = ids; }
+        public String getId() { return id; }
+    }
+
+    public static class Territory {
+        public final String id;
+        public Territory(String id) { this.id = id; }
+        public String getId() { return id; }
+    }
+
+    public static class Location {
+        public final String id;
+        public Location(String id) { this.id = id; }
+        public String getId() { return id; }
+    }
+
+    @Test
+    void parsesComputedBlockFromYaml() throws Exception {
+        YamlOntologyLoader loader = new YamlOntologyLoader();
+        List<ComputedEdgeSpec> specs = loader.loadComputedSpecsFromClasspath("/computed-edges-example.yaml");
+
+        assertEquals(1, specs.size());
+        ComputedEdgeSpec s = specs.get(0);
+        assertEquals("canSeeLocation", s.id());
+        assertEquals("Associate", s.domain());
+        assertEquals("Location", s.range());
+        assertEquals("Territory", s.hierarchy().nodeType());
+        assertEquals("assignedTerritories", s.hierarchy().fromField());
+        assertEquals(Expand.DESCENDANTS, s.hierarchy().expand());
+        assertEquals("locationLists", s.list().field());
+        assertEquals(List.of("Territory", "LocationList"), s.dependsOnTypes());
+    }
+
+    @Test
+    void declarativeProviderProducesExpectedEdges() throws Exception {
+        YamlOntologyLoader loader = new YamlOntologyLoader();
+        ComputedEdgeSpec spec = loader.loadComputedSpecsFromClasspath("/computed-edges-example.yaml").get(0);
+
+        Territory west = new Territory("west");
+        Territory ca = new Territory("ca");
+        Territory bay = new Territory("bay");
+        Location sf = new Location("sf");
+        Location la = new Location("la");
+        Location oak = new Location("oak");
+
+        InMemoryHierarchy<Territory, Location> world =
+                new InMemoryHierarchy<Territory, Location>(Territory::getId)
+                        .add(west).add(ca).add(bay)
+                        .link(west, ca).link(ca, bay)
+                        .items(west, sf, la)
+                        .items(ca, oak);
+
+        DeclarativeRuntime<Associate, Territory, Location> runtime =
+                new DeclarativeRuntime<>() {
+                    @Override public boolean supports(ComputedEdgeSpec s) { return "canSeeLocation".equals(s.id()); }
+                    @Override public List<String> assignedNodeIds(Associate a) { return a.assignedTerritoryIds; }
+                    @Override public Optional<Territory> loadHierarchyNode(String id) { return world.load(id); }
+                    @Override public List<Territory> walkHierarchy(String id, Expand expand) {
+                        return expand == Expand.DESCENDANTS ? world.descendants(id) : List.of();
+                    }
+                    @Override public List<Location> resolveListItems(Territory node) { return world.itemsOf(node.getId()); }
+                    @Override public String extractTargetId(Location t) { return t.getId(); }
+                    @Override public Class<Associate> getSourceType() { return Associate.class; }
+                };
+
+        var provider = new DeclarativeComputedEdgeProvider<>(spec, runtime);
+        Associate john = new Associate("john", List.of("west"));
+
+        var result = ComputedEdgeProviderHarness.invoke(provider, john);
+        assertEquals(Set.of("sf", "la", "oak"), result.targetIds());
+        assertEquals("declarative:canSeeLocation", provider.getProviderId());
+    }
+
+    @Test
+    void unknownExpandValueIsRejected() {
+        YamlOntologyLoader loader = new YamlOntologyLoader();
+        String yaml = """
+                computed:
+                  - id: bad
+                    domain: A
+                    range: B
+                    via:
+                      hierarchy:
+                        node: Node
+                        from: f
+                        expand: sideways
+                """;
+        Exception e = assertThrows(RuntimeException.class,
+                () -> loader.loadComputedSpecs(new java.io.ByteArrayInputStream(yaml.getBytes())));
+        assertTrue(e.getMessage().contains("expand"));
+    }
+
+    @Test
+    void emptyComputedBlockIsBenign() throws Exception {
+        YamlOntologyLoader loader = new YamlOntologyLoader();
+        String yaml = """
+                version: 1
+                classes:
+                  - id: A
+                """;
+        List<ComputedEdgeSpec> specs = loader.loadComputedSpecs(new java.io.ByteArrayInputStream(yaml.getBytes()));
+        assertTrue(specs.isEmpty());
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/HierarchyListGuardsTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/HierarchyListGuardsTest.java
@@ -1,0 +1,136 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.annotations.OntologyClass;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the cycle / maxDepth / maxTargets guards on {@link HierarchyListEdgeProvider}.
+ */
+class HierarchyListGuardsTest {
+
+    @OntologyClass(id = "TestSrc")
+    static class Src {
+        final String id;
+        final List<String> nodeIds;
+        Src(String id, List<String> nodeIds) { this.id = id; this.nodeIds = nodeIds; }
+        public String getId() { return id; }
+    }
+
+    static class Node {
+        final String id;
+        final List<String> targets;
+        Node(String id, List<String> targets) { this.id = id; this.targets = targets; }
+        public String getId() { return id; }
+    }
+
+    /** Hierarchy provider over an in-memory node tree configured per test. */
+    static class TestProvider extends HierarchyListEdgeProvider<Src, Node, String> {
+        final Map<String, Node> nodes;
+        final Map<String, List<String>> children;
+
+        TestProvider(Map<String, Node> nodes, Map<String, List<String>> children) {
+            this.nodes = nodes; this.children = children;
+        }
+
+        @Override public Class<Src> getSourceType() { return Src.class; }
+        @Override public String getPredicate() { return "p"; }
+        @Override public String getTargetTypeName() { return "T"; }
+        @Override protected String getHierarchyTypeName() { return "Node"; }
+        @Override protected List<String> getAssignedNodeIds(Src source) { return source.nodeIds; }
+        @Override protected Optional<Node> loadHierarchyNode(ComputationContext ctx, String id) {
+            return Optional.ofNullable(nodes.get(id));
+        }
+        @Override protected List<Node> getChildNodes(ComputationContext ctx, String id) {
+            // Flat descendants, as the contract requires.
+            List<Node> out = new ArrayList<>();
+            Deque<String> stack = new ArrayDeque<>(children.getOrDefault(id, List.of()));
+            Set<String> seen = new HashSet<>();
+            while (!stack.isEmpty()) {
+                String c = stack.pop();
+                if (!seen.add(c)) continue; // local dedup so the test feeder doesn't loop
+                Node n = nodes.get(c);
+                if (n != null) out.add(n);
+                stack.addAll(children.getOrDefault(c, List.of()));
+            }
+            return out;
+        }
+        @Override protected List<String> resolveListItems(ComputationContext ctx, Node node) {
+            return node.targets;
+        }
+        @Override protected String extractTargetId(String target) { return target; }
+    }
+
+    @Test
+    void cycleGuardSkipsRevisitedAssignment() {
+        Map<String, Node> nodes = Map.of(
+                "n1", new Node("n1", List.of("t1"))
+        );
+        TestProvider p = new TestProvider(nodes, Map.of());
+
+        // n1 listed twice as an assignment → second visit is the cycle.
+        Src src = new Src("s1", List.of("n1", "n1"));
+
+        var ctx = new ComputedEdgeProvider.ComputationContext("realm", null, "TestProvider");
+        Set<ComputedEdgeProvider.ComputedTarget> targets = p.computeTargets(ctx, src);
+
+        assertEquals(1, targets.size());
+        assertTrue(ctx.tripped("cycle"));
+    }
+
+    @Test
+    void maxTargetsCapTruncatesOutput() {
+        Map<String, Node> nodes = Map.of(
+                "n1", new Node("n1", List.of("a", "b", "c", "d", "e"))
+        );
+        TestProvider p = new TestProvider(nodes, Map.of());
+        Src src = new Src("s1", List.of("n1"));
+
+        var ctx = new ComputedEdgeProvider.ComputationContext("realm", null, "TestProvider");
+        ctx.setMaxComputedTargets(3);
+
+        Set<ComputedEdgeProvider.ComputedTarget> targets = p.computeTargets(ctx, src);
+        // Implementation breaks AFTER processing a node, so cap is "high-water" not strict.
+        assertTrue(ctx.tripped("maxTargets"));
+        assertTrue(targets.size() >= 3);
+    }
+
+    @Test
+    void maxHierarchyDepthCountsNodesProcessed() {
+        // Long chain: n0 -> n1 -> n2 -> n3 -> n4 (each as descendants of n0).
+        Map<String, Node> nodes = new LinkedHashMap<>();
+        Map<String, List<String>> kids = new LinkedHashMap<>();
+        for (int i = 0; i < 5; i++) {
+            nodes.put("n" + i, new Node("n" + i, List.of("t" + i)));
+            if (i < 4) kids.put("n" + i, List.of("n" + (i + 1)));
+        }
+        TestProvider p = new TestProvider(nodes, kids);
+        Src src = new Src("s1", List.of("n0"));
+
+        var ctx = new ComputedEdgeProvider.ComputationContext("realm", null, "TestProvider");
+        ctx.setMaxHierarchyDepth(2); // process at most 2 hierarchy nodes
+
+        Set<ComputedEdgeProvider.ComputedTarget> targets = p.computeTargets(ctx, src);
+
+        assertTrue(ctx.tripped("maxDepth"));
+        assertEquals(2, targets.size(), "should have produced exactly two targets before tripping");
+    }
+
+    @Test
+    void noGuardsTrippedOnNormalRun() {
+        Map<String, Node> nodes = Map.of(
+                "n1", new Node("n1", List.of("t1"))
+        );
+        TestProvider p = new TestProvider(nodes, Map.of());
+        Src src = new Src("s1", List.of("n1"));
+
+        var ctx = new ComputedEdgeProvider.ComputationContext("realm", null, "TestProvider");
+        Set<ComputedEdgeProvider.ComputedTarget> targets = p.computeTargets(ctx, src);
+
+        assertEquals(1, targets.size());
+        assertTrue(ctx.getGuardTrips().isEmpty());
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/metrics/OntologyMetricsTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/metrics/OntologyMetricsTest.java
@@ -1,0 +1,63 @@
+package com.e2eq.ontology.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OntologyMetricsTest {
+
+    @Test
+    void recordsInvocationsAndDerivedAggregates() {
+        OntologyMetrics m = new OntologyMetrics();
+        m.recordProviderInvocation("P1", 1_000_000L, 5);
+        m.recordProviderInvocation("P1", 3_000_000L, 7);
+
+        Map<String, Object> s = m.snapshotFor("P1");
+        assertEquals(2L, s.get("invocations"));
+        assertEquals(4_000_000L, s.get("totalNanos"));
+        assertEquals(2_000_000L, s.get("avgNanos"));
+        assertEquals(3_000_000L, s.get("maxNanos"));
+        assertEquals(12L, s.get("targetsProduced"));
+        assertEquals(0L, s.get("errors"));
+    }
+
+    @Test
+    void countsAddsRemovesAndErrors() {
+        OntologyMetrics m = new OntologyMetrics();
+        m.recordEdgesAdded("P1", 4);
+        m.recordEdgesRemoved("P1", 2);
+        m.recordProviderError("P1");
+
+        Map<String, Object> s = m.snapshotFor("P1");
+        assertEquals(4L, s.get("edgesAdded"));
+        assertEquals(2L, s.get("edgesRemoved"));
+        assertEquals(1L, s.get("errors"));
+    }
+
+    @Test
+    void tracksGuardTripsAndStalenessPerKey() {
+        OntologyMetrics m = new OntologyMetrics();
+        m.recordGuardTrip("P1", "maxDepth");
+        m.recordGuardTrip("P1", "maxDepth");
+        m.recordGuardTrip("P1", "cycle");
+        m.recordStalenessRisk("P1", "Territory");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Long> guards = (Map<String, Long>) m.snapshotFor("P1").get("guardTrips");
+        assertEquals(2L, guards.get("maxDepth"));
+        assertEquals(1L, guards.get("cycle"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Long> stale = (Map<String, Long>) m.snapshotFor("P1").get("stalenessRiskByDependency");
+        assertEquals(1L, stale.get("Territory"));
+    }
+
+    @Test
+    void emptySnapshotForUnknownProvider() {
+        OntologyMetrics m = new OntologyMetrics();
+        assertTrue(m.snapshotFor("nope").isEmpty());
+        assertTrue(m.snapshot().isEmpty());
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/testkit/TestKitSampleTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/testkit/TestKitSampleTest.java
@@ -1,0 +1,99 @@
+package com.e2eq.ontology.testkit;
+
+import com.e2eq.ontology.annotations.OntologyClass;
+import com.e2eq.ontology.core.ComputedEdgeProvider;
+import com.e2eq.ontology.core.HierarchyListEdgeProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end sample of the testkit: declare a provider against in-memory
+ * fakes and assert on the produced edges with no Mongo, no Quarkus.
+ */
+class TestKitSampleTest {
+
+    @OntologyClass(id = "Associate")
+    public static class Associate {
+        public final String id;
+        public final List<String> assignedTerritoryIds;
+        public Associate(String id, List<String> territories) {
+            this.id = id; this.assignedTerritoryIds = territories;
+        }
+        public String getId() { return id; }
+    }
+
+    public static class Territory {
+        public final String id;
+        public Territory(String id) { this.id = id; }
+        public String getId() { return id; }
+    }
+
+    public static class Location {
+        public final String id;
+        public Location(String id) { this.id = id; }
+        public String getId() { return id; }
+    }
+
+    static class AssociateCanSeeLocation
+            extends HierarchyListEdgeProvider<Associate, Territory, Location> {
+
+        final InMemoryHierarchy<Territory, Location> world;
+
+        AssociateCanSeeLocation(InMemoryHierarchy<Territory, Location> world) {
+            this.world = world;
+        }
+
+        @Override public Class<Associate> getSourceType() { return Associate.class; }
+        @Override public String getPredicate() { return "canSeeLocation"; }
+        @Override public String getTargetTypeName() { return "Location"; }
+        @Override protected String getHierarchyTypeName() { return "Territory"; }
+        @Override protected List<String> getAssignedNodeIds(Associate s) { return s.assignedTerritoryIds; }
+        @Override protected Optional<Territory> loadHierarchyNode(ComputationContext c, String id) {
+            return world.load(id);
+        }
+        @Override protected List<Territory> getChildNodes(ComputationContext c, String id) {
+            return world.descendants(id);
+        }
+        @Override protected List<Location> resolveListItems(ComputationContext c, Territory node) {
+            return world.itemsOf(node.getId());
+        }
+        @Override protected String extractTargetId(Location target) { return target.getId(); }
+    }
+
+    @Test
+    void associateSeesAllLocationsInAssignedTerritoryAndDescendants() {
+        Territory west = new Territory("west");
+        Territory ca = new Territory("ca");
+        Territory bay = new Territory("bay");
+        Location sf = new Location("sf");
+        Location la = new Location("la");
+        Location oak = new Location("oak");
+
+        InMemoryHierarchy<Territory, Location> world =
+                new InMemoryHierarchy<Territory, Location>(Territory::getId)
+                        .add(west).add(ca).add(bay)
+                        .link(west, ca).link(ca, bay)
+                        .items(west, sf, la)
+                        .items(ca, oak);
+
+        Associate john = new Associate("john", List.of("west"));
+
+        var result = ComputedEdgeProviderHarness.invoke(new AssociateCanSeeLocation(world), john);
+
+        assertEquals(Set.of("sf", "la", "oak"), result.targetIds());
+        assertEquals(Set.of("AssociateCanSeeLocation"), result.providerIds());
+    }
+
+    @Test
+    void unknownAssignedTerritoryProducesNoEdges() {
+        InMemoryHierarchy<Territory, Location> world =
+                new InMemoryHierarchy<>(Territory::getId);
+        Associate john = new Associate("john", List.of("nonexistent"));
+
+        var result = ComputedEdgeProviderHarness.invoke(new AssociateCanSeeLocation(world), john);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/quantum-ontology-core/src/test/resources/computed-edges-example.yaml
+++ b/quantum-ontology-core/src/test/resources/computed-edges-example.yaml
@@ -1,0 +1,25 @@
+version: 1
+classes:
+  - id: Associate
+  - id: Territory
+  - id: Location
+properties:
+  - id: assignedTerritories
+    domain: Associate
+    range: Territory
+    relation: ONE_TO_MANY
+computed:
+  - id: canSeeLocation
+    domain: Associate
+    range: Location
+    via:
+      hierarchy:
+        node: Territory
+        from: assignedTerritories
+        expand: descendants
+      list:
+        field: locationLists
+        mode: auto
+    dependsOn:
+      - type: Territory
+      - type: LocationList

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/OntologyEdgeProvenanceDoc.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/OntologyEdgeProvenanceDoc.java
@@ -1,0 +1,52 @@
+package com.e2eq.ontology.model;
+
+import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import dev.morphia.annotations.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * Side-collection document holding the per-edge provenance map.
+ *
+ * <p>When {@code quantum.ontology.provenance.split=true}, computed-edge provenance
+ * (hierarchy paths, resolved lists) is written here keyed by {@code edgeId} rather
+ * than inlined on {@link OntologyEdge#getProv()}. This keeps the working set of
+ * the primary edges collection small for high-fanout providers, and lets large
+ * provenance trails be loaded only on demand.</p>
+ *
+ * <p>The {@code providerId} field is denormalized for indexed filtering ("show me
+ * all provenance for AssociateCanSeeLocationProvider").</p>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Entity(value = "ontology_edge_provenance", useDiscriminator = false)
+@Indexes({
+    @Index(options = @IndexOptions(name = "uniq_edgeId", unique = true),
+           fields = { @Field("edgeId") }),
+    @Index(options = @IndexOptions(name = "idx_providerId"),
+           fields = { @Field("providerId") })
+})
+public class OntologyEdgeProvenanceDoc extends UnversionedBaseModel {
+
+    /** ID of the OntologyEdge this provenance describes. */
+    protected String edgeId;
+
+    /** Convenience denormalization for filtering. */
+    protected String providerId;
+
+    /** The provenance payload (hierarchyPath, resolvedLists, computedAt, etc.). */
+    protected Map<String, Object> prov;
+
+    protected Date ts;
+
+    @Override
+    public String bmFunctionalArea() { return "ontology"; }
+
+    @Override
+    public String bmFunctionalDomain() { return "edge_provenance"; }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/BulkRecomputeService.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/BulkRecomputeService.java
@@ -1,0 +1,213 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.ontology.core.ComputedEdgeProvider;
+import com.e2eq.ontology.core.ComputedEdgeRegistry;
+import com.e2eq.ontology.core.DataDomainInfo;
+import com.e2eq.ontology.core.Reasoner;
+import com.e2eq.ontology.metrics.OntologyMetrics;
+import com.e2eq.ontology.model.OntologyEdge;
+import com.e2eq.ontology.repo.OntologyEdgeRepo;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import java.util.*;
+
+/**
+ * Bulk recompute / reconciliation for {@link ComputedEdgeProvider}s.
+ *
+ * <p>Given a provider id and a {@link DataDomain}, walks all source entities
+ * of the provider's source type (via a registered {@link SourceEntityEnumerator}),
+ * recomputes their target sets, diffs against the persisted edges, and either
+ * reports the deltas (dry-run) or applies them.</p>
+ *
+ * <p>Use cases:</p>
+ * <ul>
+ *   <li>A provider's logic changed and existing edges need to converge.</li>
+ *   <li>Audit: confirm in-store edges still match what the provider would
+ *       produce today.</li>
+ *   <li>Targeted repair: pass {@code sourceId} to recompute one entity.</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class BulkRecomputeService {
+
+    @Inject ComputedEdgeRegistry registry;
+    @Inject ComputedEdgeRecomputeHandler recomputeHandler;
+    @Inject OntologyEdgeRepo edgeRepo;
+    @Inject OntologyMetrics metrics;
+    @Inject Instance<SourceEntityEnumerator> enumerators;
+
+    public Result recompute(Request req) {
+        Objects.requireNonNull(req, "request");
+        Objects.requireNonNull(req.providerId, "providerId");
+        Objects.requireNonNull(req.dataDomain, "dataDomain");
+
+        Optional<ComputedEdgeProvider<?>> providerOpt = registry.getProvider(req.providerId);
+        if (providerOpt.isEmpty()) {
+            return Result.failure("Provider not found: " + req.providerId);
+        }
+        ComputedEdgeProvider<?> provider = providerOpt.get();
+        Class<?> sourceType = provider.getSourceType();
+
+        SourceEntityEnumerator enumerator = pickEnumerator(sourceType);
+        // Enumerator is optional only when sourceId is supplied.
+        if (enumerator == null && (req.sourceId == null || req.sourceId.isBlank())) {
+            return Result.failure(
+                    "No SourceEntityEnumerator registered for " + sourceType.getName() +
+                    " — supply --source-id to recompute a single entity, or register an enumerator.");
+        }
+
+        List<String> idsToProcess = (req.sourceId != null && !req.sourceId.isBlank())
+                ? List.of(req.sourceId)
+                : drainAll(enumerator, req, sourceType);
+
+        DataDomainInfo domainInfo = DataDomainConverter.toInfo(req.dataDomain);
+        Result result = new Result();
+        result.providerId = req.providerId;
+        result.sourceType = sourceType.getSimpleName();
+        result.dryRun = req.dryRun;
+
+        for (String sourceId : idsToProcess) {
+            try {
+                SourceDelta delta = computeDelta(provider, req.realmId, req.dataDomain, domainInfo, sourceId);
+                if (delta == null) continue;
+                result.add(delta);
+
+                if (!req.dryRun && (delta.added > 0 || delta.removed > 0)) {
+                    boolean ok = recomputeHandler.recomputeManually(
+                            req.realmId, req.dataDomain, req.providerId, sourceId);
+                    if (!ok) {
+                        result.errors.add("recomputeManually returned false for " + sourceId);
+                    }
+                }
+            } catch (Exception e) {
+                Log.warnf(e, "BulkRecomputeService: failed for %s/%s", req.providerId, sourceId);
+                result.errors.add("source " + sourceId + ": " + e.getMessage());
+            }
+        }
+        return result;
+    }
+
+    private SourceEntityEnumerator pickEnumerator(Class<?> sourceType) {
+        for (SourceEntityEnumerator e : enumerators) {
+            if (e.supports(sourceType)) return e;
+        }
+        return null;
+    }
+
+    private List<String> drainAll(SourceEntityEnumerator enumerator, Request req, Class<?> sourceType) {
+        List<String> all = new ArrayList<>();
+        String cursor = null;
+        int batch = req.batchSize > 0 ? req.batchSize : 500;
+        while (true) {
+            List<String> page = enumerator.listIds(req.realmId, req.dataDomain, sourceType, cursor, batch);
+            if (page == null || page.isEmpty()) break;
+            all.addAll(page);
+            cursor = page.get(page.size() - 1);
+            if (page.size() < batch) break;
+        }
+        return all;
+    }
+
+    @SuppressWarnings("unchecked")
+    private SourceDelta computeDelta(ComputedEdgeProvider<?> provider,
+                                     String realmId,
+                                     DataDomain dataDomain,
+                                     DataDomainInfo domainInfo,
+                                     String sourceId) {
+        ComputedEdgeRecomputeHandler.SourceEntityLoader loader = sourceLoader();
+        if (loader == null) return null;
+
+        Optional<Object> entityOpt = loader.loadEntity(realmId, dataDomain, provider.getSourceType(), sourceId);
+        if (entityOpt.isEmpty()) return null;
+
+        // Recompute target set.
+        List<Reasoner.Edge> newEdges =
+                ((ComputedEdgeProvider<Object>) provider).edges(realmId, domainInfo, entityOpt.get());
+        Set<String> newTargets = new HashSet<>();
+        for (Reasoner.Edge e : newEdges) newTargets.add(e.dstId());
+
+        // Existing edges produced by this provider for this source.
+        String predicate = provider.getPredicate();
+        Set<String> existingTargets = new HashSet<>();
+        for (OntologyEdge e : edgeRepo.findBySrcAndP(dataDomain, sourceId, predicate)) {
+            if (Boolean.TRUE.equals(e.isDerived())) {
+                Object pid = e.getProv() != null ? e.getProv().get("providerId") : null;
+                if (pid == null || provider.getProviderId().equals(pid.toString())) {
+                    existingTargets.add(e.getDst());
+                }
+            }
+        }
+
+        Set<String> added = new HashSet<>(newTargets);
+        added.removeAll(existingTargets);
+        Set<String> removed = new HashSet<>(existingTargets);
+        removed.removeAll(newTargets);
+
+        SourceDelta d = new SourceDelta();
+        d.sourceId = sourceId;
+        d.added = added.size();
+        d.removed = removed.size();
+        d.unchanged = newTargets.size() - added.size();
+        return d;
+    }
+
+    /** Pulled out for test override; in prod, the recompute handler holds the loader. */
+    protected ComputedEdgeRecomputeHandler.SourceEntityLoader sourceLoader() {
+        try {
+            var f = ComputedEdgeRecomputeHandler.class.getDeclaredField("sourceEntityLoader");
+            f.setAccessible(true);
+            return (ComputedEdgeRecomputeHandler.SourceEntityLoader) f.get(recomputeHandler);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static final class Request {
+        public String realmId;
+        public DataDomain dataDomain;
+        public String providerId;
+        public String sourceId;       // optional: recompute one source only
+        public int batchSize = 500;
+        public boolean dryRun = false;
+    }
+
+    public static final class SourceDelta {
+        public String sourceId;
+        public int added;
+        public int removed;
+        public int unchanged;
+    }
+
+    public static final class Result {
+        public String providerId;
+        public String sourceType;
+        public boolean dryRun;
+        public int sourcesProcessed;
+        public int sourcesWithChanges;
+        public long totalAdded;
+        public long totalRemoved;
+        public List<SourceDelta> changedSources = new ArrayList<>();
+        public List<String> errors = new ArrayList<>();
+        public String error;
+
+        static Result failure(String msg) {
+            Result r = new Result();
+            r.error = msg;
+            return r;
+        }
+
+        void add(SourceDelta d) {
+            sourcesProcessed++;
+            totalAdded += d.added;
+            totalRemoved += d.removed;
+            if (d.added > 0 || d.removed > 0) {
+                sourcesWithChanges++;
+                changedSources.add(d);
+            }
+        }
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/BulkRecomputeService.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/BulkRecomputeService.java
@@ -132,13 +132,13 @@ public class BulkRecomputeService {
 
         // Existing edges produced by this provider for this source.
         String predicate = provider.getPredicate();
+        String wantedId = provider.getProviderId();
         Set<String> existingTargets = new HashSet<>();
         for (OntologyEdge e : edgeRepo.findBySrcAndP(dataDomain, sourceId, predicate)) {
-            if (Boolean.TRUE.equals(e.isDerived())) {
-                Object pid = e.getProv() != null ? e.getProv().get("providerId") : null;
-                if (pid == null || provider.getProviderId().equals(pid.toString())) {
-                    existingTargets.add(e.getDst());
-                }
+            if (!Boolean.TRUE.equals(e.isDerived())) continue;
+            String pid = ComputedEdgeReader.extractProviderId(e.getProv());
+            if (pid == null || wantedId.equals(pid)) {
+                existingTargets.add(e.getDst());
             }
         }
 

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -96,17 +96,47 @@ public class ComputedEdgeReader {
                                              ComputedEdgeProvider<?> provider, String sourceId) {
         List<OntologyEdge> stored = edgeRepo.findBySrcAndP(realmId, dataDomain, sourceId, provider.getPredicate());
         List<Reasoner.Edge> out = new ArrayList<>(stored.size());
+        String wantedId = provider.getProviderId();
         for (OntologyEdge e : stored) {
             if (!Boolean.TRUE.equals(e.isDerived())) continue;
-            // Only edges produced by THIS provider (when providerId is recorded).
-            Object pid = e.getProv() != null ? e.getProv().get("providerId") : null;
-            if (pid != null && !provider.getProviderId().equals(pid.toString())) continue;
+            String pid = extractProviderId(e.getProv());
+            // If we know which provider made this edge, filter strictly. Truly
+            // legacy edges with no recorded providerId are passed through (the
+            // alternative is dropping them silently, which is worse).
+            if (pid != null && !wantedId.equals(pid)) continue;
             out.add(new Reasoner.Edge(
                     e.getSrc(), e.getSrcType(), e.getP(),
                     e.getDst(), e.getDstType(), e.isInferred(),
                     Optional.empty()));
         }
         return out;
+    }
+
+    /**
+     * Provider id can live in two shapes depending on the write path:
+     *
+     * <ul>
+     *   <li>{@code OntologyMaterializer.upsertDerived} stores
+     *       {@code {rule:"computed", inputs:{providerId:..., ...}}}</li>
+     *   <li>{@code ComputedEdgeRecomputeHandler.insertComputedEdge} stores
+     *       {@code {rule:"computed", providerId:..., ...}} (flat)</li>
+     * </ul>
+     *
+     * Plus the M2.D5 split-provenance marker
+     * {@code {providerId:..., split:true}}. Returns {@code null} when no
+     * id can be located (truly legacy edges).
+     */
+    @SuppressWarnings("unchecked")
+    static String extractProviderId(java.util.Map<String, Object> prov) {
+        if (prov == null || prov.isEmpty()) return null;
+        Object top = prov.get("providerId");
+        if (top != null) return top.toString();
+        Object inputs = prov.get("inputs");
+        if (inputs instanceof java.util.Map<?, ?> m) {
+            Object nested = ((java.util.Map<String, Object>) m).get("providerId");
+            if (nested != null) return nested.toString();
+        }
+        return null;
     }
 
     private List<Reasoner.Edge> compute(String realmId, DataDomain dataDomain,
@@ -130,8 +160,11 @@ public class ComputedEdgeReader {
 
     private static ComputedEdgeCache.Key cacheKey(String realmId, DataDomain dataDomain,
                                                   ComputedEdgeProvider<?> provider, String sourceId) {
+        String org = dataDomain == null ? null : dataDomain.getOrgRefName();
+        String acct = dataDomain == null ? null : dataDomain.getAccountNum();
         String tenant = dataDomain == null ? null : dataDomain.getTenantId();
-        return new ComputedEdgeCache.Key(provider.getProviderId(), realmId, tenant, sourceId);
+        int seg = dataDomain == null ? 0 : dataDomain.getDataSegment();
+        return new ComputedEdgeCache.Key(provider.getProviderId(), realmId, org, acct, tenant, seg, sourceId);
     }
 
     /** Same trick as BulkRecomputeService for accessing the registered loader. */

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -1,0 +1,147 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.ontology.core.*;
+import com.e2eq.ontology.metrics.OntologyMetrics;
+import com.e2eq.ontology.model.OntologyEdge;
+import com.e2eq.ontology.repo.OntologyEdgeRepo;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.*;
+
+/**
+ * Read-side facade for retrieving computed edges that honors a provider's
+ * {@link MaterializationMode}.
+ *
+ * <p>Behavior:</p>
+ * <ul>
+ *   <li>{@code EAGER} — straight read from {@link OntologyEdgeRepo}.</li>
+ *   <li>{@code LAZY} — check {@link ComputedEdgeCache}; on miss, load the
+ *       source entity and call the provider, cache, return.</li>
+ *   <li>{@code ONDEMAND} — load the source entity and call the provider every
+ *       time. No cache.</li>
+ * </ul>
+ *
+ * <p>For {@code LAZY} and {@code ONDEMAND}, source-entity loading uses the
+ * {@link ComputedEdgeRecomputeHandler.SourceEntityLoader} that the application
+ * registers at startup.</p>
+ *
+ * <p>Callers that don't care about mode can keep using the repo directly; this
+ * facade is the right entry when correctness across all modes matters.</p>
+ */
+@ApplicationScoped
+public class ComputedEdgeReader {
+
+    @Inject ComputedEdgeRegistry registry;
+    @Inject ComputedEdgeRecomputeHandler recomputeHandler;
+    @Inject OntologyEdgeRepo edgeRepo;
+    @Inject ComputedEdgeCache cache;
+    @Inject OntologyMetrics metrics;
+
+    /** Edges produced by {@code provider} for {@code sourceId} under {@code dataDomain}. */
+    @SuppressWarnings("unchecked")
+    public List<Reasoner.Edge> edgesFor(String realmId,
+                                        DataDomain dataDomain,
+                                        ComputedEdgeProvider<?> provider,
+                                        String sourceId) {
+        Objects.requireNonNull(provider, "provider");
+        Objects.requireNonNull(sourceId, "sourceId");
+
+        MaterializationMode mode = provider.getMaterializationMode();
+        switch (mode) {
+            case EAGER -> {
+                return readFromRepo(realmId, dataDomain, provider, sourceId);
+            }
+            case LAZY -> {
+                ComputedEdgeCache.Key key = cacheKey(realmId, dataDomain, provider, sourceId);
+                Optional<List<Reasoner.Edge>> hit = cache.get(key);
+                if (hit.isPresent()) return hit.get();
+                List<Reasoner.Edge> computed =
+                        compute(realmId, dataDomain, (ComputedEdgeProvider<Object>) provider, sourceId);
+                cache.put(key, computed, provider.getCacheTtlSeconds());
+                return computed;
+            }
+            case ONDEMAND -> {
+                return compute(realmId, dataDomain, (ComputedEdgeProvider<Object>) provider, sourceId);
+            }
+            default -> throw new IllegalStateException("Unhandled mode: " + mode);
+        }
+    }
+
+    /**
+     * Convenience: look up provider by id, then dispatch.
+     */
+    public List<Reasoner.Edge> edgesFor(String realmId, DataDomain dataDomain,
+                                        String providerId, String sourceId) {
+        return registry.getProvider(providerId)
+                .map(p -> edgesFor(realmId, dataDomain, p, sourceId))
+                .orElse(List.of());
+    }
+
+    /**
+     * Invalidate the cached entry for a (provider, source) pair.
+     * No-op for non-LAZY providers.
+     */
+    public void invalidate(String realmId, DataDomain dataDomain,
+                           ComputedEdgeProvider<?> provider, String sourceId) {
+        if (provider.getMaterializationMode() != MaterializationMode.LAZY) return;
+        cache.invalidate(cacheKey(realmId, dataDomain, provider, sourceId));
+    }
+
+    // ────────── internal ──────────
+
+    private List<Reasoner.Edge> readFromRepo(String realmId, DataDomain dataDomain,
+                                             ComputedEdgeProvider<?> provider, String sourceId) {
+        List<OntologyEdge> stored = edgeRepo.findBySrcAndP(realmId, dataDomain, sourceId, provider.getPredicate());
+        List<Reasoner.Edge> out = new ArrayList<>(stored.size());
+        for (OntologyEdge e : stored) {
+            if (!Boolean.TRUE.equals(e.isDerived())) continue;
+            // Only edges produced by THIS provider (when providerId is recorded).
+            Object pid = e.getProv() != null ? e.getProv().get("providerId") : null;
+            if (pid != null && !provider.getProviderId().equals(pid.toString())) continue;
+            out.add(new Reasoner.Edge(
+                    e.getSrc(), e.getSrcType(), e.getP(),
+                    e.getDst(), e.getDstType(), e.isInferred(),
+                    Optional.empty()));
+        }
+        return out;
+    }
+
+    private List<Reasoner.Edge> compute(String realmId, DataDomain dataDomain,
+                                        ComputedEdgeProvider<Object> provider, String sourceId) {
+        ComputedEdgeRecomputeHandler.SourceEntityLoader loader = sourceLoader();
+        if (loader == null) {
+            Log.warnf("ComputedEdgeReader: no SourceEntityLoader; provider %s mode requires one",
+                    provider.getProviderId());
+            return List.of();
+        }
+        Optional<Object> entity = loader.loadEntity(realmId, dataDomain, provider.getSourceType(), sourceId);
+        if (entity.isEmpty()) return List.of();
+        DataDomainInfo domainInfo = DataDomainConverter.toInfo(dataDomain);
+        long start = System.nanoTime();
+        List<Reasoner.Edge> edges = provider.edges(realmId, domainInfo, entity.get());
+        metrics.recordProviderInvocation(provider.getProviderId(),
+                System.nanoTime() - start,
+                edges == null ? 0 : edges.size());
+        return edges == null ? List.of() : edges;
+    }
+
+    private static ComputedEdgeCache.Key cacheKey(String realmId, DataDomain dataDomain,
+                                                  ComputedEdgeProvider<?> provider, String sourceId) {
+        String tenant = dataDomain == null ? null : dataDomain.getTenantId();
+        return new ComputedEdgeCache.Key(provider.getProviderId(), realmId, tenant, sourceId);
+    }
+
+    /** Same trick as BulkRecomputeService for accessing the registered loader. */
+    protected ComputedEdgeRecomputeHandler.SourceEntityLoader sourceLoader() {
+        try {
+            var f = ComputedEdgeRecomputeHandler.class.getDeclaredField("sourceEntityLoader");
+            f.setAccessible(true);
+            return (ComputedEdgeRecomputeHandler.SourceEntityLoader) f.get(recomputeHandler);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeRecomputeHandler.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeRecomputeHandler.java
@@ -46,6 +46,9 @@ public class ComputedEdgeRecomputeHandler {
     @Inject
     OntologyMaterializer materializer;
 
+    @Inject
+    ComputedEdgeCache computedEdgeCache;
+
     /** Optional loader for source entities - must be provided by application */
     private SourceEntityLoader sourceEntityLoader;
 
@@ -166,6 +169,21 @@ public class ComputedEdgeRecomputeHandler {
             ComputedEdgeProvider<?> provider,
             String sourceId) {
 
+        MaterializationMode mode = provider.getMaterializationMode();
+        if (mode == MaterializationMode.ONDEMAND) {
+            // Nothing stored, nothing cached. Reads always recompute.
+            return true;
+        }
+        if (mode == MaterializationMode.LAZY) {
+            // No stored edges to refresh; just punch the cache so the next read
+            // recomputes against the new dependency state.
+            String tenant = dataDomain == null ? null : dataDomain.getTenantId();
+            computedEdgeCache.invalidate(new ComputedEdgeCache.Key(
+                    provider.getProviderId(), realmId, tenant, sourceId));
+            return true;
+        }
+
+        // EAGER (default): persist new edges, prune old ones.
         // Load source entity
         if (sourceEntityLoader == null) {
             Log.warnf("Cannot recompute edges: no SourceEntityLoader configured");

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeRecomputeHandler.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeRecomputeHandler.java
@@ -177,9 +177,12 @@ public class ComputedEdgeRecomputeHandler {
         if (mode == MaterializationMode.LAZY) {
             // No stored edges to refresh; just punch the cache so the next read
             // recomputes against the new dependency state.
+            String org = dataDomain == null ? null : dataDomain.getOrgRefName();
+            String acct = dataDomain == null ? null : dataDomain.getAccountNum();
             String tenant = dataDomain == null ? null : dataDomain.getTenantId();
+            int seg = dataDomain == null ? 0 : dataDomain.getDataSegment();
             computedEdgeCache.invalidate(new ComputedEdgeCache.Key(
-                    provider.getProviderId(), realmId, tenant, sourceId));
+                    provider.getProviderId(), realmId, org, acct, tenant, seg, sourceId));
             return true;
         }
 

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/OntologyMaterializer.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/OntologyMaterializer.java
@@ -6,6 +6,7 @@ import java.util.*;
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.ontology.core.DataDomainInfo;
 import com.e2eq.ontology.core.EdgeRecord;
+import com.e2eq.ontology.metrics.OntologyMetrics;
 import com.e2eq.ontology.model.OntologyEdge;
 import com.e2eq.ontology.repo.OntologyEdgeRepo;
 import jakarta.inject.Inject;
@@ -28,6 +29,32 @@ public class OntologyMaterializer {
 
    @Inject
    protected OntologyEdgeRepo edgeRepo;
+
+   @Inject
+   protected OntologyMetrics metrics;
+
+    /**
+     * Extract a provider id from a Reasoner.Edge's provenance, or null if the
+     * edge was not produced by a {@code ComputedEdgeProvider}.
+     */
+    private static String providerIdOf(Reasoner.Edge e) {
+        return e.prov()
+                .filter(p -> "computed".equals(p.rule()))
+                .map(p -> {
+                    Object v = p.inputs() == null ? null : p.inputs().get("providerId");
+                    return v == null ? null : v.toString();
+                })
+                .orElse(null);
+    }
+
+    /**
+     * Extract a provider id from a stored OntologyEdge's provenance.
+     */
+    private static String providerIdOf(OntologyEdge e) {
+        if (e == null || e.getProv() == null) return null;
+        Object v = e.getProv().get("providerId");
+        return v == null ? null : v.toString();
+    }
 
     /**
      * Apply materialization for an entity with full DataDomain scoping.
@@ -140,6 +167,8 @@ public class OntologyMaterializer {
                     OntologyEdge updated = findEdge(realmId, dataDomain, e.srcId(), e.p(), e.dstId());
                     if (existing == null) {
                         changes.added().add(toEdgeRecord(updated, dataDomain));
+                        String pid = providerIdOf(e);
+                        if (pid != null) metrics.recordEdgesAdded(pid, 1);
                     } else if (isModified(existing, updated)) {
                         changes.modified().add(toEdgeRecord(updated, dataDomain));
                     }
@@ -251,7 +280,11 @@ public class OntologyMaterializer {
 
             existingAfterUpsert.stream()
                     .filter(ex -> Objects.equals(ex.getP(), p) && Boolean.TRUE.equals(ex.isDerived()) && !ex.isInferred() && !keep.contains(ex.getDst()))
-                    .forEach(ex -> changes.removed().add(toEdgeRecord(ex, dataDomain)));
+                    .forEach(ex -> {
+                        changes.removed().add(toEdgeRecord(ex, dataDomain));
+                        String pid = providerIdOf(ex);
+                        if (pid != null) metrics.recordEdgesRemoved(pid, 1);
+                    });
 
             edgeRepo.deleteDerivedBySrcNotIn(realmId, dataDomain, entityId, p, keep);
             existingDerivedByP.remove(p);
@@ -260,7 +293,11 @@ public class OntologyMaterializer {
         for (String pAbsent : existingDerivedByP.keySet()) {
             existingAfterUpsert.stream()
                     .filter(ex -> Objects.equals(ex.getP(), pAbsent) && Boolean.TRUE.equals(ex.isDerived()) && !ex.isInferred())
-                    .forEach(ex -> changes.removed().add(toEdgeRecord(ex, dataDomain)));
+                    .forEach(ex -> {
+                        changes.removed().add(toEdgeRecord(ex, dataDomain));
+                        String pid = providerIdOf(ex);
+                        if (pid != null) metrics.recordEdgesRemoved(pid, 1);
+                    });
             edgeRepo.deleteDerivedBySrcNotIn(realmId, dataDomain, entityId, pAbsent, Set.of());
         }
 

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/OntologyWriteHook.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/OntologyWriteHook.java
@@ -4,9 +4,11 @@ import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
 import com.e2eq.framework.model.persistent.morphia.PostPersistHook;
 import com.e2eq.ontology.annotations.OntologyClass;
+import com.e2eq.ontology.core.ComputedEdgeProvider;
 import com.e2eq.ontology.core.DataDomainInfo;
 import com.e2eq.ontology.core.OntologyRegistry;
 import com.e2eq.ontology.core.Reasoner;
+import com.e2eq.ontology.metrics.OntologyMetrics;
 import com.e2eq.ontology.model.OntologyEdge;
 import com.e2eq.ontology.repo.OntologyEdgeRepo;
 import com.e2eq.ontology.spi.OntologyEdgeProvider;
@@ -29,6 +31,7 @@ public class OntologyWriteHook implements PostPersistHook {
     @Inject CascadeExecutor cascadeExecutor;
     @Inject OntologyEdgeRepo edgeRepo;
     @Inject Instance<OntologyEdgeProvider> providers;
+    @Inject OntologyMetrics metrics;
 
     @Override
     public void afterPersist(String realmId, Object entity) {
@@ -53,17 +56,26 @@ public class OntologyWriteHook implements PostPersistHook {
 
         // Extend with SPI-provided edges (includes ComputedEdgeProviders)
         DataDomainInfo dataDomainInfo = DataDomainConverter.toInfo(dataDomain);
-        try {
-            for (OntologyEdgeProvider p : providers) {
-                if (p.supports(entityClass)) {
-                    var extra = p.edges(realmId, dataDomainInfo, entity);
-                    if (extra != null && !extra.isEmpty()) {
-                        explicit.addAll(extra);
-                    }
+        for (OntologyEdgeProvider p : providers) {
+            if (!p.supports(entityClass)) continue;
+            String providerId = (p instanceof ComputedEdgeProvider<?> cep)
+                    ? cep.getProviderId()
+                    : p.getClass().getSimpleName();
+            long start = System.nanoTime();
+            int produced = 0;
+            try {
+                var extra = p.edges(realmId, dataDomainInfo, entity);
+                if (extra != null && !extra.isEmpty()) {
+                    produced = extra.size();
+                    explicit.addAll(extra);
                 }
+            } catch (Throwable t) {
+                metrics.recordProviderError(providerId);
+                io.quarkus.logging.Log.warnf(t, "OntologyWriteHook: provider %s failed", providerId);
+                continue;
+            } finally {
+                metrics.recordProviderInvocation(providerId, System.nanoTime() - start, produced);
             }
-        } catch (Throwable t) {
-            io.quarkus.logging.Log.warn("OntologyWriteHook: provider extension failed", t);
         }
 
         String srcId = extractor.idOf(entity);

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/OntologyWriteHook.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/OntologyWriteHook.java
@@ -6,6 +6,7 @@ import com.e2eq.framework.model.persistent.morphia.PostPersistHook;
 import com.e2eq.ontology.annotations.OntologyClass;
 import com.e2eq.ontology.core.ComputedEdgeProvider;
 import com.e2eq.ontology.core.DataDomainInfo;
+import com.e2eq.ontology.core.MaterializationMode;
 import com.e2eq.ontology.core.OntologyRegistry;
 import com.e2eq.ontology.core.Reasoner;
 import com.e2eq.ontology.metrics.OntologyMetrics;
@@ -61,6 +62,11 @@ public class OntologyWriteHook implements PostPersistHook {
             String providerId = (p instanceof ComputedEdgeProvider<?> cep)
                     ? cep.getProviderId()
                     : p.getClass().getSimpleName();
+            // Honor materialization mode: only EAGER providers contribute at write time.
+            if (p instanceof ComputedEdgeProvider<?> cep
+                    && cep.getMaterializationMode() != MaterializationMode.EAGER) {
+                continue;
+            }
             long start = System.nanoTime();
             int produced = 0;
             try {

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ProvenanceMigrationService.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ProvenanceMigrationService.java
@@ -1,0 +1,85 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.ontology.model.OntologyEdge;
+import com.e2eq.ontology.repo.OntologyEdgeProvenanceRepo;
+import com.e2eq.ontology.repo.OntologyEdgeRepo;
+import dev.morphia.Datastore;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One-shot migration from inline-provenance edges to the side
+ * {@code ontology_edge_provenance} collection.
+ *
+ * <p>Idempotent: re-running over already-migrated edges is a no-op (the side
+ * collection's unique-by-edgeId index dedupes; the inline {@code prov} clear
+ * is conditional on size).</p>
+ *
+ * <p>Targets only computed/derived edges (those carrying a non-trivial prov
+ * map). Non-derived edges generally have small or empty prov and are left in
+ * place.</p>
+ */
+@ApplicationScoped
+public class ProvenanceMigrationService {
+
+    @Inject OntologyEdgeRepo edgeRepo;
+    @Inject OntologyEdgeProvenanceRepo provenanceRepo;
+
+    public Result migrate(String realmId, boolean dryRun) {
+        Result r = new Result();
+        Datastore ds = edgeRepo.ds(realmId);
+        // Stream all derived edges in the realm.
+        List<OntologyEdge> all = ds.find(OntologyEdge.class).iterator().toList();
+
+        for (OntologyEdge edge : all) {
+            if (!Boolean.TRUE.equals(edge.isDerived())) continue;
+            Map<String, Object> prov = edge.getProv();
+            if (prov == null || prov.isEmpty()) continue;
+            // Skip if already migrated (marker present).
+            if (Boolean.TRUE.equals(prov.get("split"))) {
+                r.alreadyMigrated++;
+                continue;
+            }
+
+            r.candidates++;
+            if (dryRun) continue;
+
+            try {
+                String edgeId = edge.getId() == null ? null : edge.getId().toString();
+                if (edgeId == null) {
+                    r.skippedNoId++;
+                    continue;
+                }
+                Object pid = prov.get("providerId");
+                String providerId = pid == null ? null : pid.toString();
+
+                provenanceRepo.upsert(realmId, edgeId, providerId, prov);
+
+                // Replace the inline prov with a marker. Keep providerId for filtering.
+                Map<String, Object> marker = providerId != null
+                        ? Map.of("providerId", providerId, "split", true)
+                        : Map.of("split", true);
+                edge.setProv(marker);
+                edgeRepo.save(ds, edge);
+                r.migrated++;
+            } catch (Exception e) {
+                Log.warnf(e, "Provenance migration failed for edge %s", edge.getId());
+                r.errors++;
+            }
+        }
+        return r;
+    }
+
+    public static final class Result {
+        public int candidates;
+        public int migrated;
+        public int alreadyMigrated;
+        public int skippedNoId;
+        public int errors;
+        public boolean dryRun;
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ProvenanceStore.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ProvenanceStore.java
@@ -1,0 +1,83 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.ontology.model.OntologyEdge;
+import com.e2eq.ontology.model.OntologyEdgeProvenanceDoc;
+import com.e2eq.ontology.repo.OntologyEdgeProvenanceRepo;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Strategy for reading and writing edge provenance.
+ *
+ * <p>Behavior is gated by config {@code quantum.ontology.provenance.split}:</p>
+ * <ul>
+ *   <li>{@code false} (default): provenance is inlined on {@link OntologyEdge#getProv()}.
+ *       This module is then a thin pass-through over the inline storage so callers
+ *       can use the same API regardless of mode.</li>
+ *   <li>{@code true}: provenance is written to {@link OntologyEdgeProvenanceDoc}
+ *       keyed by edge id. The inline {@code prov} map on {@code OntologyEdge}
+ *       remains for legacy edges and a small {@code "providerId"} marker.</li>
+ * </ul>
+ *
+ * <p>Read path checks both: side-collection first, then inline fallback. This lets
+ * a deployment switch the flag on without breaking existing inline-provenance edges.</p>
+ *
+ * <p>NOTE: this PR ships the storage and migration plumbing. Wiring the flag into
+ * the {@code OntologyMaterializer} / {@code OntologyEdgeRepo.upsert*} write paths
+ * is intentionally a follow-up so it can land with full integration-test coverage.</p>
+ */
+@ApplicationScoped
+public class ProvenanceStore {
+
+    @Inject OntologyEdgeProvenanceRepo provenanceRepo;
+
+    @ConfigProperty(name = "quantum.ontology.provenance.split", defaultValue = "false")
+    boolean splitEnabled;
+
+    /** True if the side-collection mode is active for new writes. */
+    public boolean isSplitEnabled() { return splitEnabled; }
+
+    /**
+     * Persist provenance for an edge.
+     *
+     * @param realmId    the realm
+     * @param edge       the edge being persisted
+     * @param providerId provider id (may be null for non-computed edges)
+     * @param prov       full provenance map
+     */
+    public void persist(String realmId, OntologyEdge edge, String providerId, Map<String, Object> prov) {
+        if (edge == null) return;
+        if (!splitEnabled) {
+            edge.setProv(prov);
+            return;
+        }
+        // Side-collection mode: keep a tiny marker on the edge so reads know provenance exists.
+        edge.setProv(providerId == null ? Map.of() : Map.of("providerId", providerId, "split", true));
+        if (edge.getId() != null) {
+            provenanceRepo.upsert(realmId, edge.getId().toString(), providerId, prov);
+        } else {
+            // Edge not yet saved. Caller should re-invoke after assigning an id.
+            Log.debugf("ProvenanceStore.persist called before edge has an id; deferred to caller");
+        }
+    }
+
+    /**
+     * Resolve provenance for an edge, regardless of where it lives.
+     */
+    public Optional<Map<String, Object>> read(String realmId, OntologyEdge edge) {
+        if (edge == null) return Optional.empty();
+        // Side collection wins if present.
+        if (edge.getId() != null) {
+            Optional<OntologyEdgeProvenanceDoc> sideHit = provenanceRepo.findByEdgeId(realmId, edge.getId().toString());
+            if (sideHit.isPresent()) {
+                return Optional.ofNullable(sideHit.get().getProv());
+            }
+        }
+        return Optional.ofNullable(edge.getProv());
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/SourceEntityEnumerator.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/SourceEntityEnumerator.java
@@ -1,0 +1,32 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+
+import java.util.List;
+
+/**
+ * SPI for listing source entity IDs of a given type within a {@link DataDomain}.
+ *
+ * <p>Used by {@link BulkRecomputeService} to walk all sources for a provider
+ * during a bulk recompute. Each application registers one bean per source
+ * entity type; the bulk service picks the matching enumerator by
+ * {@link #supports(Class)}.</p>
+ */
+public interface SourceEntityEnumerator {
+
+    /** True if this enumerator can list IDs for the given entity type. */
+    boolean supports(Class<?> entityType);
+
+    /**
+     * Page through source entity IDs.
+     *
+     * @param realmId      realm
+     * @param dataDomain   scoping domain
+     * @param entityType   the source type
+     * @param afterId      pagination cursor (exclusive); null on first call
+     * @param limit        max IDs to return
+     * @return up to {@code limit} ids ordered ascending; empty when exhausted
+     */
+    List<String> listIds(String realmId, DataDomain dataDomain,
+                         Class<?> entityType, String afterId, int limit);
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeProvenanceRepo.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeProvenanceRepo.java
@@ -1,0 +1,66 @@
+package com.e2eq.ontology.repo;
+
+import com.e2eq.framework.model.persistent.morphia.MorphiaRepo;
+import com.e2eq.ontology.model.OntologyEdgeProvenanceDoc;
+import dev.morphia.Datastore;
+import dev.morphia.query.filters.Filters;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Repository for {@link OntologyEdgeProvenanceDoc}.
+ *
+ * <p>Side-collection storage for computed-edge provenance. See
+ * {@code ProvenanceStore} for the read/write strategy that decides whether a
+ * given edge's provenance lives inline on {@code OntologyEdge} or here.</p>
+ */
+@ApplicationScoped
+public class OntologyEdgeProvenanceRepo extends MorphiaRepo<OntologyEdgeProvenanceDoc> {
+
+    public Datastore ds() { return ds(getSecurityContextRealmId()); }
+
+    public Datastore ds(String realm) {
+        if (realm == null) return morphiaDataStoreWrapper.getDataStore(getSecurityContextRealmId());
+        return morphiaDataStoreWrapper.getDataStore(realm);
+    }
+
+    public Optional<OntologyEdgeProvenanceDoc> findByEdgeId(String edgeId) {
+        return findByEdgeId(getSecurityContextRealmId(), edgeId);
+    }
+
+    public Optional<OntologyEdgeProvenanceDoc> findByEdgeId(String realmId, String edgeId) {
+        if (edgeId == null || edgeId.isBlank()) return Optional.empty();
+        return Optional.ofNullable(ds(realmId).find(OntologyEdgeProvenanceDoc.class)
+                .filter(Filters.eq("edgeId", edgeId))
+                .first());
+    }
+
+    public List<OntologyEdgeProvenanceDoc> findByProviderId(String realmId, String providerId) {
+        return ds(realmId).find(OntologyEdgeProvenanceDoc.class)
+                .filter(Filters.eq("providerId", providerId))
+                .iterator().toList();
+    }
+
+    /** Upsert provenance for an edge. */
+    public OntologyEdgeProvenanceDoc upsert(String realmId, String edgeId, String providerId, Map<String, Object> prov) {
+        Optional<OntologyEdgeProvenanceDoc> existing = findByEdgeId(realmId, edgeId);
+        OntologyEdgeProvenanceDoc doc = existing.orElseGet(OntologyEdgeProvenanceDoc::new);
+        doc.setEdgeId(edgeId);
+        doc.setProviderId(providerId);
+        doc.setProv(prov);
+        doc.setTs(new Date());
+        if (doc.getRefName() == null) doc.setRefName(edgeId);
+        return save(ds(realmId), doc);
+    }
+
+    public long deleteByEdgeId(String realmId, String edgeId) {
+        return ds(realmId).find(OntologyEdgeProvenanceDoc.class)
+                .filter(Filters.eq("edgeId", edgeId))
+                .delete()
+                .getDeletedCount();
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/resource/OntologyAdminResource.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/resource/OntologyAdminResource.java
@@ -4,6 +4,7 @@ import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.ontology.metrics.OntologyMetrics;
 import com.e2eq.ontology.model.OntologyMeta;
 import com.e2eq.ontology.mongo.BulkRecomputeService;
+import com.e2eq.ontology.mongo.ProvenanceMigrationService;
 import com.e2eq.ontology.repo.OntologyMetaRepo;
 import com.e2eq.ontology.service.OntologyReindexer;
 import io.smallrye.mutiny.Multi;
@@ -38,6 +39,9 @@ public class OntologyAdminResource {
 
     @Inject
     OntologyMetrics ontologyMetrics;
+
+    @Inject
+    ProvenanceMigrationService provenanceMigration;
 
     @GET
     @Path("/meta")
@@ -159,5 +163,21 @@ public class OntologyAdminResource {
     @Path("/metrics")
     public Map<String, Map<String, Object>> metrics() {
         return ontologyMetrics.snapshot();
+    }
+
+    /**
+     * One-shot migration of inline provenance to the side
+     * {@code ontology_edge_provenance} collection. Idempotent.
+     *
+     * <p>Use {@code dryRun=true} to count candidates without writing.</p>
+     */
+    @POST
+    @Path("/provenance/migrate")
+    public ProvenanceMigrationService.Result migrateProvenance(
+            @QueryParam("realm") @DefaultValue("default") String realm,
+            @QueryParam("dryRun") @DefaultValue("false") boolean dryRun) {
+        ProvenanceMigrationService.Result r = provenanceMigration.migrate(realm, dryRun);
+        r.dryRun = dryRun;
+        return r;
     }
 }

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/resource/OntologyAdminResource.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/resource/OntologyAdminResource.java
@@ -1,6 +1,9 @@
 package com.e2eq.ontology.resource;
 
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.ontology.metrics.OntologyMetrics;
 import com.e2eq.ontology.model.OntologyMeta;
+import com.e2eq.ontology.mongo.BulkRecomputeService;
 import com.e2eq.ontology.repo.OntologyMetaRepo;
 import com.e2eq.ontology.service.OntologyReindexer;
 import io.smallrye.mutiny.Multi;
@@ -29,6 +32,12 @@ public class OntologyAdminResource {
 
     @Inject
     Executor managedExecutor;
+
+    @Inject
+    BulkRecomputeService bulkRecompute;
+
+    @Inject
+    OntologyMetrics ontologyMetrics;
 
     @GET
     @Path("/meta")
@@ -109,5 +118,46 @@ public class OntologyAdminResource {
                 "status", reindexer.status(),
                 "result", reindexer.getResult()
         );
+    }
+
+    /**
+     * Bulk recompute / reconciliation for one provider.
+     *
+     * <p>Walks all source entities of the provider's source type via a
+     * registered {@code SourceEntityEnumerator}, recomputes their target
+     * sets, and either reports the deltas (dryRun=true) or applies them.</p>
+     *
+     * <p>Body:</p>
+     * <pre>
+     * {
+     *   "providerId": "AssociateCanSeeLocationProvider",
+     *   "realmId": "acme",
+     *   "dataDomain": { "orgRefName": "...", "accountNum": "...", "tenantId": "...", "dataSegment": 0 },
+     *   "sourceId": "optional-single-id",
+     *   "batchSize": 500,
+     *   "dryRun": true
+     * }
+     * </pre>
+     */
+    @POST
+    @Path("/recompute")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response recompute(BulkRecomputeService.Request req) {
+        if (req == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "request body required")).build();
+        }
+        BulkRecomputeService.Result result = bulkRecompute.recompute(req);
+        if (result.error != null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(result).build();
+        }
+        return Response.ok(result).build();
+    }
+
+    /** Snapshot of per-provider metrics (invocations, durations, deltas, guard trips). */
+    @GET
+    @Path("/metrics")
+    public Map<String, Map<String, Object>> metrics() {
+        return ontologyMetrics.snapshot();
     }
 }


### PR DESCRIPTION
Implements the calculated-relations design from
`quantum-docs/src/docs/asciidoc/design/calculated-relations-roadmap.adoc`
(M1 Safety Net, M2 Operability, M3 Performance/Authoring).

## Summary

| # | Item | Status |
|---|---|---|
| M1.D7 | `OntologyMetrics` bean + write-hook/materializer wiring | Done |
| M1.D4 | Cycle / depth / target guards in `ComputationContext` + `HierarchyListEdgeProvider` | Done |
| M1.D2 | `@DependsOn` annotation + `ComputedEdgeStalenessValidator` + startup WARNs | Done |
| M1.D8 | `InMemoryHierarchy` + `ComputedEdgeProviderHarness` test kit | Done |
| M2.D6 | `BulkRecomputeService` + `POST /ontology/admin/recompute` (CLI shim deferred) | Done* |
| M2.D5 | `OntologyEdgeProvenanceDoc` + `ProvenanceStore` + migration runner (upsert wiring deferred) | Done* |
| M3.D1 | `MaterializationMode` + `ComputedEdgeCache` + `ComputedEdgeReader` + recompute-handler awareness | Done |
| M3.D3 | YAML `computed:` block + `DeclarativeRuntime` SPI + `DeclarativeComputedEdgeProvider` | Done |

72/72 tests in `quantum-ontology-core` (was 53). Per-item status callouts
appear inline in the design doc.

## Deferrals (documented in the roadmap)

- **D6 CLI shim.** quarkus-picocli only allows one `@TopCommand` and
  `ServiceTokenCLI` already claims it. The REST endpoint is the canonical
  entry; a thin CLI wrapper that posts to it can land separately.
- **D5 upsert-path wiring.** Side-collection storage, migration, and the
  feature flag (`quantum.ontology.provenance.split`, default `false`) are
  in place. Rewriting `OntologyMaterializer` and `OntologyEdgeRepo`
  upsert paths to consult `ProvenanceStore` instead of setting `prov`
  directly should land with full IT coverage in a follow-up. With the
  flag off (default), behavior is unchanged.

## Notes for review

- Local environment can build `quantum-ontology-core` but not the rest of
  the chain (the `quantum-extension` snapshot returns 403). Mongo-side
  additions (`BulkRecomputeService`, `ComputedEdgeReader`,
  `ProvenanceStore`, `ProvenanceMigrationService`,
  `OntologyAdminResource` additions, `OntologyMaterializer` and
  `OntologyWriteHook` edits) were edited carefully but will be validated
  by CI.
- The `OntologyMetrics` bean is dependency-free on purpose so
  `quantum-ontology-core` doesn't pick up a Micrometer dep. Snapshots
  are exposable now via `GET /ontology/admin/metrics`; a Micrometer
  bridge that subscribes to those snapshots is a follow-up.
- Drive-by fix: `extractId`, `extractNodeId`, and `extractNodeRefName`
  now `setAccessible(true)` so providers work against package-private
  fixtures and reflection-loaded entity classes.

## Test plan

- [ ] CI green on `quantum-ontology-core` (72 tests, all new ones included).
- [ ] CI green on `quantum-ontology-mongo` integration tests
      (`@QuarkusTest` suite, including the existing `OntologyEndToEndIT`).
- [ ] Manual smoke: hit `GET /ontology/admin/metrics` after a few
      ontology writes; verify per-provider counters appear.
- [ ] Manual smoke: `POST /ontology/admin/recompute` with `dryRun=true`
      and a known provider id; verify the deltas response shape.
- [ ] Manual smoke: leave `quantum.ontology.provenance.split=false`
      (default) and confirm provenance behavior is unchanged. Then flip
      to `true`, run `POST /ontology/admin/provenance/migrate?dryRun=true`,
      check the candidate count.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FFUxHADig8jEf47j8UmzVM)_