### PR TITLE
Fix PlannerProjectionValidationTest: analyze() chokes on fields:[...] projection

### DIFF
--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/planner/QueryPlanner.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/planner/QueryPlanner.java
@@ -63,7 +63,17 @@ public class QueryPlanner {
         if (query == null || query.isBlank()) {
             return new PlannerResult(PlannerResult.Mode.FILTER, List.of());
         }
-        BIAPIQueryLexer lexer = new BIAPIQueryLexer(CharStreams.fromString(query));
+        // The root-projection directive `fields:[...]` is handled by string
+        // preprocessing (parseRootProjection / stripExpandAndProjection), not the
+        // grammar — it has no `fields` rule. Strip it before parsing here too, or a
+        // projection query trips the parser ("no viable alternative at input
+        // 'fields:['") before plan() ever gets to strip it. expand(...) is left in
+        // place because the grammar parses it and analyze() needs it to detect mode.
+        String parseable = query.contains("fields:[") ? stripProjectionForParse(query) : query;
+        if (parseable.isBlank()) {
+            return new PlannerResult(PlannerResult.Mode.FILTER, List.of());
+        }
+        BIAPIQueryLexer lexer = new BIAPIQueryLexer(CharStreams.fromString(parseable));
         BIAPIQueryParser parser = new BIAPIQueryParser(new CommonTokenStream(lexer));
         parser.addErrorListener(new BaseErrorListener() {
             @Override
@@ -81,6 +91,17 @@ public class QueryPlanner {
 
     public <T extends UnversionedBaseModel> PlannedQuery plan(String query, Class<T> modelClass) {
         return plan(query, modelClass, null, null, null, null);
+    }
+
+    // Remove only the fields:[...] projection (keep expand(...) so analyze can detect
+    // it), then tidy any logical operator the removal left dangling.
+    private String stripProjectionForParse(String query) {
+        String s = query.replaceAll("(?i)fields:\\[[^]]*\\]", "");
+        s = s.replaceAll("\\s*&&\\s*", " && ");
+        s = s.replaceAll("\\s*\\|\\|\\s*", " || ");
+        s = s.replaceAll("^(?:\\s*(?:&&|\\|\\|)\\s*)+", "");
+        s = s.replaceAll("(?:\\s*(?:&&|\\|\\|)\\s*)+$", "");
+        return s.trim().replaceAll("\\s{2,}", " ");
     }
 
     // Remove expand(...) directives and fields:[...] projection from the raw query string


### PR DESCRIPTION
Fixes the two `PlannerProjectionValidationTest` failures on `1.4.0-SNAPSHOT`:

```
PlannerProjectionValidationTest.rootProjection_unknownPath_throws
  expected QueryMetadataException but was IllegalStateException
PlannerProjectionValidationTest.rootProjection_only_id_is_allowed_even_if_not_in_model
  IllegalState: Failed to parse query at line 1: no viable alternative at input 'fields:['
```

## Root cause
`QueryPlanner.analyze()` ran the ANTLR grammar over the **full** query string, including the `fields:[...]` root-projection directive. The grammar deliberately has **no `fields` rule** — projection is handled by string preprocessing everywhere else (`parseRootProjection` / `stripExpandAndProjection`). So a projection query tripped the parser (`no viable alternative at input 'fields:['`) inside `analyze()`, before `plan()` ever got to strip it. That surfaced as an `IllegalStateException` instead of the expected `QueryMetadataException` (unknown path) or a clean `AGGREGATION` plan.

## Fix
Strip `fields:[...]` in `analyze()` before parsing too — only when present, so non-projection queries parse exactly as before — while leaving `expand(...)` in place (the grammar parses it and `analyze` needs it to detect aggregation mode). This makes `analyze()` consistent with `plan()`'s aggregation path.

## Verification
- `PlannerProjectionValidationTest` 2/2 green.
- Planner package (`PlannerDecisionTest`, `MongoAggregationCompilerProjectionTest`, `PlannerProjectionValidationTest`) 5/5 green.

Targets `1.4.0-SNAPSHOT` (locked branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)