### PR TITLE
Framework: governed ontology (DataDomainPolicy/QueryGateway/B5/TBox) + seed-system-only flags

### DIFF
--- a/docs/design/quantum-central-auth-control-plane.md
+++ b/docs/design/quantum-central-auth-control-plane.md
@@ -1,0 +1,826 @@
+# Quantum Central Auth and Control Plane Service
+
+## Status
+
+Implementation design with initial wrapper-service slice in progress.
+
+The deployable `quantum-auth-service` belongs in `quantum-enterprise`, not the
+open-source framework reactor, because HelixCode can deploy enterprise modules
+and the service needs the enterprise `quantum-oidc-provider` to support generic
+OIDC/GitHub login. The open-source `quantum-framework` remains the reusable
+contract/resource/provider foundation.
+
+This document intentionally steps back from the current `quantum-auth-service`
+prototype. That prototype should be treated as disposable unless a class is
+proven to be deployment glue around existing Quantum capabilities. The service
+we need is not a new authentication or authorization framework. It is a
+deployable boundary around the authentication, authorization, policy,
+functional-domain, tenant, organization, account, feature-flag, impersonation,
+realm, and query/filter capabilities that already exist in Quantum.
+
+## Goal
+
+Create a separately deployable Quantum auth/control-plane service that Helixor,
+Quantum applications, and other clients can use for:
+
+- authentication and provider discovery;
+- authorization checks and policy diagnostics;
+- principal and resource context evaluation;
+- realm override and impersonation behavior;
+- functional area, functional domain, and functional action catalog access;
+- tenant, organization, account, realm, and membership access;
+- feature flag and entitlement access;
+- policy/query filter generation for provider-backed data access.
+
+The service must reuse existing Quantum modules and contracts. New code is
+allowed only when it is a thin facade, deployment adapter, SDK contract, or
+provider-specific binding that does not already exist.
+
+## Non-Goals
+
+- Do not create a parallel authz model hierarchy.
+- Do not create new `PrincipalContext`, `ResourceContext`, policy, tenant,
+  organization, account, feature flag, functional-domain, or credential models.
+- Do not hard-code org, tenant, GitHub owner, role, realm, or data-domain
+  filters in the service.
+- Do not implement a new policy engine.
+- Do not implement a new auth provider chain.
+- Do not duplicate existing policy-check, debug, authorization, authentication,
+  impersonation, or X-Realm behavior.
+- Do not build Python-side or Helixor-side control-plane tables that compete
+  with Quantum as the source of truth.
+
+## Reuse Gate
+
+Before adding any class, endpoint, DTO, or repository to this service, answer:
+
+1. Does an existing Quantum module already expose this behavior?
+2. Does an existing model already represent this concept?
+3. Does an existing resource already expose this endpoint shape?
+4. Does an existing repository already persist this entity?
+5. Does an existing provider binding already lower the query/filter?
+6. If we still add code, is it only facade/config/deployment/SDK glue?
+
+If the answer to 1-5 is yes, reuse it. If the answer to 6 is no, do not add the
+code.
+
+## Existing Quantum Capabilities To Reuse
+
+### Authentication
+
+Source of truth:
+
+- `quantum-models`
+  - `com.e2eq.framework.model.auth.AuthProvider`
+  - `com.e2eq.framework.model.auth.AuthProviderFactory`
+  - `com.e2eq.framework.model.auth.UserManagement`
+  - `com.e2eq.framework.model.auth.ClaimsAuthProvider`
+- `quantum-jwt-provider`
+  - `com.e2eq.framework.model.auth.provider.jwtToken.CustomTokenAuthProvider`
+- `quantum-enterprise`
+  - `quantum-oidc-provider`, discovered through `AuthProviderFactory` when the
+    enterprise service is deployed
+- Cognito provider module when needed
+- `quantum-framework`
+  - `com.e2eq.framework.rest.resources.AuthResource`
+  - `com.e2eq.framework.rest.resources.SecurityResource`
+- `quantum-oauth-server`
+  - OAuth/OIDC authorize/token/userinfo/JWKS/discovery resources
+
+Important existing behavior:
+
+- `auth.provider=custom,oidc` default chain.
+- provider discovery must read `AuthProviderFactory` rather than parsing config
+  independently;
+- explicit provider override;
+- credential-level provider override;
+- fallback through configured providers;
+- custom JWT credential persistence;
+- OIDC as the generic path for GitHub and later Cognito-compatible login;
+- existing OAuth/OIDC server endpoints.
+
+Inventory note: `quantum-oauth-server` exposes OAuth/OIDC server endpoints and
+`quantum-jwt-provider` exposes the custom JWT provider in the open-source
+framework reactor. The external OIDC client provider is enterprise-owned:
+`quantum-enterprise/quantum-oidc-provider`. The service package used by
+HelixCode should therefore be an enterprise deployable wrapper that depends on
+that provider while reusing the framework resources unchanged.
+
+### Authorization And Policy
+
+Source of truth:
+
+- `quantum-models`
+  - `PrincipalContext`
+  - `ResourceContext`
+  - `SecurityCallScope`
+  - `SecurityCheckResponse`
+  - `Rule`, `Policy`, `DataDomainPolicy`
+  - functional area/domain/action models if present
+- `quantum-morphia-repos`
+  - `RuleContext`
+  - `RepoSecurityFilterBuilder`
+  - `RuleScriptExecutor`
+  - `RuleFilterApplicabilityEvaluator`
+  - `PolicyRepo`
+- `quantum-framework`
+  - `SecurityFilter`
+  - policy resources and debug/check endpoints
+
+Important existing behavior:
+
+- policy check/evaluation endpoints already exist;
+- policy debug capabilities already exist;
+- `RuleContext.checkRules(...)` is the authorization engine;
+- field exclusions are already resolved through `RuleContext.getExcludedFieldPaths(...)`;
+- pre-authorization is already enforced by `SecurityFilter`;
+- policy scripts and rule matching already exist;
+- request cache and rule reload behavior already exist.
+
+### Realm Override And Impersonation
+
+Source of truth:
+
+- `SecurityFilter`
+- `CredentialUserIdPassword`
+- `BaseAuthProvider`
+- `PrincipalContext`
+- `SecurityCallScope`
+
+Important existing behavior:
+
+- `X-Realm` override already adjusts the effective `PrincipalContext`.
+- impersonation already validates impersonation scripts.
+- impersonation tracks original and effective subject/user.
+- impersonation takes precedence over `X-Realm`.
+
+### Query And Filter Binding
+
+Source of truth:
+
+- `quantum-models`
+  - ANTLR grammar `BIAPIQuery.g4`
+- `quantum-framework`
+  - `QueryPredicates`
+  - in-memory JSON predicate evaluation
+- `quantum-morphia-repos`
+  - `QueryToFilterListener`
+  - `ValidatingQueryToFilterListener`
+  - `MorphiaRepo`
+  - `QueryGateway`
+
+Important existing behavior:
+
+- BIAPI query language is already the filter language.
+- Mongo/Morphia lowering already exists.
+- in-memory lowering already exists.
+- the provider binding pattern can be extended to DynamoDB later without
+  changing the authorization model.
+
+### Control Plane
+
+Source of truth should remain existing Quantum models, repos, and resources for:
+
+- tenants;
+- organizations;
+- accounts;
+- realms;
+- memberships;
+- user profiles;
+- credentials;
+- functional areas;
+- functional domains;
+- functional actions;
+- feature flags;
+- entitlements;
+- policy catalogs.
+
+The implementation phase must inventory exact model/resource/repo names before
+writing code. If a concept already exists, use the existing concept.
+
+## Credential Realm Strategy
+
+Credential lookup is a special case and must be designed explicitly. Login
+starts with only a `userId`, password or external-provider assertion, and
+optional provider hints. At that point the service has not yet resolved a
+tenant, realm, or `DomainContext`. That means authentication needs a global
+identity registry step before the normal realm-scoped authorization model can
+run.
+
+The existing implementation already leans in this direction:
+
+- `CredentialRepo` defaults no-realm credential reads and writes to
+  `envConfigUtils.getSystemRealm()`;
+- `AuthResource` first looks up login credentials in the system realm;
+- `SecurityFilter` resolves JWT credentials and impersonation targets from the
+  system realm;
+- realm catalog lookups also use the system realm, while a resolved
+  credential's `DomainContext` supplies the effective default realm and data
+  domain.
+
+That may be the correct shape for a separately deployed, tenant-agnostic auth
+service, but it must not remain an accidental hard-coded assumption scattered
+through resources and providers.
+
+### Recommended Model
+
+Use a central credential registry for authentication, then resolve into normal
+realm/domain context for authorization and data access.
+
+Flow:
+
+1. Resolve the credential from a global registry using `userId`, subject,
+   provider assertion, or provider-specific identity.
+2. Authenticate through the existing `AuthProviderFactory` chain and
+   credential-level provider override.
+3. Read the credential's `DomainContext`, memberships, allowed realms,
+   roles/groups, and provider metadata.
+4. Build `PrincipalContext` from the credential's resolved default realm and
+   data domain.
+5. If an `X-Realm` header is present, apply it only after the base principal is
+   resolved and only if the credential/policy allows that target realm.
+6. Run normal `RuleContext` authorization and provider filter generation using
+   the effective realm/domain context.
+
+In this model, `X-Realm` does not mean "look up the login credential in that
+realm." It is an optional realm override: when absent, the credential's resolved
+default realm and `DomainContext` are used; when present and authorized, the
+request operates in that allowed target realm. The credential registry
+identifies the person or service principal; the resolved principal context
+determines where that identity can act.
+
+### Design Requirement
+
+Introduce or reuse one small credential lookup boundary so resource/provider
+code does not call `envConfigUtils.getSystemRealm()` directly for credential
+identity decisions.
+
+The boundary should make these choices explicit:
+
+- credential registry realm, defaulting to the configured system/auth realm;
+- whether credential lookup ignores data-domain filters during authentication;
+- whether multi-realm credential lookup is enabled at all;
+- lookup order for user id, subject, external provider subject, and email;
+- whether provider hints or credential-level provider metadata override the
+  default chain;
+- how duplicate user ids across realms are rejected, namespaced, or resolved.
+
+The current no-realm `CredentialRepo` methods can remain as repository
+convenience methods only if they are documented as central-registry methods.
+Otherwise, auth resources should call an explicit service such as
+`CredentialRegistry` or `CredentialLookupService`, which may delegate to
+`CredentialRepo`.
+
+Phase 0 decision: use the existing system/auth realm as the central credential
+registry for the first deployable service. Make that choice explicit through a
+small lookup boundary before adding new behavior. Do not make `X-Realm`
+required for login, and do not use `X-Realm` as the primary credential lookup
+realm. `X-Realm` remains an optional post-authentication override validated
+against accessible realms and policy.
+
+Known inconsistencies to address in Phase 1:
+
+- `CredentialRepo` intentionally routes default credential CRUD/list/update
+  operations to `envConfigUtils.getSystemRealm()`, while auth resources and
+  filters also make direct system-realm calls. This is the right model, but the
+  call sites should be centralized.
+- `SecurityResource` exposes a `PUT /security/disableImpersonation` method that
+  calls `enableImpersonationWithSubject(...)`; the path/name mismatch should be
+  fixed or compatibility-shimmed.
+- `BaseAuthProvider.enableImpersonationWithUserId/Subject(...)` looks up the
+  credential in the supplied `realmToEnableIn`, while most central identity
+  lookup uses the system realm. That should be reviewed before relying on
+  cross-realm impersonation from the central service.
+
+### Alternatives
+
+Central registry:
+
+- credentials live in one auth/system realm;
+- credential `DomainContext` and memberships point to effective realms/orgs;
+- simplest login and cross-org identity model;
+- best fit for GitHub/Gmail identities where one user may belong to multiple
+  organizations;
+- requires strict uniqueness and audit rules for user id, email, and external
+  provider subject.
+
+Multi-realm credential storage:
+
+- credentials live inside each tenant/realm;
+- closer to generic realm-scoped repository behavior;
+- requires login realm discovery before authentication;
+- makes a single human identity across multiple orgs harder to reason about;
+- increases risk of duplicate accounts and fragmented usage/audit trails.
+
+The initial central-service design should prefer the central registry unless
+Phase 0 proves existing Quantum deployments depend on multi-realm credential
+storage.
+
+## Deployable Service Shape
+
+The deployable module may be named `quantum-auth-service` initially, but its
+actual responsibility is central auth and control-plane exposure. If the name
+causes confusion, rename it before the API hardens.
+
+The module should contain:
+
+- `pom.xml`;
+- `Dockerfile`;
+- `application.properties`;
+- local Docker compose files;
+- health/config/OpenAPI exposure;
+- thin facade resources only when existing resources do not already provide the
+  needed public contract;
+- local bootstrap code only when it uses existing `UserManagement` and repos.
+
+The module should depend on existing modules:
+
+- `quantum-models`;
+- `quantum-framework`;
+- `quantum-morphia-repos`;
+- `quantum-jwt-provider`;
+- an external OIDC client provider module when found or added;
+- `quantum-oauth-server`;
+- Cognito provider later when needed.
+
+The module should not contain:
+
+- new authz DTO trees;
+- new policy engine classes;
+- new principal/resource models;
+- new org/tenant/account/feature/domain models;
+- hard-coded policy decisions;
+- direct credential fabrication that bypasses `UserManagement`.
+
+## API Strategy
+
+### Reuse Existing Endpoints First
+
+Existing endpoints for authentication, authorization checks, policy debug, and
+security resources remain canonical. Implementation must first produce an API
+inventory table before adding anything.
+
+Phase 0 inventory:
+
+| Capability | Existing endpoint/resource | Existing model/response | Reuse as-is? | Gap |
+| --- | --- | --- | --- | --- |
+| Auth provider name | `GET /auth/provider/name` in `AuthResource` | provider name string | Yes | None |
+| Create user | `POST /auth/create-user` in `AuthResource` | existing `UserManagement` result | Yes | Must use `AuthProviderFactory`, not local fabrication |
+| Login | `POST /auth/login` and richer `POST /security/login` | existing auth response / `AuthResponse` | Yes | Standardize which login surface Helixor uses |
+| Refresh | `POST /auth/refresh` and `POST /security/refresh` | existing auth response / `AuthResponse` | Yes | Standardize which refresh surface Helixor uses |
+| Service token | `POST /auth/service-token` | existing service-token response | Yes | Useful for companion/MCP agents |
+| Registration | `POST /security/register`, `GET /security/register` | `RegistrationRequest`, `ApplicationRegistration` | Yes | Keep anonymous save scoped through existing ignore-rules behavior |
+| Current user | `GET /security/me` | identity/profile/realm summary | Yes | May need SDK-safe projection for portal |
+| Logout/health/auth test | `POST /security/logout`, `GET /security/healthCheck`, `GET /security/authenticated/test` | existing responses | Yes | None |
+| Realm override admin | `PUT /security/enableRealmOverride`, `PUT /security/disableRealmOverride` | existing user-management calls | Yes | Audit auth-provider implementation consistency |
+| Impersonation admin | `PUT /security/disableImpersonation`, `PUT /security/disableImpersonation/withSubject/{subject}` | existing user-management calls | Partly | Path name appears wrong: one `disableImpersonation` method enables impersonation |
+| Policy CRUD/import | `/security/permission/policies` via `PolicyResource` and `BaseResource`; `POST /refreshRuleContext`, `POST /import` | `Policy`, `PolicyRepo` | Yes | None |
+| Policy check | `POST /system/permissions/check` | `PermissionResource.CheckResponse` with `SecurityCheckResponse` | Yes | Canonical check endpoint for Helixor |
+| Indexed policy check | `POST /system/permissions/check-with-index` | `RuleIndexSnapshot` | Yes | Useful for diagnostics and bulk UX |
+| Policy evaluation/debug | `POST /system/permissions/fd/evaluate`, `POST /system/permissions/role-provenance`, `GET /system/permissions/entities`, `GET /system/permissions/fd` | existing debug/evaluation projections | Yes | Keep response typed in SDK |
+| Functional domains/actions | `/security/functionalDomain` via `FunctionalDomainResource` and `/system/permissions/fd` | `FunctionalDomain`, derived area/domain/action catalog | Yes | Prefer `/system/permissions/fd` for read catalog; resource for CRUD |
+| Feature flags | `/features/flags` via `FeatureFlagResource` | `FeatureFlag` | Yes | Entitlement-specific resource still needs inventory |
+| Realms | `/security/realm`, plus `GET /byTenantId`, `GET /possibleImpersonations/realms`, `GET /accessible` | `Realm` | Yes | None |
+| Realm memberships | `/security/realm-memberships` via `RealmTenantMembershipResource` | `RealmTenantMembership` | Yes | None |
+| Organizations | `/security/accounts/organizations` via `OrganizationResource` | `Organization` | Yes | None |
+| Accounts | `Account`, `AccountRepo`, registration/provisioning flows | `Account` | Partly | No direct `AccountResource` found; decide whether existing flows are enough |
+| Tenant provisioning | `/admin/tenants`, `/admin/tenants/runs/{executionRef}`, `/admin/tenants/runs/{executionRef}/retry`, `DELETE /admin/tenants/{realmId}` | tenant provisioning request/run responses | Yes | Admin-only, not generic tenant CRUD |
+| Tenant workflow/onboarding | `/admin/tenants/workflow/current`, `/onboarding/workflow/current`, `/onboarding/run/start`, `/onboarding/run/{runRef}` | workflow definitions/runs | Yes | Keep as workflow layer |
+| User profile | `/user/userProfile`, `GET /byRefName`, `PUT /updateStatus`, `POST /create` | `UserProfile` | Yes | None |
+| Credentials | `/user/credentials`, `POST /changePassword`, `POST /changeEmail`, `POST /resendTemporaryPassword`, `GET /matching-realms`, `GET /byUserId`, `POST /resetPassword` | `CredentialUserIdPassword` | Yes | Should route identity lookup through explicit registry boundary |
+| Query/filter gateway | `/api/query/plan`, `/find`, `/count`, `/save`, `/delete`, `/deleteMany`, import/export endpoints | existing query gateway contracts | Yes for data operations | Need a stable authorization-filter projection if provider filters are a product API |
+| OAuth/OIDC server | `/.well-known/openid-configuration`, `/oauth/authorize`, `/oauth/token`, `/oauth/userinfo`, `/oauth/jwks` | OAuth/OIDC responses | Yes | This is server functionality, not proof of an external GitHub OIDC provider |
+| Provider discovery facade | `GET /auth/providers`, `GET /auth/oidc/session` in `quantum-auth-service` | provider/session projection | Thin facade allowed | Must continue delegating to `AuthProviderFactory` |
+
+### New Facades Are Only Allowed For Gaps
+
+Potential facades:
+
+- provider discovery facade, because existing `/auth/provider/name` exposes
+  only one provider name and the UI needs discovered/configured provider state;
+- filter-generation facade, only if existing policy-check/query endpoints do
+  not expose a provider-neutral or provider-specific filter result;
+- SDK projection facade, if existing responses are too internal for generated
+  clients.
+
+Any facade must delegate to existing Quantum services.
+
+Implemented facade decision:
+
+- `GET /v1/authz/filter` is an authenticated thin facade in the enterprise
+  `quantum-auth-service` wrapper.
+- It delegates to the existing request `PrincipalContext`, optional `X-Realm`
+  behavior, and `RuleContext.checkRules`.
+- It accepts functional area/domain/action plus optional data-domain fields
+  (`orgRefName`, `accountNumber`, `tenantId`, `dataSegment`, `ownerId`,
+  `locationId`, `businessTransactionId`) so callers can ask for the authorized
+  filter in an explicit scope without inventing a parallel policy model.
+- It returns the full effective `resourceContext` with nested `dataDomain`, the
+  aggregate `quantumFilter`, split `dataDomainFilter` and `businessFilter`
+  projections, field exclusions, and optional raw check diagnostics.
+- It is not a new authorizer. Missing or contradictory behavior must be fixed
+  in `RuleContext`, data-domain resolution, BIAPI query lowering, or provider
+  bindings.
+
+## Filter Generation Design
+
+The only likely missing capability is a stable provider-facing filter contract.
+`POST /system/permissions/check` and `POST /system/permissions/fd/evaluate`
+already evaluate policy decisions. `QueryGatewayResource` and the BIAPI
+ANTLR/Morphia/in-memory query bindings already lower query expressions to data
+providers. The gap is not a new policy engine; it is a stable projection that
+returns the authorized filter/exclusions/diagnostics in a form SDK clients can
+consume.
+
+Input:
+
+- bearer token;
+- optional `X-Realm`;
+- optional existing impersonation headers;
+- functional area;
+- functional domain;
+- functional action;
+- optional resource id;
+- optional owner id;
+- target provider: `mongo`, `memory`, later `dynamo`;
+- optional model/entity type when provider lowering needs it.
+
+Flow:
+
+1. Reuse existing request/security machinery to resolve `PrincipalContext`.
+2. Build or reuse `ResourceContext`.
+3. Call `RuleContext.checkRules(...)`.
+4. Collect rule decision, matched rules, filters, excluded fields, reasons, and
+   diagnostics from existing response/context APIs.
+5. Lower filters through provider binding:
+   - Mongo: existing `QueryToFilterListener`;
+   - memory: existing `QueryPredicates`;
+   - DynamoDB: new future provider adapter only.
+6. Return an SDK-safe projection.
+
+Provider adapter interface, if needed:
+
+```java
+interface QuantumPolicyFilterBinding<T> {
+    String provider();
+    T lower(String biapiFilter, PrincipalContext principal, ResourceContext resource, Class<?> modelClass);
+}
+```
+
+Do not place policy decisions in provider adapters. Adapters only lower an
+already-authorized filter expression.
+
+## Helixor Code Integration
+
+Helixor Code should use Quantum as source of truth for identity and control
+plane. Helixor Code should only store Helixor-specific artifacts.
+
+Quantum-owned concepts:
+
+- user identity;
+- subject;
+- roles;
+- organizations;
+- tenants;
+- accounts;
+- realms;
+- memberships;
+- functional domains/actions;
+- feature flags/entitlements;
+- authorization policy;
+- impersonation;
+- realm override.
+
+Helixor-owned artifacts:
+
+- code indexes;
+- workspace channels;
+- designs;
+- TODO stacks;
+- companion registrations;
+- usage/token-savings events;
+- product feedback;
+- index/license receipts only if not modeled centrally.
+
+Every Helixor artifact should be stamped with Quantum identifiers where
+available:
+
+- `subject_id`;
+- `user_id`;
+- `realm`;
+- `tenant_id`;
+- `org_ref_name`;
+- `account_id`;
+- `functional_area`;
+- `functional_domain`;
+- `functional_action`;
+- optional `github_owner`;
+- optional `github_repo`.
+
+Before Helixor reads or writes an artifact, it should call the existing Quantum
+authorization check/debug endpoint or the minimal filter facade if the operation
+needs a data-provider filter.
+
+Examples:
+
+- `helixor-code / indexes / read`;
+- `helixor-code / indexes / write`;
+- `helixor-code / workspace / read`;
+- `helixor-code / todos / write`;
+- `helixor-code / usage / read`;
+- `helixor-code / companions / manage`.
+
+## Migration From Current Prototype
+
+Treat these as wrong-path until proven otherwise:
+
+- `quantum-auth-service/src/main/java/com/e2eq/framework/authz/model/*`;
+- hard-coded `CentralAuthzService`;
+- tests that assert hard-coded org/tenant/GitHub constraints.
+
+Keep or salvage only:
+
+- `pom.xml` if the dependencies are correct;
+- `Dockerfile`;
+- `application.properties`;
+- local compose files;
+- local bootstrap if it continues to use `AuthProviderFactory`,
+  `UserManagement`, and existing repos.
+
+## Implementation Phases
+
+### Phase 0: Inventory
+
+- List existing auth endpoints and exact paths.
+- List existing policy check/debug endpoints and exact paths.
+- List existing functional-domain/action/catalog endpoints.
+- List existing tenant/org/account/realm/membership endpoints.
+- List existing feature flag/entitlement endpoints.
+- Audit `CredentialRepo`, `AuthResource`, `SecurityResource`,
+  `SecurityFilter`, `BaseAuthProvider`, and concrete auth providers for direct
+  system-realm credential assumptions.
+- Decide whether credential lookup is a central registry, multi-realm lookup,
+  or configurable strategy, and document the exact lookup order.
+- Identify whether filter generation already exists.
+- Document exact request/response contracts.
+
+No new endpoint should be written in this phase.
+
+### Phase 1: Strip Service To Wrapper
+
+- Remove wrong-path authz model/service/resource code.
+- Keep deployable module structure.
+- Ensure existing resources from dependencies are indexed and exposed by Quarkus.
+- Ensure Mongo config points to the configured local/cloud Mongo instance.
+- Ensure custom JWT and OIDC provider chain is configured through existing
+  `AuthProviderFactory`.
+- Ensure runtime JWT key locations are environment/file references, not PEM
+  files packaged in the deployable jar.
+
+### Phase 2: Facade Only For Proven Gaps
+
+- Add provider discovery facade only if needed.
+- Add filter-generation facade only if no existing endpoint satisfies it.
+- Place reusable facade code in `quantum-framework` or a small runtime module,
+  not buried in the deployable service, unless it is purely deployment-specific.
+- Current slice adds the filter-generation facade inside the enterprise wrapper
+  as a deployment-specific projection over `RuleContext`; promote it to a shared
+  runtime module only if another product needs the same route.
+
+### Phase 3: SDK Contract
+
+- Generate OpenAPI for the reused/facade endpoints.
+- Feed OpenAPI into `helixor-sdk-gen` or the appropriate SDK generator.
+- Ensure Java clients consume SDK bindings instead of hard-coded URLs.
+- Generate Python/JavaScript clients for Helixor Code.
+
+### Phase 4: Helixor Integration
+
+- Replace Helixor-local identity/org assumptions with calls to Quantum.
+- Keep Helixor artifact storage but stamp records with Quantum identifiers.
+- Use Quantum authz/filter calls before artifact reads/writes.
+- Remove or downgrade Helixor admin screens that imply Helixor owns identity or
+  org control-plane data.
+
+### Phase 5: End-To-End Tests
+
+Required tests:
+
+- custom JWT login reads/writes Mongo-backed credential data;
+- provider discovery reports the configured chain and the providers discovered
+  by `AuthProviderFactory`;
+- OIDC provider is advertised from the factory inventory, while UI/session
+  readiness still depends on OIDC client configuration;
+- login resolves a global credential registry entry into the expected default
+  `DomainContext`;
+- authentication can ignore data-domain filters only at the credential registry
+  step, not during normal authorization;
+- credential-level provider override is honored;
+- fallback provider chain uses `custom,oidc`;
+- existing policy check endpoint returns the expected allow/deny;
+- existing policy debug endpoint remains reachable;
+- absent `X-Realm` uses the credential's default `DomainContext`;
+- present and authorized `X-Realm` changes effective context;
+- impersonation uses existing script validation;
+- filter generation, if added, delegates to existing BIAPI provider binding;
+- Helixor Code artifact read/write is denied when Quantum policy denies;
+- Helixor Code artifact read/write is allowed and scoped when Quantum policy
+  allows.
+
+## Initial Implementation Notes
+
+The first implementation pass intentionally keeps `quantum-auth-service` thin:
+
+- wrong-path duplicate authz DTO/service/resource code was removed;
+- Quarkus indexing/dependencies expose existing Quantum resources such as
+  `/auth/login`, `/security/register`, `/security/permission/policies`,
+  `/system/permissions/check`, `/system/permissions/fd/evaluate`,
+  `/system/permissions/role-provenance`, `/admin/tenants`, OAuth discovery, and
+  JWKS;
+- `AuthProviderDiscoveryResource` delegates provider inventory to
+  `AuthProviderFactory` and reports both the configured chain and the discovered
+  provider implementations;
+- `/security/register` remains `@PermitAll`, but its registration-request save
+  uses the existing `SecurityCallScope.openIgnoringRules()` scope so anonymous
+  registration is not blocked by the persistence rule interceptor;
+- runtime JWT signing and verification keys are external file/env references
+  through `QUANTUM_JWT_PRIVATE_KEY_LOCATION` and
+  `QUANTUM_JWT_PUBLIC_KEY_LOCATION`; PEM files are allowed only in
+  `src/test/resources` or external dev/test secret mounts, not in
+  `src/main/resources`.
+
+Focused wrapper tests now cover:
+
+- provider discovery through the factory;
+- custom JWT login using the local bootstrap credential;
+- public registration create/read;
+- admin user creation, login, lookup, and deletion via existing credential APIs;
+- policy create, rule-context refresh, permission check, permission evaluate,
+  role-provenance debug, and policy delete;
+- tenant provision/delete through the existing control-plane resource;
+- OAuth discovery, JWKS, health check, and OpenAPI exposure of reused resources.
+
+Verification performed:
+
+- `mvn -pl quantum-models,quantum-framework -am install -DskipTests`
+- `mvn -pl quantum-auth-service clean test`
+- `QUANTUM_JWT_PRIVATE_KEY_LOCATION=file:/tmp/quantum-auth-keys/privateKey.pem QUANTUM_JWT_PUBLIC_KEY_LOCATION=file:/tmp/quantum-auth-keys/publicKey.pem MP_JWT_VERIFY_PUBLICKEY_LOCATION=file:/tmp/quantum-auth-keys/publicKey.pem SMALLRYE_JWT_SIGN_KEY_LOCATION=file:/tmp/quantum-auth-keys/privateKey.pem mvn -pl quantum-auth-service package -DskipTests`
+- runtime jar scan confirmed no `*.pem` resources in the Quarkus application jar
+  or dependency jars.
+
+## SDK/OpenAPI Slice
+
+The service now has a generated contract owned beside the deployable enterprise
+service:
+
+- `quantum-auth-service/contracts/quantum-auth-service.openapi.yaml` is a
+  runtime snapshot from `/q/openapi`;
+- `quantum-auth-service/contracts/quantum-auth-service-sdk.yml` is the
+  `helixor-sdk-gen` config for Java, Python, and TypeScript clients;
+- `quantum-auth-service/generated/quantum-auth-service-sdk/` contains the
+  generated SDK artifacts, including `operation-contracts.json`.
+
+Wrapper resources were tightened only where the generated contract needed typed
+facade responses:
+
+- `GET /auth/providers` returns `AuthProvidersResponse` from
+  `AuthProviderFactory` discovery data;
+- `GET /v1/authz/filter` returns `AuthzFilterResponse` with typed data-domain,
+  resource-context, principal-context, filter-rule, and optional raw
+  `SecurityCheckResponse` fields.
+
+Generating against the full reused Quantum service surface also found and fixed
+two `helixor-sdk-gen` gaps:
+
+- OpenAPI parameter lists are now de-duplicated by `(in, name)` so path-level
+  and operation-level duplicates do not produce duplicate SDK method
+  parameters.
+- Java type generation now resolves `$ref` aliases to scalar and array schemas
+  before emitting types, so references such as `Date`, `Instant`, and
+  `UIActionList` compile as `LocalDate`, `OffsetDateTime`, or `List<T>` instead
+  of missing model classes.
+
+Verification performed:
+
+- `PYTHONPATH=src /Users/mingardia/dev/helixor/.venv/bin/python -m pytest tests/test_generator.py tests/test_central_authz_contract.py -q`
+- `mvn -pl quantum-auth-service -Dtest=QuantumAuthServiceWrapperTest test -q`
+- `PYTHONPATH=/Users/mingardia/dev/helixor/helixor-sdk-gen/src /Users/mingardia/dev/helixor/.venv/bin/python -m helixor_sdk_gen.cli generate quantum-auth-service/contracts/quantum-auth-service-sdk.yml quantum-auth-service/contracts/quantum-auth-service.openapi.yaml --out quantum-auth-service/generated/quantum-auth-service-sdk --local`
+- `/Users/mingardia/dev/helixor/.venv/bin/python -m compileall -q quantum-auth-service/generated/quantum-auth-service-sdk/python/quantum_auth_service`
+- `mvn -q -DskipTests compile` in
+  `quantum-auth-service/generated/quantum-auth-service-sdk/java`
+
+## Helixor Code Consumer Integration Slice
+
+Helixor Code now has a first consumer integration against the generated Quantum
+auth/control-plane contract while preserving the existing Dynamo/seeded/cloud
+auth fallback paths.
+
+Backend bridge changes:
+
+- `helixor_code_backend.central_authz` loads the generated
+  `quantum_auth_service` Python SDK when available, with the REST fallback still
+  in place for beta diagnostics.
+- The bridge maps Helixor Code workspace context into Quantum filter parameters:
+  selected org becomes `orgRefName` and `tenantId`, the active subject becomes
+  `ownerId`, and workspace functional area/domain/action are passed as both the
+  typed facade fields and the existing Quantum filter fields.
+- The typed `AuthzFilterResponse` is normalized back into Helixor Code's
+  existing diagnostic envelope: `scope`, `resource`, `principal`, and
+  `constraints` carry enough information for portal/admin diagnostics and
+  future fail-closed enforcement.
+- `/api/v1/admin/authz/context` now proves the active Helixor org and user are
+  included in central authz checks.
+
+The first protected surface remains deliberately narrow: workspace design reads
+can run central authz in `diagnostic` or `enforce` mode, and local org scoping
+continues to apply even when central authz is disabled.
+
+Verification performed:
+
+- `python -m py_compile src/helixor_code_backend/central_authz.py src/helixor_code_backend/app.py`
+- `pytest tests/test_app.py -q -k "central_authz or authz_context or quantum_auth_accepts_access_token_shape or dynamo_login_uses_username_identity_for_org_switch or signup_provisions_dynamo_user_and_workspace_org"`
+
+## Docker Runtime Slice
+
+The local Docker harness has now been exercised against a running local MongoDB
+without mounting the source checkout into the container.
+
+Runtime configuration updates:
+
+- `deploy/local-docker/compose.yml` keeps MongoDB external by default through
+  `MONGODB_CONNECTION_STRING=mongodb://host.docker.internal:27017`.
+- JWT secret file paths are configurable through
+  `QUANTUM_JWT_PRIVATE_KEY_FILE` and `QUANTUM_JWT_PUBLIC_KEY_FILE`, defaulting
+  to the framework `quantum-default-keys/target/classes` files in this checkout.
+- `deploy/local-docker/.env` is ignored, while `.env.example` documents the
+  required local settings.
+
+Runtime verification performed:
+
+- `mvn -pl quantum-auth-service package -DskipTests`
+- `docker compose --env-file deploy/local-docker/.env -f deploy/local-docker/compose.yml up --build -d`
+- `curl http://127.0.0.1:8180/q/health/live` returned `UP`.
+- `curl http://127.0.0.1:8180/auth/providers` returned the configured and
+  discovered provider chain `custom,oidc`.
+- Runtime `/q/openapi` exposes `/auth/providers`, `/v1/authz/filter`,
+  `AuthProvidersResponse`, and `AuthzFilterResponse`.
+- `POST /auth/login?provider=custom&userId=local-test&password=test123456`
+  returned an access token and refresh token from the custom provider.
+- `GET /v1/authz/filter` with the token, `orgRefName=HelixorAI`,
+  `tenantId=HelixorAI`, `ownerId=local-test`, and no `X-Realm` returned
+  `decision=ALLOW`, a Quantum filter, data-domain fields, and principal context.
+- Helixor Code's Python bridge successfully called the Dockerized service
+  through the generated `quantum_auth_service` SDK and normalized the response
+  to `source=generated_sdk`, `decision=ALLOW`, `orgRefs=HelixorAI`, and the
+  Quantum filter.
+
+Important finding:
+
+- Sending `X-Realm: quantum-auth` to protected routes returned a 500 because the
+  security filter treats `X-Realm` as an explicit realm override and rejects it
+  when that realm is not present in the realm collection. Helixor Code now only
+  forwards a default realm override when
+  `HELIXOR_CODE_AUTHZ_FORWARD_DEFAULT_REALM=true`; otherwise `X-Realm` remains
+  optional and absent by default.
+
+## Open Questions
+
+- Should the deployable artifact stay named `quantum-auth-service`, or should it
+  become `quantum-control-plane-service`?
+- Should Helixor use `POST /auth/login` or the richer `POST /security/login` as
+  the canonical login endpoint?
+- Does a distinct external OIDC client provider module exist under a different
+  name, or do we need to add one for GitHub/Gmail login?
+- Do we need a minimal authorization-filter projection facade, or can an
+  existing policy/check response be safely typed for SDK consumers?
+- Which existing models/resources represent entitlements beyond
+  `FeatureFlagResource`?
+- Is a direct `AccountResource` needed, or are registration/provisioning flows
+  the intended account-management API?
+- Should GitHub organization affiliation be modeled as a Quantum membership,
+  external identity claim, provider custom property, or all three?
+- What is the canonical uniqueness constraint for `userId`, email, subject, and
+  external provider subject in the global registry?
+- Should Helixor Code enforce central authz on workspace channels, TODOs,
+  designs, projects, indexes, companions, and usage in one pass or phase it by
+  artifact type?
+
+## Next Implementation Slice
+
+The next slice is the end-to-end/runtime verification pass:
+
+1. Add end-to-end tests for login, registration, create/delete account,
+   create/delete/add users, policy CRUD, evaluate/debug endpoints, optional
+   `X-Realm`, impersonation, and provider-chain behavior.
+2. Run the Helixor Code portal against the Quantum-backed auth mode and verify
+   GitHub/provider discovery, org switcher, user management, usage, designs,
+   TODOs, indexes, companions, and central authz diagnostics.
+3. Decide which additional artifact routes should call central authz in
+   diagnostic mode before switching any route to enforce mode.
+4. Continue narrowing the published SDK contract to stable external operations
+   once the first runtime path is proven.
+
+The most important guardrail remains:
+
+If Quantum already has the model, endpoint, provider, repository, or policy
+behavior, the central service must reuse it instead of reimplementing it.

--- a/quantum-docs/src/docs/asciidoc/design/query-gateway-ontology-support.adoc
+++ b/quantum-docs/src/docs/asciidoc/design/query-gateway-ontology-support.adoc
@@ -4,6 +4,28 @@
 
 *Delete prevention:* Query Gateway delete and deleteMany now enforce the same referential integrity as MorphiaRepo: `DeleteValidationService` runs before each delete (back-reference check for `@TrackReferences` and all `PreDeleteHook` beans, e.g. ontology BLOCK_IF_REFERENCED). On violation the gateway returns 409 (ReferentialIntegrity or DeleteBlocked). deleteMany loads matching entities (capped by `quantum.queryGateway.deleteMany.maxMatches`, default 2000), validates each, then deletes only those ids.
 
+*Row- and field-level governance (implemented):* The generic query path previously
+ran a raw `ds.find(...)` and bypassed both row- and field-level security. That gap is
+now closed. `find`, `count`, `delete`, `deleteMany`, and `export` build their row
+filter with `QueryGatewayResource.securedFilterArray(...)`, which ANDs the parsed query
+filter with the caller's DataDomain scope plus the `RuleContext` rule
+`filterConstraints` (mirroring `MorphiaRepo` / `RepoSecurityFilterBuilder`). `find`
+additionally applies `applyExcludedFieldProjection(...)`, projecting away the deny-wins
+`RuleContext.getExcludedFieldPaths(...)` at the MongoDB level. When neither
+`SecurityContext.isIgnoringRules()` is set nor a `PrincipalContext`/`ResourceContext`
+are present, the gateway **fails closed** with HTTP 500 `SecurityContextMissing` rather
+than running ungoverned. `delete` ANDs the `_id` filter with the secured filter, so an
+entity outside the caller's DataDomain returns HTTP 404 (no row-existence leak).
+
+*AGGREGATION/expand still ungoverned (501-gated):* The `expand(...)` / AGGREGATION path
+is NOT yet governed and is intentionally gated. `POST /api/query/find` returns HTTP 501
+for an AGGREGATION-mode query even when `feature.queryGateway.execution.enabled=true`,
+because a leading secured `$match` stage and an `excludedFields` `$project` have not yet
+been wired into the aggregation pipeline. `count` and `deleteMany` reject `expand(...)`
+with HTTP 400 (`InvalidQuery`). Re-enabling governed aggregation execution is the
+tracked follow-up below; see also
+xref:../user-guide/planner-and-query-gateway.adoc#query-gateway-governance[Planner and QueryGateway: row- and field-level governance].
+
 This document describes how to add ontology support to the Query Gateway API (`POST /api/query/find`, `POST /api/query/plan`, and related endpoints) so that callers can use ontology edge predicates (`hasEdge`, `hasOutgoingEdge`, `hasIncomingEdge`, and optionally `hasEdgeAny`, `notHasEdge`) in the query string and get correct, tenant-scoped results.
 
 == Current State

--- a/quantum-docs/src/docs/asciidoc/user-guide/domain-rule-context.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/domain-rule-context.adoc
@@ -294,3 +294,21 @@ Notes
 
 - Always scope by tenantId from RuleContext/PrincipalContext.
 - This is optional and only active if you wire ontology components. For a deeper integration path, see xref:modeling.adoc#ontology-integration-morphia-permissions[Integrating Ontology].
+
+=== Admitted vocabulary for rule predicates
+
+When a rule references an ontology predicate through a query helper such as
+`hasEdge("placedInOrg", ...)`, the predicate must be *admitted* for policy use, not merely
+declared in the TBox. As `RuleContext` registers a rule it fires a `RuleVocabularyCheck`,
+and `PolicyVocabularyGuard` (`quantum-ontology-policy-bridge`) validates the referenced
+predicates against the realm's admitted set. A predicate that is undeclared (`ABSENT`) or
+declared-but-not-admitted (`PROVISIONAL`) fails rule registration, naming the rule and the
+offending predicate.
+
+Enforcement is fail-closed: if the realm's admitted set cannot be read it is treated as
+`UNAVAILABLE` and the guard refuses to downgrade a governed realm to "all admitted." A
+legacy realm (`admittedPredicates == null`) admits all declared predicates for
+back-compatibility. See xref:ontology.adoc#provisional-admitted-vocabulary-tier[Ontology
+Modeling: provisional vs. admitted vocabulary tier] for the tier model, and the Quantum
+Enterprise *Ontology governance control plane* chapter for the admin promote/demote
+endpoints.

--- a/quantum-docs/src/docs/asciidoc/user-guide/mcp-server-and-client.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/mcp-server-and-client.adoc
@@ -55,6 +55,23 @@ You can generate a long-lived service token for use with the MCP server using th
 
 Tools are defined in `McpGatewayTools` using the Quarkiverse `@Tool` and `@ToolArg` annotations. Each tool is protected with `@Authenticated` and delegates to `AgentExecuteHandler`, which routes to the `QueryGatewayResource` -- reusing the same security, realm resolution, and query execution as the REST API.
 
+[NOTE]
+====
+Because the tools route through `QueryGatewayResource`, the data-access tools are
+row- and field-governed. `query_find`, `query_count`, `query_delete`,
+`query_deleteMany`, and `query_export` apply the caller's DataDomain scope plus the
+`RuleContext` rule `filterConstraints`, and `query_find` additionally excludes
+deny-wins `excludedFields` at the MongoDB level. The gateway **fails closed** (HTTP 500
+`SecurityContextMissing`) if no security context is established for the request, so an
+agent never executes an ungoverned query. `query_delete` returns "not found" for an id
+outside the caller's DataDomain rather than revealing that the row exists.
+
+`expand(...)` (aggregation) execution is currently disabled: a `query_find` with
+`expand(...)` returns HTTP 501 because the aggregation path is not yet governed by
+row- and field-level security. See
+xref:planner-and-query-gateway.adoc#query-gateway-governance[Planner and QueryGateway: row- and field-level governance].
+====
+
 [cols="1,3", options="header"]
 |===
 | Tool Name | Description

--- a/quantum-docs/src/docs/asciidoc/user-guide/ontology.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/ontology.adoc
@@ -1034,6 +1034,57 @@ public class Customer {
 - Never trust a client-supplied predicate or destination id blindly; combine with rule evaluation and whitelist allowed predicates per domain if needed.
 - For shared resources across tenants (rare), model cross-tenant permissions at the policy layer; don’t reuse edges across tenants unless explicitly designed.
 
+[[provisional-admitted-vocabulary-tier]]
+=== Provisional vs. admitted vocabulary tier
+
+Declaring a predicate in the ontology (the TBox) does not by itself authorize it for use
+in security rules. There are two tiers:
+
+- *Provisional* — a predicate declared in the active TBox's `properties`. It is usable for
+  facts and materialized edges, but a security rule that references it (for example
+  `hasEdge("placedInOrg", ...)`) is rejected.
+- *Admitted* — a predicate that has been explicitly admitted for policy use. Only admitted
+  predicates may be referenced by security rules.
+
+The realm-governance set lives on `TenantOntologyTBox.admittedPredicates`
+(`quantum-ontology-mongo`) and is three-valued:
+
+[cols="1,3",options="header"]
+|===
+| `admittedPredicates`
+| Meaning
+
+| `null`
+| Legacy realm: *all declared predicates are admitted*. This is the back-compatible default — realms that predate the tier are unaffected.
+
+| empty set
+| Governed realm that admits *no* predicates for rule use; every declared predicate is provisional.
+
+| populated set
+| Governed realm: *exactly* these predicates may be referenced by rules; everything else declared is provisional.
+|===
+
+Enforcement happens at rule-registration time. When `RuleContext` adds a rule it fires a
+`RuleVocabularyCheck`; `PolicyVocabularyGuard` (`quantum-ontology-policy-bridge`) observes
+it and runs `RuleVocabularyValidator` over the predicate literals the rule references.
+A reference to an undeclared predicate (`ABSENT`) or a declared-but-not-admitted predicate
+(`PROVISIONAL`) fails rule registration, naming the rule and the offending predicate.
+
+This is fail-closed by design. The disposition is read through the three-state
+`AdmittedVocabularyResult` (`LEGACY` / `GOVERNED` / `UNAVAILABLE`); if the admitted-set
+read fails (for example a transient Mongo outage) the result is `UNAVAILABLE` and the
+guard refuses to downgrade a governed realm to "all admitted" — rule registration that
+references any predicate is rejected rather than silently re-opening the vocabulary.
+
+NOTE: Admitting a predicate is an admin, audited, human-in-the-loop action. Promotion and
+demotion are performed through the enterprise ontology-governance control plane
+(`POST /v1/ontology/{realm}/vocabulary/{predicate}:promote` and `\...:demote`), which also
+owns TBox admission. The first promote/demote on a legacy realm grandfathers the
+currently-declared predicates so no existing rule is silently de-authorized. See the
+Quantum Enterprise book's *Ontology governance control plane* chapter for the admission
+and vocabulary endpoints, the canonical TBox hash version token, and the control-plane /
+data-plane split.
+
 === Developer workflow and DX checklist
 
 - When writing a rule: use hasEdge("<predicate>", <rhs>) and rely on RuleContext variables for the destination when possible.

--- a/quantum-docs/src/docs/asciidoc/user-guide/planner-and-query-gateway.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/planner-and-query-gateway.adoc
@@ -76,10 +76,54 @@ See also: xref:query-expansion.adoc[Relationship hydration with expand(path)]. F
 [[query-gateway-rest]]
 === REST endpoints (v1)
 
-Two helper endpoints expose the planner and execution path. FILTER mode executes immediately. AGGREGATION mode is planned, and execution is guarded by a feature flag.
+The gateway (`QueryGatewayResource`, `@Path("/api/query")`,
+`@FunctionalMapping(area="integration", domain="query")`) exposes a planner endpoint
+plus the generic query operations. FILTER mode executes immediately; AGGREGATION mode
+(any `expand(...)`) is planned but execution is currently disabled (see
+<<query-gateway-governance>>).
 
 - POST /api/query/plan — returns planner mode and expand paths detected
-- POST /api/query/find — executes FILTER-mode queries and returns the standard Collection<T> envelope; when AGGREGATION is requested, behavior depends on a feature flag (see below)
+- POST /api/query/find — executes FILTER-mode queries and returns the standard Collection<T> envelope
+- POST /api/query/count — returns the governed count for a FILTER-mode query
+- POST /api/query/delete — deletes a single entity by id (governed; 404 across DataDomain boundaries)
+- POST /api/query/deleteMany — deletes the matching FILTER-mode set
+- POST /api/query/export — streams a governed CSV export
+
+[[query-gateway-governance]]
+=== Row- and field-level governance
+
+NOTE: Earlier the generic query path ran a raw `ds.find(...)` and therefore bypassed
+row- and field-level security. That gap is closed: `find`, `count`, `delete`,
+`deleteMany`, and `export` now run through the same `RuleContext`-derived security
+filter as `MorphiaRepo`, and they fail closed when no security context is established.
+
+For every governed operation the gateway:
+
+- builds the row filter with `securedFilterArray(...)`, which ANDs the parsed query
+  filter with the caller's DataDomain scope plus the rule `filterConstraints`
+  resolved from `RuleContext` (mirroring `MorphiaRepo` / `RepoSecurityFilterBuilder`);
+- applies the field-governance projection on `find` via `applyExcludedFieldProjection(...)`,
+  which excludes the deny-wins `excludedFieldPaths` (also from `RuleContext`) at the
+  MongoDB level so excluded fields never leave the datastore;
+- **fails closed** when neither `SecurityContext.isIgnoringRules()` is set nor a
+  `PrincipalContext` and `ResourceContext` are present: the request is refused with
+  HTTP 500 and `{"error":"SecurityContextMissing"}` rather than running ungoverned.
+
+`delete` ANDs the `_id` filter with the secured row filter, so an entity that exists
+but lies outside the caller's DataDomain simply does not match and the endpoint returns
+HTTP 404 (`deletedCount=0`, `success=false`). This deliberately does not distinguish
+"not found" from "not permitted", to avoid leaking row existence across tenants.
+
+[WARNING]
+====
+The `expand(...)` / AGGREGATION path is **not yet governed** and is intentionally
+gated. Even with `feature.queryGateway.execution.enabled=true`, `POST /api/query/find`
+returns HTTP 501 Not Implemented for an AGGREGATION-mode query, because a leading
+secured `$match` and an `excludedFields` `$project` have not yet been wired into the
+aggregation pipeline. `count` and `deleteMany` reject `expand(...)` queries up front
+with HTTP 400 (`InvalidQuery`). Re-enabling aggregation execution is a tracked
+follow-up; until then, expand-based hydration is planned but not executed.
+====
 
 ==== Request/Response: /api/query/plan
 
@@ -142,8 +186,8 @@ Parameters in the request body
 
 Behavior when AGGREGATION is requested
 
-- If the planner selects AGGREGATION (due to expand(...)) and the configuration property feature.queryGateway.execution.enabled=false (default), the endpoint responds with HTTP 501 Not Implemented and a message indicating execution is disabled.
-- If feature.queryGateway.execution.enabled=true, the gateway attempts to execute the aggregation pipeline. If the pipeline contains an unresolved $lookup.from ("__unknown__"), the endpoint responds with HTTP 422 Unprocessable Entity and an explanatory error. Otherwise, results are returned in the same Collection envelope shape, with rows being Documents.
+- If the planner selects AGGREGATION (due to `expand(...)`), `POST /api/query/find` responds with HTTP 501 Not Implemented. This holds regardless of `feature.queryGateway.execution.enabled`: when the flag is `false` (default) the message notes execution is disabled; when it is `true` the message notes that aggregation/expand execution is not yet governed by row- and field-level security and is disabled to prevent data leakage. See <<query-gateway-governance>>.
+- `count` and `deleteMany` reject `expand(...)` queries with HTTP 400 (`InvalidQuery`) because they support simple filter queries only.
 
 cURL examples
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/api/query/QueryGatewayResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/api/query/QueryGatewayResource.java
@@ -18,6 +18,7 @@ import com.e2eq.framework.model.persistent.imports.ImportSessionRow;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
 import com.e2eq.framework.model.securityrules.SecurityContext;
+import com.e2eq.framework.security.runtime.RuleContext;
 import com.e2eq.framework.rest.models.Collection;
 import com.e2eq.framework.csv.CSVExportHelper;
 import com.e2eq.framework.csv.CSVImportHelper;
@@ -28,6 +29,7 @@ import dev.morphia.mapping.Mapper;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.query.FindOptions;
 import dev.morphia.query.Query;
+import dev.morphia.query.filters.Filter;
 import dev.morphia.query.filters.Filters;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -116,6 +118,9 @@ public class QueryGatewayResource {
 
     @Inject
     MorphiaDataStoreWrapper morphiaDataStoreWrapper;
+
+    @Inject
+    RuleContext ruleContext;
 
     @Inject
     DeleteValidationService deleteValidationService;
@@ -219,7 +224,21 @@ public class QueryGatewayResource {
                 body.put("message", "Aggregation execution is disabled. Enable feature.queryGateway.execution.enabled to execute expand(...)");
                 return Response.status(Response.Status.NOT_IMPLEMENTED).entity(body).build();
             }
+            // SECURITY: the expand/aggregation path cannot yet inject the row-level security
+            // $match (DataDomain + rule filterConstraints) nor the excluded-field $project that the
+            // FILTER path enforces below. Executing it would bypass governance and leak rows/fields
+            // across DataDomain boundaries. Until the secured $match is reproduced for aggregation,
+            // short-circuit to 501 even when the feature flag is enabled so confidentiality never
+            // regresses on this path. FOLLOW-UP: translate securedFilterArray(...) into a leading
+            // $match stage and excludedFieldPaths() into a $project, then re-enable execution.
+            {
+                Map<String, Object> body = new HashMap<>();
+                body.put("error", "NotImplemented");
+                body.put("message", "Aggregation/expand execution is not governed by row-level and field-level security yet and is disabled to prevent data leakage. Tracked as a follow-up.");
+                return Response.status(Response.Status.NOT_IMPLEMENTED).entity(body).build();
+            }
             // Execution is enabled, but ensure the pipeline is executable
+            /* UNREACHABLE until the secured $match is implemented (see SECURITY note above).
             var pipeline = planned.getAggregation();
             boolean hasUnknownFrom = pipeline.stream()
                     .filter(d -> d instanceof org.bson.Document)
@@ -258,17 +277,25 @@ public class QueryGatewayResource {
                     .into(new java.util.ArrayList<>());
             Collection<org.bson.Document> col = new Collection<>(rows, effSkip, effLimit, req.query);
             return Response.ok(col).build();
+            END OF UNREACHABLE AGGREGATION BLOCK */
         }
         // FILTER path using Morphia
         String realm = resolveRealm(req.realm);
         Datastore ds = morphiaDataStoreWrapper.getDataStore(realm);
-        Query<? extends UnversionedBaseModel> q = ds.find(root);
+        // SECURITY: AND the caller's parsed filter with the row-level security filter array
+        // (DataDomain scope + rule filterConstraints) so results are scoped to the caller's
+        // org/account/tenant/dataSegment/owner boundary within the realm. Mirrors MorphiaRepo.
+        List<Filter> baseFilters = new ArrayList<>();
         if (planned.getFilter() != null) {
-            q = q.filter(planned.getFilter());
+            baseFilters.add(planned.getFilter());
         }
+        Filter[] securedFilters = securedFilterArray(baseFilters, root);
+        Query<? extends UnversionedBaseModel> q = ds.find(root).filter(securedFilters);
         int fLimit = req.page != null && req.page.limit != null ? req.page.limit : 50;
         int fSkip = req.page != null && req.page.skip != null ? req.page.skip : 0;
         FindOptions fo = new FindOptions().limit(fLimit).skip(fSkip);
+        // SECURITY: strip field-level excluded paths (deny-wins) at the datastore.
+        applyExcludedFieldProjection(fo);
         List<?> rows = q.iterator(fo).toList();
         Collection<?> col = new Collection<>(rows, fSkip, fLimit, req.query);
         return Response.ok(col).build();
@@ -287,8 +314,10 @@ public class QueryGatewayResource {
         Datastore ds = morphiaDataStoreWrapper.getDataStore(realm);
 
         try {
-            Query<? extends UnversionedBaseModel> q = ds.find(root);
-
+            // SECURITY: build the caller's parsed filter (if any), then AND it with the row-level
+            // security filter array before counting, so the count reflects only rows in the
+            // caller's DataDomain. Mirrors the governed read path in MorphiaRepo.
+            List<Filter> baseFilters = new ArrayList<>();
             if (req.query != null && !req.query.isBlank()) {
                 Map<String, String> variableMap = variableMapForQuery(req.realm);
                 PlannedQuery planned = MorphiaUtils.convertToPlannedQuery(req.query, root, null, null, null, variableMap);
@@ -299,9 +328,11 @@ public class QueryGatewayResource {
                     return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
                 }
                 if (planned.getFilter() != null) {
-                    q = q.filter(planned.getFilter());
+                    baseFilters.add(planned.getFilter());
                 }
             }
+            Filter[] securedFilters = securedFilterArray(baseFilters, root);
+            Query<? extends UnversionedBaseModel> q = ds.find(root).filter(securedFilters);
 
             long count = q.count();
 
@@ -420,7 +451,13 @@ public class QueryGatewayResource {
 
         try {
             ObjectId objectId = new ObjectId(req.id);
-            Query<? extends UnversionedBaseModel> query = ds.find(root).filter(Filters.eq("_id", objectId));
+            // SECURITY: match on _id AND the row-level security filter so a row outside the
+            // caller's DataDomain is simply not found. We return 404 in that case (below) without
+            // distinguishing not-found from not-permitted, to avoid leaking row existence.
+            List<Filter> baseFilters = new ArrayList<>();
+            baseFilters.add(Filters.eq("_id", objectId));
+            Filter[] securedFilters = securedFilterArray(baseFilters, root);
+            Query<? extends UnversionedBaseModel> query = ds.find(root).filter(securedFilters);
             UnversionedBaseModel entity = query.first();
             if (entity == null) {
                 DeleteResponse notFound = new DeleteResponse();
@@ -489,7 +526,10 @@ public class QueryGatewayResource {
         Datastore ds = morphiaDataStoreWrapper.getDataStore(realm);
 
         try {
-            Query<? extends UnversionedBaseModel> query = ds.find(root);
+            // SECURITY: AND the caller's parsed filter with the row-level security filter array so
+            // only rows inside the caller's DataDomain are matched (and therefore deleted). Without
+            // this, deleteMany could read+delete rows across DataDomain boundaries.
+            List<Filter> baseFilters = new ArrayList<>();
 
             // Apply query filter if provided
             if (req.query != null && !req.query.isBlank()) {
@@ -502,9 +542,11 @@ public class QueryGatewayResource {
                     return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
                 }
                 if (planned.getFilter() != null) {
-                    query = query.filter(planned.getFilter());
+                    baseFilters.add(planned.getFilter());
                 }
             }
+            Filter[] securedFilters = securedFilterArray(baseFilters, root);
+            Query<? extends UnversionedBaseModel> query = ds.find(root).filter(securedFilters);
 
             // Load matching entities (capped) so we can validate each before delete
             List<? extends UnversionedBaseModel> toDelete = query
@@ -812,17 +854,24 @@ public class QueryGatewayResource {
                     quoteChar, charset, false, query, skip, limit,
                     includeHeader, null);
 
-            // Determine row count for threshold decision
+            // Determine row count for threshold decision.
+            // SECURITY: the streamed CSV data above flows through the governed repo path
+            // (repo.getStreamByQuery -> buildSecuredFilters + field projection), so it is already
+            // row- and field-scoped. The threshold count must match that scope, so AND the caller's
+            // parsed filter with the row-level security filter array here too; otherwise the count
+            // would leak the cross-DataDomain total and could mis-route inline vs file mode.
             String realm = resolveRealm(req.realm);
             Datastore ds = morphiaDataStoreWrapper.getDataStore(realm);
-            Query<? extends UnversionedBaseModel> countQuery = ds.find(root);
+            List<Filter> baseFilters = new ArrayList<>();
             if (query != null && !query.isBlank()) {
                 Map<String, String> variableMap = variableMapForQuery(req.realm);
                 PlannedQuery planned = MorphiaUtils.convertToPlannedQuery(query, root, null, null, null, variableMap);
                 if (planned.getFilter() != null) {
-                    countQuery = countQuery.filter(planned.getFilter());
+                    baseFilters.add(planned.getFilter());
                 }
             }
+            Filter[] securedFilters = securedFilterArray(baseFilters, root);
+            Query<? extends UnversionedBaseModel> countQuery = ds.find(root).filter(securedFilters);
             long rowCount = countQuery.count();
 
             ExportResponse response = new ExportResponse();
@@ -889,6 +938,80 @@ public class QueryGatewayResource {
      * @param requestRealm optional realm from the request (may be null)
      * @return map of variable names to values (never null)
      */
+    /**
+     * Builds the row-level security filter array for a generic rootType, mirroring the governed
+     * read path in {@code MorphiaRepo}/{@code RepoSecurityFilterBuilder#getFilterArray}.
+     *
+     * <p>The supplied {@code baseFilters} (the caller's parsed query filter, if any) are ANDed with
+     * the RuleContext-derived DataDomain scope and rule filterConstraints for the current
+     * PrincipalContext/ResourceContext. This is what scopes results to the caller's
+     * org/account/tenant/dataSegment/owner boundary within the realm.</p>
+     *
+     * <p>Fail-closed: if SecurityContext is not populated (and rules are not being ignored) this
+     * throws, so a generic query can never run unscoped. When {@link SecurityContext#isIgnoringRules()}
+     * is active the base filters are returned unchanged, matching the repo layer.</p>
+     *
+     * @param baseFilters caller-supplied filters to be secured (never null; may be empty)
+     * @param modelClass  the resolved root entity class (used for variable resolution)
+     * @return the secured filter array to apply to the Morphia query
+     */
+    private Filter[] securedFilterArray(List<Filter> baseFilters, Class<? extends UnversionedBaseModel> modelClass) {
+        if (SecurityContext.isIgnoringRules()) {
+            return baseFilters.toArray(new Filter[0]);
+        }
+        java.util.Optional<PrincipalContext> pc = SecurityContext.getPrincipalContext();
+        java.util.Optional<ResourceContext> rc = SecurityContext.getResourceContext();
+        if (pc.isEmpty() || rc.isEmpty()) {
+            // Fail-closed: never execute a generic query without a resolved security context.
+            boolean missingP = pc.isEmpty();
+            boolean missingR = rc.isEmpty();
+            String missing = (missingP && missingR) ? "PrincipalContext and ResourceContext"
+                    : missingP ? "PrincipalContext" : "ResourceContext";
+            // Log the detail server-side; return a SANITIZED error to the client. A bare
+            // RuntimeException would be rendered by the exception mapper as a full stack trace in
+            // the response body (info-disclosure). No row/field data is exposed — no query ran.
+            Log.warnf("QueryGateway refusing ungoverned query: SecurityContext missing %s", missing);
+            throw new WebApplicationException(
+                    Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                            .entity(Map.of("error", "SecurityContextMissing",
+                                    "message", "Query cannot be governed: security context is not established for this request."))
+                            .build());
+        }
+        List<Filter> secured = ruleContext.getFilters(baseFilters, pc.get(), rc.get(), modelClass);
+        return secured.toArray(new Filter[0]);
+    }
+
+    /**
+     * Field-level policy companion to {@link #securedFilterArray}: the deny-wins set of excluded
+     * field paths for the current security context, mirroring
+     * {@code RepoSecurityFilterBuilder#buildExcludedFieldPaths}. Empty when rules are ignored or no
+     * principal is present (field exclusions are principal-relative).
+     */
+    private java.util.Set<String> excludedFieldPaths() {
+        if (SecurityContext.isIgnoringRules()) {
+            return java.util.Set.of();
+        }
+        java.util.Optional<PrincipalContext> pc = SecurityContext.getPrincipalContext();
+        java.util.Optional<ResourceContext> rc = SecurityContext.getResourceContext();
+        if (pc.isEmpty() || rc.isEmpty()) {
+            return java.util.Set.of();
+        }
+        return ruleContext.getExcludedFieldPaths(pc.get(), rc.get());
+    }
+
+    /**
+     * Applies the field-level exclusion projection (deny-wins) to a FindOptions, mirroring
+     * {@code MorphiaRepo#convertToProjection}. Excluded paths are stripped at the datastore so the
+     * data never leaves Mongo.
+     */
+    private FindOptions applyExcludedFieldProjection(FindOptions options) {
+        java.util.Set<String> excluded = excludedFieldPaths();
+        if (!excluded.isEmpty()) {
+            options.projection().exclude(excluded.toArray(new String[0]));
+        }
+        return options;
+    }
+
     private Map<String, String> variableMapForQuery(String requestRealm) {
         java.util.Optional<PrincipalContext> pc = SecurityContext.getPrincipalContext();
         java.util.Optional<ResourceContext> rc = SecurityContext.getResourceContext();

--- a/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/BootstrapPackService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/BootstrapPackService.java
@@ -1,7 +1,6 @@
 package com.e2eq.framework.bootstrap.runtime;
 
 import com.e2eq.framework.bootstrap.model.ApplyBootstrapPackRequest;
-import com.e2eq.framework.bootstrap.model.BootstrapPackApplyMode;
 import com.e2eq.framework.bootstrap.model.BootstrapPackDefinition;
 import com.e2eq.framework.bootstrap.model.BootstrapPackRun;
 import com.e2eq.framework.bootstrap.model.BootstrapPackRunStatus;
@@ -18,7 +17,6 @@ import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -36,17 +34,17 @@ public class BootstrapPackService {
 
     @Inject
     public BootstrapPackService(
-            BootstrapPackRegistry registry,
-            Instance<BootstrapPackStepHandler> handlers,
-            BootstrapPackRunRepository runRepository
+        BootstrapPackRegistry registry,
+        Instance<BootstrapPackStepHandler> handlers,
+        BootstrapPackRunRepository runRepository
     ) {
         this(registry, toOrderedHandlers(handlers), runRepository);
     }
 
     public BootstrapPackService(
-            BootstrapPackRegistry registry,
-            Iterable<BootstrapPackStepHandler> handlers,
-            BootstrapPackRunRepository runRepository
+        BootstrapPackRegistry registry,
+        Iterable<BootstrapPackStepHandler> handlers,
+        BootstrapPackRunRepository runRepository
     ) {
         this.registry = registry;
         this.handlers = handlers;
@@ -62,70 +60,90 @@ public class BootstrapPackService {
     }
 
     public BootstrapPackRun apply(ApplyBootstrapPackRequest request) {
-        BootstrapPackDefinition pack = registry.find(request.packRef())
-                .orElseThrow(() -> new IllegalArgumentException("Unknown bootstrap pack: " + request.packRef()));
+        BootstrapPackDefinition pack = registry
+            .find(request.packRef())
+            .orElseThrow(() ->
+                new IllegalArgumentException(
+                    "Unknown bootstrap pack: " + request.packRef()
+                )
+            );
 
         Instant packStartedAt = Instant.now();
         Map<String, Object> scope = buildScope(request, pack);
         List<BootstrapPackStepRun> stepRuns = new ArrayList<>();
-        Map<String, BootstrapPackStepRun> completedSteps = new LinkedHashMap<>();
+        Map<String, BootstrapPackStepRun> completedSteps =
+            new LinkedHashMap<>();
 
         for (BootstrapPackStepDefinition step : pack.steps()) {
-            BootstrapPackStepRun stepRun = executeStep(pack, request, scope, step, completedSteps);
+            BootstrapPackStepRun stepRun = executeStep(
+                pack,
+                request,
+                scope,
+                step,
+                completedSteps
+            );
             stepRuns.add(stepRun);
             completedSteps.put(step.stepRef(), stepRun);
             if (stepRun.status() == BootstrapStepStatus.FAILED) {
                 BootstrapPackRun failedRun = new BootstrapPackRun(
-                        buildRunRef(),
-                        pack.packRef(),
-                        pack.packVersion(),
-                        pack.productRef(),
-                        pack.profileRef(),
-                        request.mode(),
-                        BootstrapPackRunStatus.FAILED,
-                        scope,
-                        stepRuns,
-                        packStartedAt,
-                        Instant.now()
+                    buildRunRef(),
+                    pack.packRef(),
+                    pack.packVersion(),
+                    pack.productRef(),
+                    pack.profileRef(),
+                    request.mode(),
+                    BootstrapPackRunStatus.FAILED,
+                    scope,
+                    stepRuns,
+                    packStartedAt,
+                    Instant.now()
                 );
                 return runRepository.save(failedRun);
             }
         }
 
         BootstrapPackRun completedRun = new BootstrapPackRun(
-                buildRunRef(),
-                pack.packRef(),
-                pack.packVersion(),
-                pack.productRef(),
-                pack.profileRef(),
-                request.mode(),
-                BootstrapPackRunStatus.COMPLETED,
-                scope,
-                stepRuns,
-                packStartedAt,
-                Instant.now()
+            buildRunRef(),
+            pack.packRef(),
+            pack.packVersion(),
+            pack.productRef(),
+            pack.profileRef(),
+            request.mode(),
+            BootstrapPackRunStatus.COMPLETED,
+            scope,
+            stepRuns,
+            packStartedAt,
+            Instant.now()
         );
         return runRepository.save(completedRun);
     }
 
     private BootstrapPackStepRun executeStep(
-            BootstrapPackDefinition pack,
-            ApplyBootstrapPackRequest request,
-            Map<String, Object> scope,
-            BootstrapPackStepDefinition step,
-            Map<String, BootstrapPackStepRun> completedSteps
+        BootstrapPackDefinition pack,
+        ApplyBootstrapPackRequest request,
+        Map<String, Object> scope,
+        BootstrapPackStepDefinition step,
+        Map<String, BootstrapPackStepRun> completedSteps
     ) {
         Instant stepStartedAt = Instant.now();
         for (String dependency : step.dependsOn()) {
             BootstrapPackStepRun dependencyRun = completedSteps.get(dependency);
-            if (dependencyRun == null || dependencyRun.status() != BootstrapStepStatus.COMPLETED) {
+            if (
+                dependencyRun == null ||
+                dependencyRun.status() != BootstrapStepStatus.COMPLETED
+            ) {
                 return new BootstrapPackStepRun(
-                        step.stepRef(),
-                        BootstrapStepStatus.FAILED,
-                        BootstrapStepOutcome.FAILED,
-                        Map.of("reason", "DEPENDENCY_NOT_SATISFIED", "dependency", dependency),
-                        stepStartedAt,
-                        Instant.now()
+                    step.stepRef(),
+                    BootstrapStepStatus.FAILED,
+                    BootstrapStepOutcome.FAILED,
+                    Map.of(
+                        "reason",
+                        "DEPENDENCY_NOT_SATISFIED",
+                        "dependency",
+                        dependency
+                    ),
+                    stepStartedAt,
+                    Instant.now()
                 );
             }
         }
@@ -133,18 +151,22 @@ public class BootstrapPackService {
         BootstrapPackStepHandler handler = resolveHandler(step);
         if (handler == null) {
             return new BootstrapPackStepRun(
-                    step.stepRef(),
-                    BootstrapStepStatus.FAILED,
-                    BootstrapStepOutcome.FAILED,
-                    Map.of("reason", "NO_HANDLER", "kind", step.kind().name()),
-                    stepStartedAt,
-                    Instant.now()
+                step.stepRef(),
+                BootstrapStepStatus.FAILED,
+                BootstrapStepOutcome.FAILED,
+                Map.of("reason", "NO_HANDLER", "kind", step.kind().name()),
+                stepStartedAt,
+                Instant.now()
             );
         }
 
         BootstrapStepResult result;
-        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
-            result = handler.execute(new BootstrapStepRequest(
+        try (
+            SecurityCallScope.Scope ignored =
+                SecurityCallScope.openIgnoringRules()
+        ) {
+            result = handler.execute(
+                new BootstrapStepRequest(
                     pack.packRef(),
                     pack.packVersion(),
                     pack.productRef(),
@@ -155,20 +177,23 @@ public class BootstrapPackService {
                     request.actorRef(),
                     scope,
                     step.config()
-            ));
+                )
+            );
         }
 
         return new BootstrapPackStepRun(
-                step.stepRef(),
-                result.status(),
-                result.outcome(),
-                result.details(),
-                stepStartedAt,
-                Instant.now()
+            step.stepRef(),
+            result.status(),
+            result.outcome(),
+            result.details(),
+            stepStartedAt,
+            Instant.now()
         );
     }
 
-    private BootstrapPackStepHandler resolveHandler(BootstrapPackStepDefinition step) {
+    private BootstrapPackStepHandler resolveHandler(
+        BootstrapPackStepDefinition step
+    ) {
         for (BootstrapPackStepHandler handler : handlers) {
             if (handler != null && handler.supports(step.kind())) {
                 return handler;
@@ -177,11 +202,18 @@ public class BootstrapPackService {
         return null;
     }
 
-    private Map<String, Object> buildScope(ApplyBootstrapPackRequest request, BootstrapPackDefinition pack) {
+    private Map<String, Object> buildScope(
+        ApplyBootstrapPackRequest request,
+        BootstrapPackDefinition pack
+    ) {
         Map<String, Object> scope = new LinkedHashMap<>();
         putIfPresent(scope, "packRef", pack.packRef());
         putIfPresent(scope, "packVersion", pack.packVersion());
-        putIfPresent(scope, "productRef", firstNonBlank(request.productRef(), pack.productRef()));
+        putIfPresent(
+            scope,
+            "productRef",
+            firstNonBlank(request.productRef(), pack.productRef())
+        );
         putIfPresent(scope, "profileRef", pack.profileRef());
         putIfPresent(scope, "environmentRef", request.environmentRef());
         putIfPresent(scope, "realmRef", request.realmRef());
@@ -190,14 +222,22 @@ public class BootstrapPackService {
         return scope;
     }
 
-    private static Iterable<BootstrapPackStepHandler> toOrderedHandlers(Instance<BootstrapPackStepHandler> handlers) {
+    private static Iterable<BootstrapPackStepHandler> toOrderedHandlers(
+        Instance<BootstrapPackStepHandler> handlers
+    ) {
         List<BootstrapPackStepHandler> ordered = new ArrayList<>();
         handlers.forEach(ordered::add);
-        ordered.sort(Comparator.comparingInt(BootstrapPackStepHandler::priority));
+        ordered.sort(
+            Comparator.comparingInt(BootstrapPackStepHandler::priority)
+        );
         return ordered;
     }
 
-    private static void putIfPresent(Map<String, Object> target, String key, String value) {
+    private static void putIfPresent(
+        Map<String, Object> target,
+        String key,
+        String value
+    ) {
         if (value != null && !value.isBlank()) {
             target.put(key, value);
         }

--- a/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/BootstrapPackStartupRunner.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/BootstrapPackStartupRunner.java
@@ -14,14 +14,12 @@ import com.e2eq.framework.util.EnvConfigUtils;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 public class BootstrapPackStartupRunner {
@@ -35,10 +33,16 @@ public class BootstrapPackStartupRunner {
     @Inject
     SystemRealmOwnership systemRealmOwnership;
 
-    @ConfigProperty(name = "quantum.bootstrap-pack.enabled", defaultValue = "true")
+    @ConfigProperty(
+        name = "quantum.bootstrap-pack.enabled",
+        defaultValue = "true"
+    )
     boolean enabled;
 
-    @ConfigProperty(name = "quantum.bootstrap-pack.apply.on-startup", defaultValue = "false")
+    @ConfigProperty(
+        name = "quantum.bootstrap-pack.apply.on-startup",
+        defaultValue = "false"
+    )
     boolean applyOnStartup;
 
     @ConfigProperty(name = "quantum.bootstrap-pack.apply.realms")
@@ -52,25 +56,35 @@ public class BootstrapPackStartupRunner {
 
     public void onStart() {
         if (!enabled || !applyOnStartup) {
-            Log.info("BootstrapPackStartupRunner disabled by configuration (quantum.bootstrap-pack.enabled / quantum.bootstrap-pack.apply.on-startup)");
+            Log.info(
+                "BootstrapPackStartupRunner disabled by configuration (quantum.bootstrap-pack.enabled / quantum.bootstrap-pack.apply.on-startup)"
+            );
             return;
         }
 
         List<String> realms = resolveStartupRealms();
         List<BootstrapPackDefinition> packs = resolveStartupPacks();
         if (realms.isEmpty() || packs.isEmpty()) {
-            Log.info("BootstrapPackStartupRunner: no startup bootstrap packs selected");
+            Log.info(
+                "BootstrapPackStartupRunner: no startup bootstrap packs selected"
+            );
             return;
         }
 
-        Log.infof("BootstrapPackStartupRunner: will apply bootstrap packs %s to realms %s", packs.stream().map(BootstrapPackDefinition::packRef).toList(), realms);
+        Log.infof(
+            "BootstrapPackStartupRunner: will apply bootstrap packs %s to realms %s",
+            packs.stream().map(BootstrapPackDefinition::packRef).toList(),
+            realms
+        );
         for (String realm : realms) {
             for (BootstrapPackDefinition pack : packs) {
                 try {
                     BootstrapPackRun run = SecurityCallScope.runWithContexts(
-                            startupPrincipalContext(realm),
-                            startupResourceContext(realm),
-                            () -> bootstrapPackService.apply(new ApplyBootstrapPackRequest(
+                        startupPrincipalContext(realm),
+                        startupResourceContext(realm),
+                        () ->
+                            bootstrapPackService.apply(
+                                new ApplyBootstrapPackRequest(
                                     pack.packRef(),
                                     BootstrapPackApplyMode.APPLY_MISSING,
                                     pack.productRef(),
@@ -79,13 +93,26 @@ public class BootstrapPackStartupRunner {
                                     null,
                                     null,
                                     "framework/bootstrap-startup"
-                            ))
+                                )
+                            )
                     );
-                    if (run != null && run.status() == BootstrapPackRunStatus.FAILED) {
-                        Log.warnf("BootstrapPackStartupRunner: bootstrap pack %s finished with status FAILED for realm %s", pack.packRef(), realm);
+                    if (
+                        run != null &&
+                        run.status() == BootstrapPackRunStatus.FAILED
+                    ) {
+                        Log.warnf(
+                            "BootstrapPackStartupRunner: bootstrap pack %s finished with status FAILED for realm %s",
+                            pack.packRef(),
+                            realm
+                        );
                     }
                 } catch (Exception ex) {
-                    Log.warnf("BootstrapPackStartupRunner: failed applying pack %s for realm %s: %s", pack.packRef(), realm, ex.getMessage());
+                    Log.warnf(
+                        "BootstrapPackStartupRunner: failed applying pack %s for realm %s: %s",
+                        pack.packRef(),
+                        realm,
+                        ex.getMessage()
+                    );
                 }
             }
         }
@@ -111,7 +138,10 @@ public class BootstrapPackStartupRunner {
         }
         List<String> resolved = new ArrayList<>(realms);
         // Covers this runner and PendingBootstrapPacksStartupLogger (which reuses this method).
-        systemRealmOwnership.excludeSystemRealmIfNotOwned(resolved, "BootstrapPackStartupRunner");
+        systemRealmOwnership.excludeSystemRealmIfNotOwned(
+            resolved,
+            "BootstrapPackStartupRunner"
+        );
         return resolved;
     }
 
@@ -121,9 +151,10 @@ public class BootstrapPackStartupRunner {
         if (filter.isEmpty()) {
             return packs;
         }
-        return packs.stream()
-                .filter(pack -> filter.contains(pack.packRef()))
-                .toList();
+        return packs
+            .stream()
+            .filter(pack -> filter.contains(pack.packRef()))
+            .toList();
     }
 
     private Set<String> resolvePackFilter() {
@@ -162,46 +193,54 @@ public class BootstrapPackStartupRunner {
     PrincipalContext startupPrincipalContext(String realm) {
         String effectiveRealm = normalize(realm);
         DataDomain dataDomain;
-        if (effectiveRealm != null && effectiveRealm.equals(envConfigUtils.getSystemRealm())) {
+        if (
+            effectiveRealm != null &&
+            effectiveRealm.equals(envConfigUtils.getSystemRealm())
+        ) {
             dataDomain = new DataDomain(
-                    envConfigUtils.getSystemOrgRefName(),
-                    envConfigUtils.getSystemAccountNumber(),
-                    envConfigUtils.getSystemTenantId(),
-                    envConfigUtils.getDefaultDataSegment(),
-                    envConfigUtils.getSystemUserId()
+                envConfigUtils.getSystemOrgRefName(),
+                envConfigUtils.getSystemAccountNumber(),
+                envConfigUtils.getSystemTenantId(),
+                envConfigUtils.getDefaultDataSegment(),
+                envConfigUtils.getSystemUserId()
             );
-        } else if (effectiveRealm != null && effectiveRealm.equals(envConfigUtils.getTestRealm())) {
+        } else if (
+            effectiveRealm != null &&
+            effectiveRealm.equals(envConfigUtils.getTestRealm())
+        ) {
             dataDomain = new DataDomain(
-                    envConfigUtils.getTestOrgRefName(),
-                    envConfigUtils.getTestAccountNumber(),
-                    envConfigUtils.getTestTenantId(),
-                    envConfigUtils.getDefaultDataSegment(),
-                    envConfigUtils.getSystemUserId()
+                envConfigUtils.getTestOrgRefName(),
+                envConfigUtils.getTestAccountNumber(),
+                envConfigUtils.getTestTenantId(),
+                envConfigUtils.getDefaultDataSegment(),
+                envConfigUtils.getSystemUserId()
             );
         } else {
             dataDomain = new DataDomain(
-                    envConfigUtils.getDefaultOrgRefName(),
-                    envConfigUtils.getDefaultAccountNumber(),
-                    envConfigUtils.getDefaultTenantId(),
-                    envConfigUtils.getDefaultDataSegment(),
-                    envConfigUtils.getSystemUserId()
+                envConfigUtils.getDefaultOrgRefName(),
+                envConfigUtils.getDefaultAccountNumber(),
+                envConfigUtils.getDefaultTenantId(),
+                envConfigUtils.getDefaultDataSegment(),
+                envConfigUtils.getSystemUserId()
             );
         }
         return SecurityCallScope.service(
-                effectiveRealm != null ? effectiveRealm : envConfigUtils.getSystemRealm(),
-                dataDomain,
-                envConfigUtils.getSystemUserId(),
-                "SYSTEM"
+            effectiveRealm != null
+                ? effectiveRealm
+                : envConfigUtils.getSystemRealm(),
+            dataDomain,
+            envConfigUtils.getSystemUserId(),
+            "SYSTEM"
         );
     }
 
     ResourceContext startupResourceContext(String realm) {
         return SecurityCallScope.resource(
-                startupPrincipalContext(realm),
-                realm,
-                "BOOTSTRAP",
-                "BOOTSTRAP_PACK",
-                "APPLY"
+            startupPrincipalContext(realm),
+            realm,
+            "BOOTSTRAP",
+            "BOOTSTRAP_PACK",
+            "APPLY"
         );
     }
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/PendingBootstrapPacksStartupLogger.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/PendingBootstrapPacksStartupLogger.java
@@ -6,10 +6,8 @@ import com.e2eq.framework.bootstrap.spi.BootstrapPackRunRepository;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import java.util.List;
-import java.util.Map;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 public class PendingBootstrapPacksStartupLogger {
@@ -23,31 +21,48 @@ public class PendingBootstrapPacksStartupLogger {
     @Inject
     BootstrapPackRunRepository runRepository;
 
-    @ConfigProperty(name = "quantum.bootstrap-pack.enabled", defaultValue = "true")
+    @ConfigProperty(
+        name = "quantum.bootstrap-pack.enabled",
+        defaultValue = "true"
+    )
     boolean enabled;
 
     public void onStart() {
         if (!enabled) {
             return;
         }
-        List<BootstrapPackDefinition> startupPacks = startupRunner.resolveStartupPacks();
+        List<BootstrapPackDefinition> startupPacks =
+            startupRunner.resolveStartupPacks();
         for (String realm : startupRunner.resolveStartupRealms()) {
-            long pending = startupPacks.stream()
-                    .filter(pack -> hasNoSuccessfulRun(pack.packRef(), realm))
-                    .count();
+            long pending = startupPacks
+                .stream()
+                .filter(pack -> hasNoSuccessfulRun(pack.packRef(), realm))
+                .count();
             if (pending == 0) {
-                Log.infof("BootstrapPacks: No pending startup bootstrap packs for realm %s.", realm);
+                Log.infof(
+                    "BootstrapPacks: No pending startup bootstrap packs for realm %s.",
+                    realm
+                );
             } else {
-                Log.warnf("BootstrapPacks: %d pending startup bootstrap pack(s) for realm %s.", pending, realm);
+                Log.warnf(
+                    "BootstrapPacks: %d pending startup bootstrap pack(s) for realm %s.",
+                    pending,
+                    realm
+                );
             }
         }
     }
 
     private boolean hasNoSuccessfulRun(String packRef, String realm) {
-        return runRepository.list().stream()
-                .noneMatch(run -> run.status() == BootstrapPackRunStatus.COMPLETED
-                        && packRef.equals(run.packRef())
-                        && realm.equals(stringValue(run.scope().get("realmRef"))));
+        return runRepository
+            .list()
+            .stream()
+            .noneMatch(
+                run ->
+                    run.status() == BootstrapPackRunStatus.COMPLETED &&
+                    packRef.equals(run.packRef()) &&
+                    realm.equals(stringValue(run.scope().get("realmRef")))
+            );
     }
 
     private String stringValue(Object value) {

--- a/quantum-framework/src/main/java/com/e2eq/framework/imports/calculators/RefNameFieldCalculator.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/imports/calculators/RefNameFieldCalculator.java
@@ -5,8 +5,6 @@ import com.e2eq.framework.imports.spi.ImportContext;
 import com.e2eq.framework.model.persistent.base.BaseModel;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
-import org.apache.commons.text.WordUtils;
-
 import java.util.Map;
 import java.util.UUID;
 
@@ -24,7 +22,11 @@ public class RefNameFieldCalculator implements FieldCalculator {
     }
 
     @Override
-    public void calculate(BaseModel bean, Map<String, Object> rowData, ImportContext context) {
+    public void calculate(
+        BaseModel bean,
+        Map<String, Object> rowData,
+        ImportContext context
+    ) {
         if (bean.getRefName() == null || bean.getRefName().isEmpty()) {
             String refName = generateRefName(bean, rowData);
             bean.setRefName(refName);
@@ -36,7 +38,10 @@ public class RefNameFieldCalculator implements FieldCalculator {
         return 70; // Run after UUID calculator
     }
 
-    private String generateRefName(BaseModel bean, Map<String, Object> rowData) {
+    private String generateRefName(
+        BaseModel bean,
+        Map<String, Object> rowData
+    ) {
         // Try to derive from displayName
         String displayName = bean.getDisplayName();
         if (displayName != null && !displayName.isEmpty()) {
@@ -44,7 +49,12 @@ public class RefNameFieldCalculator implements FieldCalculator {
         }
 
         // Try common name fields from row data
-        for (String fieldName : new String[]{"name", "title", "code", "identifier"}) {
+        for (String fieldName : new String[] {
+            "name",
+            "title",
+            "code",
+            "identifier",
+        }) {
             Object value = rowData.get(fieldName);
             if (value != null && !value.toString().isEmpty()) {
                 return normalizeRefName(value.toString());
@@ -61,15 +71,17 @@ public class RefNameFieldCalculator implements FieldCalculator {
         }
 
         // Convert to lowercase, replace spaces with hyphens, remove special chars
-        String normalized = value.toLowerCase()
-                .replaceAll("\\s+", "-")
-                .replaceAll("[^a-z0-9\\-_]", "")
-                .replaceAll("-+", "-")
-                .replaceAll("^-|-$", "");
+        String normalized = value
+            .toLowerCase()
+            .replaceAll("\\s+", "-")
+            .replaceAll("[^a-z0-9\\-_]", "")
+            .replaceAll("-+", "-")
+            .replaceAll("^-|-$", "");
 
         // Ensure minimum length
         if (normalized.length() < 3) {
-            normalized = normalized + "-" + UUID.randomUUID().toString().substring(0, 8);
+            normalized =
+                normalized + "-" + UUID.randomUUID().toString().substring(0, 8);
         }
 
         // Truncate if too long (keeping it reasonable for database indexes)

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/MigrationCheckRequestFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/MigrationCheckRequestFilter.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import java.io.IOException;
@@ -35,10 +36,17 @@ public class MigrationCheckRequestFilter implements ContainerRequestFilter {
     @Inject
     JsonWebToken jwt;
 
+    @ConfigProperty(name = "quantum.database.migration.enabled", defaultValue = "true")
+    boolean migrationCheckEnabled;
+
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         boolean failRequest=false;
         DatabaseMigrationException ex = null;
+
+        if (!migrationCheckEnabled) {
+            return;
+        }
 
         if (requestContext.getUriInfo().getPath().contains("hello")) {
             return;

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -157,6 +157,9 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         if (principalContext == null) {
             throw new IllegalStateException("Principal context came back null and should not be null");
         }
+        if (resourceContext != null && resourceContext.getDataDomain() == null) {
+            resourceContext = resourceContext.withDataDomain(principalContext.getDataDomain());
+        }
 
         // Always set the contexts - they may be needed by other parts of the application
         // even for @PermitAll endpoints. The policy checks will be bypassed elsewhere.

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/AuthResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/AuthResource.java
@@ -13,6 +13,7 @@ import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.UserProfile;
 import com.e2eq.framework.rest.requests.CreateUserRequest;
 import com.e2eq.framework.rest.requests.ServiceTokenRequest;
+import com.e2eq.framework.rest.services.AuthLoginService;
 import com.e2eq.framework.util.EnvConfigUtils;
 import io.quarkus.logging.Log;
 import jakarta.annotation.security.PermitAll;
@@ -47,6 +48,9 @@ public class AuthResource {
 
     @Inject
     EnvConfigUtils envConfigUtils;
+
+    @Inject
+    AuthLoginService authLoginService;
 
 
     @GET
@@ -89,21 +93,7 @@ public class AuthResource {
     public Response login(@QueryParam("userId") String userId,
                           @QueryParam("password") String password,
                           @QueryParam("provider") @DefaultValue("") String provider) {
-        var authProvider = provider.isBlank()
-                ? authProviderFactory.getAuthProvider()
-                : authProviderFactory.getProviderByName(provider);
-        var loginResponse = authProvider.login(userId, password);
-
-        if (!loginResponse.authenticated() || loginResponse.positiveResponse() == null) {
-            return Response.status(Response.Status.UNAUTHORIZED)
-                    .entity(Map.of("error", "Authentication failed")).build();
-        }
-
-        return Response.ok(Map.of(
-            "accessToken", loginResponse.positiveResponse().accessToken(),
-            "refreshToken", loginResponse.positiveResponse().refreshToken(),
-            "authProvider", authProvider.getName()
-        )).build();
+        return authLoginService.login(userId, password, provider).toResponse();
     }
 
     @POST

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
@@ -2,14 +2,14 @@ package com.e2eq.framework.rest.resources;
 
 
 import com.e2eq.framework.model.persistent.morphia.RealmRepo;
-import com.e2eq.framework.model.auth.AuthProvider;
 import com.e2eq.framework.model.auth.AuthProviderFactory;
-import com.e2eq.framework.model.auth.RoleAssignment;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.Realm;
 import com.e2eq.framework.rest.models.*;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.model.securityrules.SecurityCheckException;
 import com.e2eq.framework.model.security.ApplicationRegistration;
+import com.e2eq.framework.rest.services.AuthLoginService;
 
 import com.e2eq.framework.model.security.UserProfile;
 import com.e2eq.framework.model.persistent.morphia.ApplicationRegistrationRequestRepo;
@@ -54,7 +54,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @OpenAPIDefinition(
         tags = {
@@ -105,6 +104,9 @@ public class SecurityResource {
 
     @Inject
     EnvConfigUtils envConfigUtils;
+
+    @Inject
+    AuthLoginService authLoginService;
 
     @ConfigProperty(name = "mp.jwt.verify.issuer")
     protected String issuer;
@@ -178,7 +180,9 @@ public class SecurityResource {
         registration.setLname(registrationRequest.getLname());
         registration.setUserTelephone(registrationRequest.getTelephone());
 
-        registration = registrationRepo.save(registration);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            registration = registrationRepo.save(registration);
+        }
         return Response.ok().entity(registration).status(Response.Status.CREATED).build();
     }
 
@@ -294,50 +298,19 @@ public class SecurityResource {
 
         Log.infof("Logging in userid: %s realm: %s",authRequest.getUserId(), realm);
 
-        AuthProvider authProvider;
-        Optional<CredentialUserIdPassword> credentialOptional = credentialRepo.findByUserId(authRequest.getUserId());
-        if (credentialOptional.isPresent()) {
-            CredentialUserIdPassword credential = credentialOptional.get();
-            if (credential.getAuthProviderName() != null && !credential.getAuthProviderName().isBlank()) {
-                authProvider = authProviderFactory.getProviderByName(credential.getAuthProviderName());
-            } else {
-                authProvider = authProviderFactory.getAuthProvider();
-            }
-        } else {
-            authProvider = authProviderFactory.getAuthProvider();
-        }
-
         try {
-            AuthProvider.LoginResponse loginResponse;
-            loginResponse = authProvider.login(authRequest.getUserId(), authRequest.getPassword());
-
-            if (loginResponse.authenticated()) {
-                Log.info("Login successful for userId:" + authRequest.getUserId());
-                Optional<CredentialUserIdPassword> credentialOp = findCredential(
-                        loginResponse.positiveResponse().identity() != null && loginResponse.positiveResponse().identity().getPrincipal() != null
-                                ? loginResponse.positiveResponse().identity().getPrincipal().getName()
-                                : null,
-                        loginResponse.positiveResponse().userId()
-                );
-                AuthResponse response = new AuthResponse();
-                response.setAccess_token(loginResponse.positiveResponse().accessToken());
-                response.setRefresh_token(loginResponse.positiveResponse().refreshToken());
-                response.setExpires_at(loginResponse.positiveResponse().expirationTime());
-                response.setMongodburl(loginResponse.positiveResponse().mongodbUrl());
-                response.setRealm(loginResponse.positiveResponse().realm());
-                response.setRoles(loginResponse.positiveResponse().roleAssignments().stream().map(RoleAssignment::toString).collect(Collectors.toList()));
-                response.setAuthProvider(authProvider.getName());
-                response.setAccessibleRealms(resolveAccessibleRealms(credentialOp.orElse(null)));
-                return Response.ok(response).build();
+            AuthLoginService.LoginResult loginResult = authLoginService.login(authRequest.getUserId(), authRequest.getPassword());
+            if (loginResult.authenticated()) {
+                Log.info("Login successful for userId:" + authRequest.getUserId() + " provider:" + loginResult.response().getAuthProvider());
+                return Response.ok(loginResult.response()).build();
             }
-            else {
-                Log.warn("Login failed for userId:" + authRequest.getUserId());
-                RestError error = RestError.builder()
-                        .statusMessage(loginResponse.negativeResponse().errorMessage())
-                        .status(Response.Status.UNAUTHORIZED.getStatusCode())
-                        .build();
-                return Response.status(Response.Status.UNAUTHORIZED).entity(error).build();
-            }
+            Log.warn("Login failed for userId:" + authRequest.getUserId() + " providers:" + loginResult.providerFailures());
+            RestError error = RestError.builder()
+                    .statusMessage("Authentication failed")
+                    .debugMessage(String.join("; ", loginResult.providerFailures()))
+                    .status(Response.Status.UNAUTHORIZED.getStatusCode())
+                    .build();
+            return Response.status(Response.Status.UNAUTHORIZED).entity(error).build();
 
         } catch (SecurityException e) {
             RestError error = RestError.builder()

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthCredentialService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthCredentialService.java
@@ -1,0 +1,76 @@
+package com.e2eq.framework.rest.services;
+
+import com.e2eq.framework.model.auth.AuthProvider;
+import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.auth.UserManagement;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.security.CredentialType;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.rest.models.ResetPasswordRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class AuthCredentialService {
+
+    @Inject
+    AuthProviderFactory authProviderFactory;
+
+    @Inject
+    CredentialRepo credentialRepo;
+
+    public void resetPassword(ResetPasswordRequest request, String providerOverride) {
+        validateResetPasswordRequest(request);
+
+        String requestedProvider = providerOverride == null || providerOverride.isBlank()
+                ? request.getAuthProvider()
+                : providerOverride;
+        UserManagement userManager = resolveUserManager(request.getUserId(), requestedProvider);
+        userManager.resetPassword(
+                request.getUserId(),
+                request.getNewPassword(),
+                Boolean.TRUE.equals(request.getForceChangePassword())
+        );
+    }
+
+    public UserManagement resolveUserManager(String userId, String requestedProvider) {
+        if (requestedProvider != null && !requestedProvider.isBlank()) {
+            return authProviderFactory.getUserManager(requestedProvider);
+        }
+
+        Optional<CredentialUserIdPassword> credentialOptional = credentialRepo.findByUserId(userId);
+        if (credentialOptional.isPresent()) {
+            CredentialUserIdPassword credential = credentialOptional.get();
+            if (credential.getCredentialType() != null && credential.getCredentialType() != CredentialType.PASSWORD) {
+                return authProviderFactory.getUserManager();
+            }
+
+            if (credential.getIssuer() != null && !credential.getIssuer().isBlank()) {
+                AuthProvider issuerProvider = authProviderFactory.getProviderForIssuer(credential.getIssuer());
+                if (issuerProvider instanceof UserManagement userManagement) {
+                    return userManagement;
+                }
+            }
+
+            if (credential.getAuthProviderName() != null && !credential.getAuthProviderName().isBlank()) {
+                return authProviderFactory.getUserManager(credential.getAuthProviderName());
+            }
+        }
+
+        return authProviderFactory.getUserManager();
+    }
+
+    private void validateResetPasswordRequest(ResetPasswordRequest request) {
+        if (request == null
+                || request.getUserId() == null || request.getUserId().isBlank()
+                || request.getNewPassword() == null || request.getNewPassword().isBlank()
+                || request.getConfirmPassword() == null || request.getConfirmPassword().isBlank()) {
+            throw new IllegalArgumentException("userId, newPassword, and confirmPassword are required");
+        }
+        if (!request.getNewPassword().equals(request.getConfirmPassword())) {
+            throw new IllegalArgumentException("Passwords do not match");
+        }
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
@@ -1,0 +1,164 @@
+package com.e2eq.framework.rest.services;
+
+import com.e2eq.framework.model.auth.AuthProvider;
+import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.auth.RoleAssignment;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.RealmRepo;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.rest.models.AccessibleRealmInfo;
+import com.e2eq.framework.rest.models.AuthResponse;
+import com.e2eq.framework.rest.models.RestError;
+import com.e2eq.framework.util.EnvConfigUtils;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class AuthLoginService {
+
+    @Inject
+    AuthProviderFactory authProviderFactory;
+
+    @Inject
+    CredentialRepo credentialRepo;
+
+    @Inject
+    RealmRepo realmRepo;
+
+    @Inject
+    EnvConfigUtils envConfigUtils;
+
+    public LoginResult login(String userId, String password) {
+        return login(userId, password, null);
+    }
+
+    public LoginResult login(String userId, String password, String providerOverride) {
+        Optional<CredentialUserIdPassword> credentialOptional = findLoginCredential(userId);
+        List<AuthProvider> authProviders = authProviderFactory.getLoginProviders(
+                providerOverride,
+                credentialOptional.map(CredentialUserIdPassword::getAuthProviderName).orElse(null));
+
+        List<String> providerFailures = new ArrayList<>();
+        for (AuthProvider authProvider : authProviders) {
+            AuthProvider.LoginResponse loginResponse = authProvider.login(userId, password);
+            if (loginResponse.authenticated() && loginResponse.positiveResponse() != null) {
+                Optional<CredentialUserIdPassword> credentialOp = findCredential(
+                        loginResponse.positiveResponse().identity() != null
+                                && loginResponse.positiveResponse().identity().getPrincipal() != null
+                                ? loginResponse.positiveResponse().identity().getPrincipal().getName()
+                                : null,
+                        loginResponse.positiveResponse().userId());
+                AuthResponse response = toAuthResponse(authProvider, loginResponse, credentialOp.orElse(null));
+                return LoginResult.success(response);
+            }
+            providerFailures.add(loginFailure(authProvider, loginResponse));
+        }
+        return LoginResult.failure(providerFailures);
+    }
+
+    public Optional<CredentialUserIdPassword> findCredential(String subject, String userId) {
+        String systemRealm = envConfigUtils.getSystemRealm();
+        if (subject != null && !subject.isBlank()) {
+            Optional<CredentialUserIdPassword> bySubject = credentialRepo.findBySubject(subject, systemRealm, true);
+            if (bySubject.isPresent()) {
+                return bySubject;
+            }
+        }
+        if (userId != null && !userId.isBlank()) {
+            Optional<CredentialUserIdPassword> byUserId = credentialRepo.findByUserId(userId, systemRealm, true);
+            if (byUserId.isPresent()) {
+                return byUserId;
+            }
+        }
+        return Optional.empty();
+    }
+
+    public Optional<CredentialUserIdPassword> findLoginCredential(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            Optional<CredentialUserIdPassword> byUserId = credentialRepo.findByUserId(
+                    userId,
+                    envConfigUtils.getSystemRealm(),
+                    true);
+            if (byUserId.isPresent()) {
+                return byUserId;
+            }
+        } catch (RuntimeException e) {
+            Log.debugf("Unable to resolve login credential in system realm for %s: %s", userId, e.getMessage());
+        }
+        try {
+            return credentialRepo.findByUserId(userId);
+        } catch (RuntimeException e) {
+            Log.debugf("Unable to resolve login credential for %s: %s", userId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    public List<AccessibleRealmInfo> resolveAccessibleRealms(CredentialUserIdPassword credential) {
+        if (credential == null) {
+            return List.of();
+        }
+        return realmRepo.computeAllowedRealms(credential).stream()
+                .map(AccessibleRealmInfo::fromRealm)
+                .toList();
+    }
+
+    private AuthResponse toAuthResponse(
+            AuthProvider authProvider,
+            AuthProvider.LoginResponse loginResponse,
+            CredentialUserIdPassword credential) {
+        AuthProvider.LoginPositiveResponse positive = loginResponse.positiveResponse();
+        AuthResponse response = new AuthResponse();
+        response.setAccess_token(positive.accessToken());
+        response.setRefresh_token(positive.refreshToken());
+        response.setExpires_at(positive.expirationTime());
+        response.setMongodburl(positive.mongodbUrl());
+        response.setRealm(positive.realm());
+        response.setRoles(positive.roleAssignments().stream().map(RoleAssignment::toString).collect(Collectors.toList()));
+        response.setAuthProvider(authProvider.getName());
+        response.setAccessibleRealms(resolveAccessibleRealms(credential));
+        return response;
+    }
+
+    private String loginFailure(AuthProvider authProvider, AuthProvider.LoginResponse loginResponse) {
+        if (loginResponse != null && loginResponse.negativeResponse() != null) {
+            return authProvider.getName() + ": " + loginResponse.negativeResponse().errorMessage();
+        }
+        return authProvider.getName() + ": Authentication failed";
+    }
+
+    public record LoginResult(AuthResponse response, List<String> providerFailures) {
+        public static LoginResult success(AuthResponse response) {
+            return new LoginResult(response, List.of());
+        }
+
+        public static LoginResult failure(List<String> providerFailures) {
+            return new LoginResult(null, List.copyOf(providerFailures));
+        }
+
+        public boolean authenticated() {
+            return response != null;
+        }
+
+        public Response toResponse() {
+            if (authenticated()) {
+                return Response.ok(response).build();
+            }
+            RestError error = RestError.builder()
+                    .statusMessage("Authentication failed")
+                    .debugMessage(String.join("; ", providerFailures))
+                    .status(Response.Status.UNAUTHORIZED.getStatusCode())
+                    .build();
+            return Response.status(Response.Status.UNAUTHORIZED).entity(error).build();
+        }
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/startup/BaselineIdentityStartupService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/startup/BaselineIdentityStartupService.java
@@ -55,7 +55,17 @@ public class BaselineIdentityStartupService {
     @ConfigProperty(name = "quantum.defaultTestPassword", defaultValue = "test123!")
     String defaultDemoPassword;
 
+    /**
+     * When true, only the cross-tenant SYSTEM identity is seeded; the tenant-shaped
+     * admin@default-tenant and admin@test-tenant identities (and their tenant-admin groups)
+     * are skipped. Defaults to false so existing apps/tests retain the system + default-tenant +
+     * test-tenant admin behavior (non-breaking).
+     */
+    @ConfigProperty(name = "quantum.baseline-identity.seed-system-only", defaultValue = "false")
+    boolean seedSystemOnly;
+
     public void onStart() {
+        // The system identity is always seeded, in every mode.
         ensureSystemUser();
         ensureTenantAdmin(
                 "admin@" + envConfigUtils.getSystemTenantId(),
@@ -67,26 +77,30 @@ public class BaselineIdentityStartupService {
                         .accountId(envConfigUtils.getSystemAccountNumber())
                         .build()
         );
-        ensureTenantAdmin(
-                "admin@" + envConfigUtils.getDefaultTenantId(),
-                defaultDemoPassword,
-                DomainContext.builder()
-                        .tenantId(envConfigUtils.getDefaultTenantId())
-                        .orgRefName(envConfigUtils.getDefaultOrgRefName())
-                        .defaultRealm(envConfigUtils.getDefaultRealm())
-                        .accountId(envConfigUtils.getDefaultAccountNumber())
-                        .build()
-        );
-        ensureTenantAdmin(
-                "admin@" + envConfigUtils.getTestTenantId(),
-                defaultDemoPassword,
-                DomainContext.builder()
-                        .tenantId(envConfigUtils.getTestTenantId())
-                        .orgRefName(envConfigUtils.getTestOrgRefName())
-                        .defaultRealm(envConfigUtils.getTestRealm())
-                        .accountId(envConfigUtils.getTestAccountNumber())
-                        .build()
-        );
+        if (!seedSystemOnly) {
+            ensureTenantAdmin(
+                    "admin@" + envConfigUtils.getDefaultTenantId(),
+                    defaultDemoPassword,
+                    DomainContext.builder()
+                            .tenantId(envConfigUtils.getDefaultTenantId())
+                            .orgRefName(envConfigUtils.getDefaultOrgRefName())
+                            .defaultRealm(envConfigUtils.getDefaultRealm())
+                            .accountId(envConfigUtils.getDefaultAccountNumber())
+                            .build()
+            );
+            ensureTenantAdmin(
+                    "admin@" + envConfigUtils.getTestTenantId(),
+                    defaultDemoPassword,
+                    DomainContext.builder()
+                            .tenantId(envConfigUtils.getTestTenantId())
+                            .orgRefName(envConfigUtils.getTestOrgRefName())
+                            .defaultRealm(envConfigUtils.getTestRealm())
+                            .accountId(envConfigUtils.getTestAccountNumber())
+                            .build()
+            );
+        } else {
+            Log.info("BaselineIdentityStartupService: seed-system-only=true; skipping default/test tenant admins");
+        }
     }
 
     private void ensureSystemUser() {

--- a/quantum-framework/src/test/java/com/e2eq/framework/api/query/QueryGatewayGovernanceIT.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/api/query/QueryGatewayGovernanceIT.java
@@ -1,0 +1,247 @@
+package com.e2eq.framework.api.query;
+
+import com.e2eq.framework.model.persistent.base.CodeList;
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.persistent.morphia.MorphiaDataStoreWrapper;
+import com.e2eq.framework.model.security.Rule;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.SecurityURI;
+import com.e2eq.framework.model.securityrules.SecurityURIBody;
+import com.e2eq.framework.model.securityrules.SecurityURIHeader;
+import com.e2eq.framework.security.runtime.RuleContext;
+import com.e2eq.framework.security.runtime.SecuritySession;
+import com.e2eq.framework.util.TestUtils;
+import dev.morphia.MorphiaDatastore;
+import dev.morphia.query.filters.Filters;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Security regression tests for {@link QueryGatewayResource}.
+ *
+ * <p>These prove the gateway no longer bypasses row-level and field-level governance: the generic
+ * find/count/delete/deleteMany paths now AND the caller's query with the RuleContext-derived
+ * DataDomain scope (and strip excluded fields), so a principal can only see and mutate rows inside
+ * its own DataDomain.</p>
+ *
+ * <p>Two tenants are exercised: tenant A is the standard test tenant (principal has the {@code admin}
+ * role, whose default rule filters {@code dataDomain.tenantId:${pTenantId}}); tenant B is a synthetic
+ * tenant whose rows must never be visible/mutable to the tenant-A principal.</p>
+ *
+ * <p>Requires Mongo on :27017 (QuarkusTest harness).</p>
+ */
+@QuarkusTest
+public class QueryGatewayGovernanceIT {
+
+    @Inject
+    QueryGatewayResource resource;
+
+    @Inject
+    MorphiaDataStoreWrapper morphiaDataStoreWrapper;
+
+    @Inject
+    TestUtils testUtils;
+
+    @Inject
+    RuleContext ruleContext;
+
+    private String realm;
+    private String marker;
+
+    private DataDomain ddA;
+    private DataDomain ddB;
+    private PrincipalContext pcA;
+    private ResourceContext rc;
+
+    @BeforeEach
+    public void setUp() {
+        ruleContext.ensureDefaultRules();
+        realm = testUtils.getTestRealm();
+        marker = "gov-" + System.currentTimeMillis();
+        morphiaDataStoreWrapper.getDataStore(realm);
+
+        DataDomain base = testUtils.getTestPrincipalContext(testUtils.getTestUserId(), new String[]{"admin"}).getDataDomain();
+        ddA = new DataDomain(base.getOrgRefName(), base.getAccountNum(), base.getTenantId(), base.getDataSegment(), base.getOwnerId());
+        ddB = new DataDomain(base.getOrgRefName(), base.getAccountNum(), base.getTenantId() + "-OTHER", base.getDataSegment(), "ownerB");
+
+        pcA = testUtils.getTestPrincipalContext(testUtils.getTestUserId(), new String[]{"admin", "user"});
+        rc = testUtils.getResourceContext("integration", "query", "find");
+
+        seedRow(ddA, marker, "a1");
+        seedRow(ddA, marker, "a2");
+        seedRow(ddB, marker, "b1");
+    }
+
+    private CodeList seedRow(DataDomain dd, String category, String key) {
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realm);
+        CodeList cl = new CodeList();
+        cl.setCategory(category);
+        cl.setKey(key);
+        cl.setRefName(category + ":" + key);
+        cl.setDescription("secret-" + key);
+        cl.setValueType("STRING");
+        cl.setDataDomain(dd);
+        return ds.save(cl);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<CodeList> rowsOf(Response r) {
+        Object entity = r.getEntity();
+        assertNotNull(entity, "find response entity should not be null");
+        try {
+            var m = entity.getClass().getMethod("getRows");
+            return (List<CodeList>) m.invoke(entity);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to read rows from response envelope", e);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // (a) find/count return ONLY rows in the caller's DataDomain
+    // ------------------------------------------------------------------
+
+    @Test
+    public void find_returns_only_callers_dataDomain_rows() {
+        try (SecuritySession ignored = new SecuritySession(pcA, rc)) {
+            QueryGatewayResource.FindRequest req = new QueryGatewayResource.FindRequest();
+            req.rootType = CodeList.class.getName();
+            req.query = "category:" + marker;
+            req.realm = realm;
+
+            Response resp = resource.find(req);
+            assertEquals(200, resp.getStatus());
+            List<CodeList> rows = rowsOf(resp);
+
+            assertEquals(2, rows.size(), "find must return only the 2 tenant-A rows, not the tenant-B row");
+            for (CodeList row : rows) {
+                assertNotNull(row.getDataDomain());
+                assertEquals(ddA.getTenantId(), row.getDataDomain().getTenantId(),
+                        "no cross-tenant row may appear in results");
+            }
+        }
+    }
+
+    @Test
+    public void count_counts_only_callers_dataDomain_rows() {
+        try (SecuritySession ignored = new SecuritySession(pcA, rc)) {
+            QueryGatewayResource.CountRequest req = new QueryGatewayResource.CountRequest();
+            req.rootType = CodeList.class.getName();
+            req.query = "category:" + marker;
+            req.realm = realm;
+
+            Response resp = resource.count(req);
+            assertEquals(200, resp.getStatus());
+            QueryGatewayResource.CountResponse body = (QueryGatewayResource.CountResponse) resp.getEntity();
+            assertEquals(2L, body.count, "count must reflect only the 2 tenant-A rows");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // (b) excluded fields are stripped from results
+    // ------------------------------------------------------------------
+
+    @Test
+    public void find_strips_excluded_fields() {
+        SecurityURIHeader header = new SecurityURIHeader.Builder()
+                .withIdentity("admin").withArea("*").withFunctionalDomain("*").withAction("*").build();
+        SecurityURIBody body = new SecurityURIBody.Builder()
+                .withOrgRefName("*").withAccountNumber("*").withRealm("*")
+                .withTenantId("*").withOwnerId("*").withDataSegment("*").build();
+        Rule excludeRule = new Rule.Builder()
+                .withName("gateway-test-exclude-description-" + marker)
+                .withSecurityURI(new SecurityURI(header, body))
+                .withEffect(RuleEffect.ALLOW)
+                .withAndFilterString("dataDomain.tenantId:${pTenantId}")
+                .withExcludedFields(List.of("description"))
+                .withPriority(-50)
+                .withFinalRule(false)
+                .build();
+        ruleContext.addRule(header, excludeRule);
+        // Invalidate the realm's compiled rule index so the newly added rule (with its
+        // excludedFields) is recompiled into the effective rule set for this realm.
+        ruleContext.clearCacheForRealm(realm);
+        RuleContext.clearRequestCache();
+
+        try (SecuritySession ignored = new SecuritySession(pcA, rc)) {
+            // Precondition: the rule's excludedFields must resolve for this principal/resource,
+            // otherwise the test is asserting on rule-injection plumbing rather than the gateway.
+            java.util.Set<String> excluded = ruleContext.getExcludedFieldPaths(pcA, rc);
+            assertTrue(excluded.contains("description"),
+                    "expected RuleContext to resolve excluded field 'description'; got " + excluded);
+
+            QueryGatewayResource.FindRequest req = new QueryGatewayResource.FindRequest();
+            req.rootType = CodeList.class.getName();
+            req.query = "category:" + marker;
+            req.realm = realm;
+
+            Response resp = resource.find(req);
+            assertEquals(200, resp.getStatus());
+            List<CodeList> rows = rowsOf(resp);
+            assertFalse(rows.isEmpty(), "should still return the in-domain rows");
+            for (CodeList row : rows) {
+                assertNull(row.getDescription(),
+                        "excluded field 'description' must be stripped from gateway results");
+            }
+        } finally {
+            ruleContext.clear();
+            ruleContext.ensureDefaultRules();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // (c) delete / deleteMany cannot affect rows outside the caller's DataDomain
+    // ------------------------------------------------------------------
+
+    @Test
+    public void delete_by_id_cannot_remove_cross_dataDomain_row() {
+        CodeList bRow = seedRow(ddB, marker + "-del", "bDel");
+        String bId = bRow.getId().toHexString();
+
+        try (SecuritySession ignored = new SecuritySession(pcA, rc)) {
+            QueryGatewayResource.DeleteRequest req = new QueryGatewayResource.DeleteRequest();
+            req.rootType = CodeList.class.getName();
+            req.realm = realm;
+            req.id = bId;
+
+            Response resp = resource.delete(req);
+            assertEquals(404, resp.getStatus(), "tenant-A principal must not be able to delete a tenant-B row");
+        }
+
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realm);
+        CodeList still = ds.find(CodeList.class).filter(Filters.eq("_id", bRow.getId())).first();
+        assertNotNull(still, "tenant-B row must NOT have been deleted by the tenant-A principal");
+    }
+
+    @Test
+    public void deleteMany_cannot_remove_cross_dataDomain_rows() {
+        String delMarker = marker + "-dm";
+        seedRow(ddA, delMarker, "a1");
+        CodeList b1 = seedRow(ddB, delMarker, "b1");
+
+        try (SecuritySession ignored = new SecuritySession(pcA, rc)) {
+            QueryGatewayResource.DeleteManyRequest req = new QueryGatewayResource.DeleteManyRequest();
+            req.rootType = CodeList.class.getName();
+            req.realm = realm;
+            req.query = "category:" + delMarker;
+
+            Response resp = resource.deleteMany(req);
+            assertEquals(200, resp.getStatus());
+            QueryGatewayResource.DeleteManyResponse body = (QueryGatewayResource.DeleteManyResponse) resp.getEntity();
+            assertEquals(1L, body.deletedCount,
+                    "deleteMany must only delete the single tenant-A row, never the tenant-B row");
+        }
+
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realm);
+        CodeList stillB = ds.find(CodeList.class).filter(Filters.eq("_id", b1.getId())).first();
+        assertNotNull(stillB, "tenant-B row must survive a tenant-A deleteMany");
+    }
+}

--- a/quantum-framework/src/test/java/com/e2eq/framework/api/query/QueryGatewayResourceIT.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/api/query/QueryGatewayResourceIT.java
@@ -84,7 +84,8 @@ public class QueryGatewayResourceIT {
             .body("limit", is(10))
             .body("filter", is("category:*test*"));
 
-        // Aggregation with unresolved target collection should return 422 (since feature flag is on in tests)
+        // Aggregation/expand execution is gated off (501) because the secured $match for the
+        // aggregation path is not yet implemented; shipping it would bypass row/field governance.
         body.put("query", "expand(customer) && category:default");
         given()
             .contentType(ContentType.JSON)
@@ -92,8 +93,8 @@ public class QueryGatewayResourceIT {
         .when()
             .post("/api/query/find")
         .then()
-            .statusCode(422)
-            .body("error", is("UnresolvedCollection"));
+            .statusCode(501)
+            .body("error", is("NotImplemented"));
     }
 
     // ========================================================================

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/services/AuthCredentialServiceTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/services/AuthCredentialServiceTest.java
@@ -1,0 +1,324 @@
+package com.e2eq.framework.rest.services;
+
+import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
+import com.e2eq.framework.model.auth.AuthProvider;
+import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.auth.UserManagement;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.security.CredentialType;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.rest.models.ResetPasswordRequest;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AuthCredentialServiceTest {
+
+    @Test
+    void explicitProviderWins() {
+        TestAuthProviderFactory factory = new TestAuthProviderFactory();
+        TestUserManager defaultManager = new TestUserManager("custom", "https://custom.example.com");
+        TestUserManager oidcManager = new TestUserManager("oidc", "https://oidc.example.com");
+        factory.defaultManager = defaultManager;
+        factory.managers.put("oidc", oidcManager);
+
+        AuthCredentialService service = service(factory, Optional.empty());
+
+        assertSame(oidcManager, service.resolveUserManager("alice", "oidc"));
+    }
+
+    @Test
+    void credentialIssuerRoutesToMatchingProvider() {
+        TestAuthProviderFactory factory = new TestAuthProviderFactory();
+        TestUserManager defaultManager = new TestUserManager("custom", "https://custom.example.com");
+        TestUserManager oidcManager = new TestUserManager("oidc", "https://oidc.example.com");
+        factory.defaultManager = defaultManager;
+        factory.issuers.put("https://oidc.example.com", oidcManager);
+
+        CredentialUserIdPassword credential = credential("alice");
+        credential.setIssuer("https://oidc.example.com");
+        AuthCredentialService service = service(factory, Optional.of(credential));
+
+        assertSame(oidcManager, service.resolveUserManager("alice", null));
+    }
+
+    @Test
+    void credentialAuthProviderNameRoutesToNamedProvider() {
+        TestAuthProviderFactory factory = new TestAuthProviderFactory();
+        TestUserManager defaultManager = new TestUserManager("custom", "https://custom.example.com");
+        TestUserManager oidcManager = new TestUserManager("oidc", "https://oidc.example.com");
+        factory.defaultManager = defaultManager;
+        factory.managers.put("oidc", oidcManager);
+
+        CredentialUserIdPassword credential = credential("alice");
+        credential.setAuthProviderName("oidc");
+        AuthCredentialService service = service(factory, Optional.of(credential));
+
+        assertSame(oidcManager, service.resolveUserManager("alice", null));
+    }
+
+    @Test
+    void nonPasswordCredentialFallsBackToDefaultProvider() {
+        TestAuthProviderFactory factory = new TestAuthProviderFactory();
+        TestUserManager defaultManager = new TestUserManager("custom", "https://custom.example.com");
+        TestUserManager oidcManager = new TestUserManager("oidc", "https://oidc.example.com");
+        factory.defaultManager = defaultManager;
+        factory.managers.put("oidc", oidcManager);
+
+        CredentialUserIdPassword credential = credential("alice");
+        credential.setCredentialType(CredentialType.SERVICE_TOKEN);
+        credential.setAuthProviderName("oidc");
+        AuthCredentialService service = service(factory, Optional.of(credential));
+
+        assertSame(defaultManager, service.resolveUserManager("alice", null));
+    }
+
+    @Test
+    void resetPasswordUsesResolvedProviderAndValidatesRequest() {
+        TestAuthProviderFactory factory = new TestAuthProviderFactory();
+        TestUserManager defaultManager = new TestUserManager("custom", "https://custom.example.com");
+        TestUserManager oidcManager = new TestUserManager("oidc", "https://oidc.example.com");
+        factory.defaultManager = defaultManager;
+        factory.managers.put("oidc", oidcManager);
+
+        AuthCredentialService service = service(factory, Optional.empty());
+        ResetPasswordRequest request = resetPasswordRequest("alice", "newPassword123");
+        request.setAuthProvider("oidc");
+
+        service.resetPassword(request, "");
+
+        assertEquals("alice", oidcManager.resetUserId);
+        assertEquals("newPassword123", oidcManager.resetPassword);
+        assertEquals(false, oidcManager.resetForceChangePassword);
+        ResetPasswordRequest invalid = resetPasswordRequest("alice", "newPassword123");
+        invalid.setConfirmPassword("differentPassword123");
+        assertThrows(IllegalArgumentException.class,
+                () -> service.resetPassword(invalid, ""));
+    }
+
+    private static AuthCredentialService service(
+            TestAuthProviderFactory factory,
+            Optional<CredentialUserIdPassword> credential) {
+        AuthCredentialService service = new AuthCredentialService();
+        service.authProviderFactory = factory;
+        service.credentialRepo = new TestCredentialRepo(credential);
+        return service;
+    }
+
+    private static CredentialUserIdPassword credential(String userId) {
+        return CredentialUserIdPassword.builder()
+                .userId(userId)
+                .subject(userId + "-subject")
+                .lastUpdate(new Date())
+                .domainContext(DomainContext.builder()
+                        .tenantId("test-tenant")
+                        .defaultRealm("test-realm")
+                        .orgRefName("test-org")
+                        .accountId("test-account")
+                        .build())
+                .build();
+    }
+
+    private static ResetPasswordRequest resetPasswordRequest(String userId, String password) {
+        ResetPasswordRequest request = new ResetPasswordRequest();
+        request.setUserId(userId);
+        request.setNewPassword(password);
+        request.setConfirmPassword(password);
+        return request;
+    }
+
+    static class TestCredentialRepo extends CredentialRepo {
+        private final Optional<CredentialUserIdPassword> credential;
+
+        TestCredentialRepo(Optional<CredentialUserIdPassword> credential) {
+            this.credential = credential;
+        }
+
+        @Override
+        public Optional<CredentialUserIdPassword> findByUserId(String userId) {
+            return credential.filter(c -> c.getUserId().equals(userId));
+        }
+    }
+
+    static class TestAuthProviderFactory extends AuthProviderFactory {
+        TestUserManager defaultManager;
+        Map<String, TestUserManager> managers = new HashMap<>();
+        Map<String, TestUserManager> issuers = new HashMap<>();
+
+        @Override
+        public UserManagement getUserManager() {
+            return defaultManager;
+        }
+
+        @Override
+        public UserManagement getUserManager(String providerName) {
+            return managers.get(providerName);
+        }
+
+        @Override
+        public AuthProvider getProviderForIssuer(String issuer) {
+            return issuers.getOrDefault(issuer, defaultManager);
+        }
+    }
+
+    static class TestUserManager implements AuthProvider, UserManagement {
+        private final String name;
+        private final String issuer;
+        String resetUserId;
+        String resetPassword;
+        Boolean resetForceChangePassword;
+
+        TestUserManager(String name, String issuer) {
+            this.name = name;
+            this.issuer = issuer;
+        }
+
+        @Override
+        public SecurityIdentity validateAccessToken(String token) {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getIssuer() {
+            return issuer;
+        }
+
+        @Override
+        public LoginResponse login(String userId, String password) {
+            return null;
+        }
+
+        @Override
+        public LoginResponse refreshTokens(String refreshToken) {
+            return null;
+        }
+
+        @Override
+        public boolean removeUserWithSubject(String subject) throws ReferentialIntegrityViolationException {
+            return false;
+        }
+
+        @Override
+        public boolean removeUserWithUserId(String userId) throws ReferentialIntegrityViolationException {
+            return false;
+        }
+
+        @Override
+        public void assignRolesForUserId(String userId, Set<String> roles) throws SecurityException {}
+
+        @Override
+        public void assignRolesForSubject(String subject, Set<String> roles) throws SecurityException {}
+
+        @Override
+        public Set<String> getUserRolesForSubject(String subject) throws SecurityException {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> getUserRolesForUserId(String userId) throws SecurityException {
+            return Set.of();
+        }
+
+        @Override
+        public boolean userIdExists(String userId) throws SecurityException {
+            return false;
+        }
+
+        @Override
+        public boolean subjectExists(String subject) throws SecurityException {
+            return false;
+        }
+
+        @Override
+        public String createUser(String userId, String password, Set<String> roles, DomainContext domainContext) throws SecurityException {
+            return null;
+        }
+
+        @Override
+        public String createUser(String userId, String password, Boolean forceChangePassword, Set<String> roles, DomainContext domainContext) throws SecurityException {
+            return null;
+        }
+
+        @Override
+        public String createUser(String userId, String password, Set<String> roles, DomainContext domainContext, DataDomain dataDomain) throws SecurityException {
+            return null;
+        }
+
+        @Override
+        public String createUser(String userId, String password, Boolean forceChangePassword, Set<String> roles, DomainContext domainContext, DataDomain dataDomain) throws SecurityException {
+            return null;
+        }
+
+        @Override
+        public Optional<String> getSubjectForUserId(String userId) throws SecurityException {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> getUserIdForSubject(String subject) throws SecurityException {
+            return Optional.empty();
+        }
+
+        @Override
+        public void changePassword(String userId, String oldPassword, String newPassword, Boolean forceChangePassword) {}
+
+        @Override
+        public void resetPassword(String userId, String newPassword, Boolean forceChangePassword) {
+            resetUserId = userId;
+            resetPassword = newPassword;
+            resetForceChangePassword = forceChangePassword;
+        }
+
+        @Override
+        public void changeEmail(String userId, String newEmail) throws SecurityException {}
+
+        @Override
+        public void resendTemporaryPassword(String userId) throws SecurityException {}
+
+        @Override
+        public void removeRolesForSubject(String subject, Set<String> roles) throws SecurityException {}
+
+        @Override
+        public void removeRolesForUserId(String userId, Set<String> roles) throws SecurityException {}
+
+        @Override
+        public void enableImpersonationWithUserId(String userId, String impersonationScript, String realmFilter, String realmToEnableIn) {}
+
+        @Override
+        public void enableImpersonationWithSubject(String subject, String impersonationScript, String realmFilter, String realmToEnableIn) {}
+
+        @Override
+        public void disableImpersonationWithSubject(String subject) {}
+
+        @Override
+        public void disableImpersonationWithUserId(String userId) {}
+
+        @Override
+        public void enableRealmOverrideWithUserId(String userId, String regexForRealm) {}
+
+        @Override
+        public void enableRealmOverrideWithSubject(String subject, String regexForRealm) {}
+
+        @Override
+        public void disableRealmOverrideWithUserId(String userId) {}
+
+        @Override
+        public void disableRealmOverrideWithSubject(String subject) {}
+    }
+}

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/startup/BaselineIdentitySeedSystemOnlyTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/startup/BaselineIdentitySeedSystemOnlyTest.java
@@ -1,0 +1,207 @@
+package com.e2eq.framework.service.startup;
+
+import com.e2eq.framework.model.auth.AuthProvider;
+import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.UserGroupRepo;
+import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.model.security.UserGroup;
+import com.e2eq.framework.model.security.UserProfile;
+import com.e2eq.framework.util.EnvConfigUtils;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit-level coverage for the {@code quantum.baseline-identity.seed-system-only} guard in
+ * {@link BaselineIdentityStartupService}.
+ *
+ * <p>Mirrors the dependency-recording style of
+ * {@code com.e2eq.framework.bootstrap.runtime.BootstrapPackStartupRunnerTest}: the service is
+ * constructed directly with hand-written recording repositories so the test runs without Quarkus
+ * or Mongo. {@code SecurityCallScope} is pure ThreadLocal, so the production code paths run as-is.
+ */
+class BaselineIdentitySeedSystemOnlyTest {
+
+    @Test
+    void defaultSeedsSystemAndDefaultAndTestAdmins() {
+        RecordingCredentialRepo credentialRepo = new RecordingCredentialRepo();
+        RecordingUserProfileRepo userProfileRepo = new RecordingUserProfileRepo();
+        RecordingUserGroupRepo userGroupRepo = new RecordingUserGroupRepo();
+
+        BaselineIdentityStartupService service = newService(false, credentialRepo, userProfileRepo, userGroupRepo);
+        service.onStart();
+
+        // System user is always seeded.
+        assertTrue(credentialRepo.savedUserIds().contains("system@system.com"),
+                "system user must be seeded in default mode");
+        // System-tenant admin + default-tenant + test-tenant admins are all seeded in default mode.
+        assertTrue(credentialRepo.savedUserIds().contains("admin@system.com"),
+                "system-tenant admin must be seeded in default mode");
+        assertTrue(credentialRepo.savedUserIds().contains("admin@mycompanyxyz.com"),
+                "default-tenant admin must be seeded in default mode");
+        assertTrue(credentialRepo.savedUserIds().contains("admin@test-quantum.com"),
+                "test-tenant admin must be seeded in default mode");
+
+        // Tenant-admin groups are created for the tenant admins (default + test realms at minimum).
+        assertTrue(userGroupRepo.savedRealms().contains("mycompanyxyz-com"),
+                "tenant-admin group expected for default realm in default mode");
+        assertTrue(userGroupRepo.savedRealms().contains("test-quantum-com"),
+                "tenant-admin group expected for test realm in default mode");
+    }
+
+    @Test
+    void seedSystemOnlySeedsOnlySystemIdentity() {
+        RecordingCredentialRepo credentialRepo = new RecordingCredentialRepo();
+        RecordingUserProfileRepo userProfileRepo = new RecordingUserProfileRepo();
+        RecordingUserGroupRepo userGroupRepo = new RecordingUserGroupRepo();
+
+        BaselineIdentityStartupService service = newService(true, credentialRepo, userProfileRepo, userGroupRepo);
+        service.onStart();
+
+        // System user IS still created under system-only.
+        assertTrue(credentialRepo.savedUserIds().contains("system@system.com"),
+                "system user MUST still be seeded under seed-system-only");
+        // The system-tenant admin is part of the system identity and remains seeded.
+        assertTrue(credentialRepo.savedUserIds().contains("admin@system.com"),
+                "system-tenant admin remains seeded under seed-system-only");
+
+        // No tenant-shaped (default/test) admins.
+        assertFalse(credentialRepo.savedUserIds().contains("admin@mycompanyxyz.com"),
+                "default-tenant admin must NOT be seeded under seed-system-only");
+        assertFalse(credentialRepo.savedUserIds().contains("admin@test-quantum.com"),
+                "test-tenant admin must NOT be seeded under seed-system-only");
+
+        // No tenant-admin groups for default/test realms.
+        assertFalse(userGroupRepo.savedRealms().contains("mycompanyxyz-com"),
+                "no default-realm tenant-admin group under seed-system-only");
+        assertFalse(userGroupRepo.savedRealms().contains("test-quantum-com"),
+                "no test-realm tenant-admin group under seed-system-only");
+    }
+
+    // ---- helpers ----------------------------------------------------------------------------
+
+    private static BaselineIdentityStartupService newService(boolean seedSystemOnly,
+                                                             RecordingCredentialRepo credentialRepo,
+                                                             RecordingUserProfileRepo userProfileRepo,
+                                                             RecordingUserGroupRepo userGroupRepo) {
+        BaselineIdentityStartupService service = new BaselineIdentityStartupService();
+        service.authProviderFactory = new StubAuthProviderFactory();
+        service.credentialRepo = credentialRepo;
+        service.userProfileRepo = userProfileRepo;
+        service.userGroupRepo = userGroupRepo;
+        service.envConfigUtils = env();
+        service.defaultSystemPassword = "test123456";
+        service.defaultDemoPassword = "test123!";
+        service.seedSystemOnly = seedSystemOnly;
+        return service;
+    }
+
+    private static EnvConfigUtils env() {
+        EnvConfigUtils utils = new EnvConfigUtils();
+        utils.setSystemRealm("system-com");
+        utils.setSystemTenantId("system.com");
+        utils.setSystemOrgRefName("system.com");
+        utils.setSystemAccountNumber("0000000000");
+        utils.setSystemUserId("system@system.com");
+        utils.setDefaultRealm("mycompanyxyz-com");
+        utils.setDefaultTenantId("mycompanyxyz.com");
+        utils.setDefaultOrgRefName("mycompanyxyz.com");
+        utils.setDefaultAccountNumber("9999999999");
+        utils.setTestRealm("test-quantum-com");
+        utils.setTestTenantId("test-quantum.com");
+        utils.setTestOrgRefName("test-quantum.com");
+        utils.setTestAccountNumber("0000000001");
+        return utils;
+    }
+
+    private static final class StubAuthProviderFactory extends AuthProviderFactory {
+        @Override
+        public AuthProvider getAuthProvider() {
+            return new AuthProvider() {
+                @Override
+                public SecurityIdentity validateAccessToken(String token) {
+                    return null;
+                }
+
+                @Override
+                public String getName() {
+                    return "custom";
+                }
+
+                @Override
+                public LoginResponse login(String userId, String password) {
+                    return null;
+                }
+
+                @Override
+                public LoginResponse refreshTokens(String refreshToken) {
+                    return null;
+                }
+            };
+        }
+    }
+
+    private static final class RecordingCredentialRepo extends CredentialRepo {
+        // userId -> stored credential (so the second findByUserId after create returns it)
+        private final Map<String, CredentialUserIdPassword> store = new LinkedHashMap<>();
+        private final List<String> saved = new ArrayList<>();
+
+        List<String> savedUserIds() {
+            return saved;
+        }
+
+        @Override
+        public Optional<CredentialUserIdPassword> findByUserId(String userId, String realmId, boolean ignoreRules) {
+            return Optional.ofNullable(store.get(userId));
+        }
+
+        @Override
+        public CredentialUserIdPassword save(String realmId, CredentialUserIdPassword value) {
+            store.put(value.getUserId(), value);
+            saved.add(value.getUserId());
+            return value;
+        }
+    }
+
+    private static final class RecordingUserProfileRepo extends UserProfileRepo {
+        @Override
+        public Optional<UserProfile> getByUserIdWithIgnoreRules(String realm, String userId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public UserProfile persistStartupProfile(String realm, UserProfile profile) {
+            return profile;
+        }
+    }
+
+    private static final class RecordingUserGroupRepo extends UserGroupRepo {
+        private final List<String> savedRealms = new ArrayList<>();
+
+        List<String> savedRealms() {
+            return savedRealms;
+        }
+
+        @Override
+        public Optional<UserGroup> findByRefName(String refName, String realmId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public UserGroup save(String realmId, UserGroup value) {
+            savedRealms.add(realmId);
+            return value;
+        }
+    }
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProviderFactory.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProviderFactory.java
@@ -8,10 +8,17 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
 @ApplicationScoped
 public class AuthProviderFactory {
 
-    @ConfigProperty(name = "auth.provider")
+    public static final String DEFAULT_AUTH_PROVIDER_CHAIN = "custom,oidc";
+
+    @ConfigProperty(name = "auth.provider", defaultValue = DEFAULT_AUTH_PROVIDER_CHAIN)
     String configuredAuthProviders; // supports comma-separated list (for example "custom,oidc")
 
     @Inject
@@ -24,20 +31,114 @@ public class AuthProviderFactory {
      * Backward compatible — single-value config works as before.
      */
     public AuthProvider getAuthProvider() {
-        String firstName = configuredAuthProviders.split(",")[0].trim();
-        return getProviderByName(firstName);
+        for (String providerName : getConfiguredProviderNames()) {
+            Optional<AuthProvider> provider = findProviderByName(providerName);
+            if (provider.isPresent()) {
+                return provider.get();
+            }
+        }
+        throw new IllegalArgumentException(String.format(
+                "None of the configured auth providers are available: %s", getConfiguredProviderNames()));
+    }
+
+    public List<String> getConfiguredProviderNames() {
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        if (configuredAuthProviders != null) {
+            for (String part : configuredAuthProviders.split(",")) {
+                String name = part == null ? "" : part.trim();
+                if (!name.isBlank()) {
+                    names.add(name);
+                }
+            }
+        }
+        if (names.isEmpty()) {
+            for (String part : DEFAULT_AUTH_PROVIDER_CHAIN.split(",")) {
+                String name = part.trim();
+                if (!name.isBlank()) {
+                    names.add(name);
+                }
+            }
+        }
+        return new ArrayList<>(names);
+    }
+
+    /**
+     * Returns the auth providers discovered by CDI.
+     *
+     * <p>This is the canonical runtime inventory of provider implementations
+     * visible to the factory. Configuration may name additional providers, but
+     * login can only use providers that are present here.</p>
+     */
+    public List<AuthProvider> getDiscoveredProviders() {
+        List<AuthProvider> discovered = new ArrayList<>();
+        for (AuthProvider authProvider : authProviders) {
+            discovered.add(authProvider);
+        }
+        return discovered;
+    }
+
+    public List<String> getDiscoveredProviderNames() {
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        for (AuthProvider authProvider : getDiscoveredProviders()) {
+            names.add(authProvider.getName());
+        }
+        return new ArrayList<>(names);
+    }
+
+    /**
+     * Returns the login providers to try for a user-facing login attempt.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>Explicit request provider, when supplied. This disables fallback.</li>
+     *   <li>Credential-level provider override, when supplied. This must exist.</li>
+     *   <li>Configured provider list from {@code auth.provider}, in order. Missing
+     *       configured providers are skipped so open-source services can list optional
+     *       enterprise providers without depending on their jars.</li>
+     * </ol>
+     */
+    public List<AuthProvider> getLoginProviders(String requestedProviderName, String credentialProviderName) {
+        if (requestedProviderName != null && !requestedProviderName.isBlank()) {
+            return List.of(getProviderByName(requestedProviderName));
+        }
+
+        List<AuthProvider> providers = new ArrayList<>();
+        if (credentialProviderName != null && !credentialProviderName.isBlank()) {
+            providers.add(getProviderByName(credentialProviderName));
+        }
+
+        LinkedHashSet<String> configuredNames = new LinkedHashSet<>(getConfiguredProviderNames());
+        if (credentialProviderName != null && !credentialProviderName.isBlank()) {
+            configuredNames.removeIf(name -> name.equalsIgnoreCase(credentialProviderName.trim()));
+        }
+        for (String name : configuredNames) {
+            findProviderByName(name).ifPresent(providers::add);
+        }
+        if (providers.isEmpty()) {
+            throw new IllegalArgumentException(String.format(
+                    "None of the configured auth providers are available: %s", getConfiguredProviderNames()));
+        }
+        return providers;
     }
 
     /**
      * Look up a specific provider by name.
      */
     public AuthProvider getProviderByName(String name) {
+        return findProviderByName(name).orElseThrow(() ->
+                new IllegalArgumentException(String.format("AuthProvider:%s was not found", name)));
+    }
+
+    public Optional<AuthProvider> findProviderByName(String name) {
+        if (name == null || name.isBlank()) {
+            return Optional.empty();
+        }
         for (AuthProvider authProvider : authProviders) {
             if (authProvider.getName().equalsIgnoreCase(name.trim())) {
-                return authProvider;
+                return Optional.of(authProvider);
             }
         }
-        throw new IllegalArgumentException(String.format("AuthProvider:%s was not found", name));
+        return Optional.empty();
     }
 
     /**
@@ -47,9 +148,11 @@ public class AuthProviderFactory {
     public AuthProvider getProviderForIssuer(String issuer) {
         if (issuer == null) return getAuthProvider();
 
-        for (String providerName : configuredAuthProviders.split(",")) {
-            AuthProvider p = getProviderByName(providerName.trim());
-            if (issuer.equals(p.getIssuer())) return p;
+        for (String providerName : getConfiguredProviderNames()) {
+            Optional<AuthProvider> provider = findProviderByName(providerName);
+            if (provider.isPresent() && issuer.equals(provider.get().getIssuer())) {
+                return provider.get();
+            }
         }
         // No match — fall back to default provider
         return getAuthProvider();

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/DataDomainComponentBinding.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/DataDomainComponentBinding.java
@@ -1,0 +1,72 @@
+package com.e2eq.framework.model.security;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.Data;
+
+/**
+ * Describes how each component of a {@link com.e2eq.framework.model.persistent.base.DataDomain}
+ * is derived when resolving placement for a source/ingestion write
+ * ({@link DataDomainPolicyEntry.ResolutionMode#FROM_SOURCE}).
+ *
+ * <p>Each component is a small union ({@link Binding}) of either a literal value, fixed at
+ * configuration time (typically because it is bound to the source itself, e.g. orgRefName /
+ * accountNum), or a reference to a named attribute of the ingested row whose value is read at
+ * resolution time (e.g. {@code tenantId = fromAttribute("tenant_id")}).</p>
+ *
+ * <p>Typical configuration:
+ * <ul>
+ *   <li>{@code orgRefName} / {@code accountNum} = literal (source-bound)</li>
+ *   <li>{@code tenantId} = fromAttribute("tenant_id")</li>
+ *   <li>{@code dataSegment} = literal("0") (default)</li>
+ *   <li>{@code ownerId} = literal("system") (default)</li>
+ * </ul>
+ * </p>
+ */
+@Entity
+@RegisterForReflection
+public @Data class DataDomainComponentBinding {
+
+    public enum Kind {
+        LITERAL,
+        FROM_ATTRIBUTE
+    }
+
+    /**
+     * A single component binding: either a literal value or a reference to a named source
+     * attribute. {@code literalValue} is significant iff {@code kind == LITERAL};
+     * {@code attributeName} is significant iff {@code kind == FROM_ATTRIBUTE}.
+     */
+    @Entity
+    @RegisterForReflection
+    public static @Data class Binding {
+        protected Kind kind = Kind.LITERAL;
+        // Significant iff kind == LITERAL. Stored as String; coerced to the target component type.
+        protected String literalValue;
+        // Significant iff kind == FROM_ATTRIBUTE. Name of the source-row attribute to read.
+        protected String attributeName;
+
+        public Binding() {
+        }
+
+        public Binding(Kind kind, String literalValue, String attributeName) {
+            this.kind = kind;
+            this.literalValue = literalValue;
+            this.attributeName = attributeName;
+        }
+
+        public static Binding literal(String value) {
+            return new Binding(Kind.LITERAL, value, null);
+        }
+
+        public static Binding fromAttribute(String attributeName) {
+            return new Binding(Kind.FROM_ATTRIBUTE, null, attributeName);
+        }
+    }
+
+    protected Binding orgRefName;
+    protected Binding accountNum;
+    protected Binding tenantId;
+    protected Binding dataSegment;
+    protected Binding ownerId;
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/DataDomainPolicyEntry.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/DataDomainPolicyEntry.java
@@ -12,7 +12,14 @@ public @Data class DataDomainPolicyEntry {
 
     public enum ResolutionMode {
         FROM_CREDENTIAL,
-        FIXED
+        FIXED,
+        /**
+         * Derive the DataDomain from the values of the ingested source row plus the
+         * source binding metadata (see {@link #componentBinding}). Used by the
+         * source/ingestion write path where there is no authenticated principal to
+         * supply a DataDomain. Only meaningful when {@link #componentBinding} is set.
+         */
+        FROM_SOURCE
     }
 
     // Optional legacy fields – kept for compatibility with existing structures
@@ -27,4 +34,15 @@ public @Data class DataDomainPolicyEntry {
 
     // New: how to resolve the dataDomain for a matching rule. Defaults to FROM_CREDENTIAL
     protected ResolutionMode resolutionMode = ResolutionMode.FROM_CREDENTIAL;
+
+    /**
+     * Per-component binding used iff {@link #resolutionMode} == {@link ResolutionMode#FROM_SOURCE}.
+     * Describes how each DataDomain component (orgRefName, accountNum, tenantId, dataSegment,
+     * ownerId) is derived from either a literal value or an attribute of the ingested source row.
+     *
+     * <p>Nullable: existing stored policy JSON predates this field and will deserialize with
+     * {@code componentBinding == null}; such entries are never {@code FROM_SOURCE} and retain
+     * today's behavior.</p>
+     */
+    protected DataDomainComponentBinding componentBinding;
 }

--- a/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/ResourceContext.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/ResourceContext.java
@@ -1,11 +1,15 @@
 package com.e2eq.framework.model.securityrules;
 
+import com.e2eq.framework.model.persistent.base.DataDomain;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.graalvm.polyglot.HostAccess;
 
 import jakarta.validation.constraints.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -24,6 +28,8 @@ public class ResourceContext {
   protected @NotNull String action;             // the action we are trying to take
   protected String resourceId; // the id (objectId) if known
   protected String ownerId; // the id (ownerId) if known
+  protected DataDomain dataDomain; // effective data-domain attributes for this resource access
+  protected Map<String, Object> attributes; // optional extension attributes for policy/debug consumers
 
    public static ResourceContext DEFAULT_ANONYMOUS_CONTEXT = new ResourceContext("NONE", "NONE", "NONE", "NONE", null, null);
 
@@ -33,6 +39,17 @@ public class ResourceContext {
                    @NotNull(message="action can not be null") String action,
                    String resourceId,
                    String ownerId) {
+      this(realm, area, functionalDomain, action, resourceId, ownerId, null, Collections.emptyMap());
+   }
+
+   ResourceContext(@NotNull(message="realmId can not be null") String realm,
+                   @NotNull(message="area can not be null") String area,
+                   @NotNull(message="functional domain can not be null") String functionalDomain,
+                   @NotNull(message="action can not be null") String action,
+                   String resourceId,
+                   String ownerId,
+                   DataDomain dataDomain,
+                   Map<String, Object> attributes) {
       Objects.requireNonNull(realm, "realm can not be null");
       Objects.requireNonNull(area, "area can not be null");
       Objects.requireNonNull(functionalDomain, "functionalDomain can not be null");
@@ -45,6 +62,10 @@ public class ResourceContext {
       this.action = action.toLowerCase();
       this.resourceId = resourceId != null ? resourceId.toLowerCase() : null;
       this.ownerId = ownerId!= null ? ownerId.toLowerCase() : null;
+      this.dataDomain = dataDomain;
+      this.attributes = attributes == null || attributes.isEmpty()
+              ? Collections.emptyMap()
+              : Collections.unmodifiableMap(new HashMap<>(attributes));
    }
 
    public static class Builder {
@@ -56,6 +77,8 @@ public class ResourceContext {
       String action = any;
       String resourceId = any;
       String ownerId = any;
+      DataDomain dataDomain = null;
+      Map<String, Object> attributes = new HashMap<>();
 
       public Builder withRealm(String realm) {
          this.realm = realm.toLowerCase();
@@ -86,9 +109,28 @@ public class ResourceContext {
            return this;
        }
 
+      public Builder withDataDomain(DataDomain dataDomain) {
+         this.dataDomain = dataDomain;
+         return this;
+      }
+
+      public Builder withAttributes(Map<String, Object> attributes) {
+         if (attributes != null) {
+            this.attributes = new HashMap<>(attributes);
+         }
+         return this;
+      }
+
+      public Builder withAttribute(String key, Object value) {
+         if (key != null && !key.isBlank() && value != null) {
+            this.attributes.put(key, value);
+         }
+         return this;
+      }
+
       public ResourceContext build() {
          return new ResourceContext( realm, area,
-            functionalDomain, action, resourceId, ownerId);
+            functionalDomain, action, resourceId, ownerId, dataDomain, attributes);
       }
    };
 
@@ -137,6 +179,30 @@ public class ResourceContext {
    public void setOwnerId (String ownerId) {this.ownerId = ownerId.toLowerCase();}
 
    @HostAccess.Export
+   public @Nullable DataDomain getDataDomain() {
+      return dataDomain;
+   }
+
+   public void setDataDomain(DataDomain dataDomain) {
+      this.dataDomain = dataDomain;
+   }
+
+   @HostAccess.Export
+   public Map<String, Object> getAttributes() {
+      return attributes == null ? Collections.emptyMap() : attributes;
+   }
+
+   public void setAttributes(Map<String, Object> attributes) {
+      this.attributes = attributes == null || attributes.isEmpty()
+              ? Collections.emptyMap()
+              : Collections.unmodifiableMap(new HashMap<>(attributes));
+   }
+
+   public ResourceContext withDataDomain(DataDomain dataDomain) {
+      return new ResourceContext(realm, area, functionalDomain, action, resourceId, ownerId, dataDomain, attributes);
+   }
+
+   @HostAccess.Export
    @Override
    public boolean equals (Object o) {
       if (this == o) return true;
@@ -173,6 +239,8 @@ public class ResourceContext {
                 ", action='" + action + '\'' +
                 ", resourceId='" + resourceId + '\'' +
                 ", ownerId='" + ownerId + '\'' +
+                ", dataDomain='" + dataDomain + '\'' +
+                ", attributes='" + attributes + '\'' +
                 '}';
    }
 }

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthResponse.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthResponse.java
@@ -1,5 +1,6 @@
 package com.e2eq.framework.rest.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -27,5 +28,20 @@ public class AuthResponse {
         this.access_token = access_token;
         this.refresh_token = refresh_token;
         this.expires_at = expires_at;
+    }
+
+    @JsonProperty("accessToken")
+    public String getAccessToken() {
+        return access_token;
+    }
+
+    @JsonProperty("refreshToken")
+    public String getRefreshToken() {
+        return refresh_token;
+    }
+
+    @JsonProperty("expiresAt")
+    public long getExpiresAt() {
+        return expires_at;
     }
 }

--- a/quantum-models/src/test/java/com/e2eq/framework/model/auth/AuthProviderFactoryTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/auth/AuthProviderFactoryTest.java
@@ -1,0 +1,34 @@
+package com.e2eq.framework.model.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthProviderFactoryTest {
+
+    @Test
+    void missingProviderConfigDefaultsToCustomOidcChain() {
+        AuthProviderFactory factory = new AuthProviderFactory();
+        factory.configuredAuthProviders = null;
+
+        assertEquals(List.of("custom", "oidc"), factory.getConfiguredProviderNames());
+    }
+
+    @Test
+    void blankProviderConfigDefaultsToCustomOidcChain() {
+        AuthProviderFactory factory = new AuthProviderFactory();
+        factory.configuredAuthProviders = " , ";
+
+        assertEquals(List.of("custom", "oidc"), factory.getConfiguredProviderNames());
+    }
+
+    @Test
+    void configuredProviderChainPreservesOrderAndDedupes() {
+        AuthProviderFactory factory = new AuthProviderFactory();
+        factory.configuredAuthProviders = " oidc, custom, oidc ";
+
+        assertEquals(List.of("oidc", "custom"), factory.getConfiguredProviderNames());
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/changesets/AddRealms.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/changesets/AddRealms.java
@@ -54,6 +54,13 @@ public class AddRealms extends ChangeSetBase {
    @ConfigProperty(name = "quantum.realmConfig.testAccountNumber", defaultValue = "0000000001")
    String testAccountNumber;
 
+   /**
+    * When true, only the cross-tenant SYSTEM realm is seeded; the tenant-shaped TEST realm is skipped.
+    * Defaults to false so existing apps/tests retain the system + test realm behavior (non-breaking).
+    */
+   @ConfigProperty(name = "quantum.realm.seed-system-only", defaultValue = "false")
+   boolean seedSystemOnly;
+
 
     @Override
     public String getId() {
@@ -136,25 +143,30 @@ public class AddRealms extends ChangeSetBase {
         Log.info(".  Added system-com realm Successfully");
         emitter.emit(".  Added system-com realm Successfully");
 
-        // now add the test-quantum-com realm as well
-        domainContext = DomainContext.builder()
-                .tenantId(testTenantId)
-                .orgRefName(testOrgRefName)
-                .defaultRealm(testRealm)
-                .accountId(testAccountNumber)
-                .build();
-        realm = Realm.builder()
-                .refName(testRealm)
-                .displayName(testRealm)
-                .emailDomain(testTenantId)
-                .databaseName(testRealm)
-                .domainContext(domainContext)
-                .defaultPerspective("TENANT_ADMIN")
-                .build();
-        saveOrUpdateRealm(session, realm);
+        if (!seedSystemOnly) {
+            // now add the test-quantum-com realm as well
+            domainContext = DomainContext.builder()
+                    .tenantId(testTenantId)
+                    .orgRefName(testOrgRefName)
+                    .defaultRealm(testRealm)
+                    .accountId(testAccountNumber)
+                    .build();
+            realm = Realm.builder()
+                    .refName(testRealm)
+                    .displayName(testRealm)
+                    .emailDomain(testTenantId)
+                    .databaseName(testRealm)
+                    .domainContext(domainContext)
+                    .defaultPerspective("TENANT_ADMIN")
+                    .build();
+            saveOrUpdateRealm(session, realm);
 
-       Log.info(".  Added test-quantum-com realm Successfully");
-       emitter.emit(".  Added test-quantum-com realm Successfully");
+            Log.info(".  Added test-quantum-com realm Successfully");
+            emitter.emit(".  Added test-quantum-com realm Successfully");
+        } else {
+            Log.info(".  Skipping test realm creation (quantum.realm.seed-system-only=true)");
+            emitter.emit(".  Skipping test realm creation (quantum.realm.seed-system-only=true)");
+        }
     }
 
     private void saveOrUpdateRealm(MorphiaSession session, Realm desiredRealm) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolution.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolution.java
@@ -1,0 +1,95 @@
+package com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+
+/**
+ * Tagged result of resolving an ingest row to a DataDomain placement.
+ *
+ * <p>This type replaces the S1 in-band {@code UNRESOLVABLE} look-alike sentinel for the governed
+ * ingest path (S3). The S1 sentinel was a real-looking {@link DataDomain} instance whose ONLY
+ * distinguishing property was object identity ({@code ==}). The S1 code_review flagged that as
+ * fail-OPEN-fragile: any code that clones, serializes/round-trips, or value-copies a DataDomain
+ * (which Morphia, Jackson, and the repo's own clone-on-insert all do) would produce an
+ * UNRESOLVABLE-VALUED domain that is NOT {@code ==} the sentinel — so the {@code ==} quarantine
+ * check would silently pass it through and STAMP a "__UNRESOLVABLE__" placement as if it were a
+ * real, governed domain.</p>
+ *
+ * <p>Here the "could not place this row" decision is carried by the TYPE TAG
+ * ({@link Unresolvable}), never by the contents of a DataDomain. There is no DataDomain instance
+ * at all in the unresolvable case, so there is nothing to clone, round-trip, or mis-compare: a
+ * caller MUST branch on {@link #isResolved()} (or pattern-match the subtype) to obtain a
+ * DataDomain, and the only way to get one is the {@link Resolved} arm. Fail-closed by construction.</p>
+ */
+public abstract sealed class DataDomainResolution
+        permits DataDomainResolution.Resolved, DataDomainResolution.Unresolvable {
+
+    private DataDomainResolution() { }
+
+    /** True iff this is a {@link Resolved} placement carrying a concrete DataDomain. */
+    public abstract boolean isResolved();
+
+    /**
+     * The resolved DataDomain.
+     * @throws IllegalStateException if this is {@link Unresolvable} — callers MUST check
+     *         {@link #isResolved()} first, which is the whole point of the tag.
+     */
+    public abstract DataDomain dataDomain();
+
+    /** The reason this row could not be placed, or {@code null} when {@link #isResolved()}. */
+    public abstract String reason();
+
+    public static DataDomainResolution resolved(DataDomain dataDomain) {
+        if (dataDomain == null) {
+            throw new IllegalArgumentException("Resolved DataDomainResolution requires a non-null DataDomain");
+        }
+        return new Resolved(dataDomain);
+    }
+
+    public static DataDomainResolution unresolvable(String reason) {
+        return new Unresolvable(reason == null ? "unresolvable" : reason);
+    }
+
+    /** A successful placement carrying the concrete DataDomain to stamp. */
+    public static final class Resolved extends DataDomainResolution {
+        private final DataDomain dataDomain;
+
+        private Resolved(DataDomain dataDomain) {
+            this.dataDomain = dataDomain;
+        }
+
+        @Override public boolean isResolved() { return true; }
+        @Override public DataDomain dataDomain() { return dataDomain; }
+        @Override public String reason() { return null; }
+
+        @Override public String toString() {
+            return "Resolved[" + dataDomain + "]";
+        }
+    }
+
+    /**
+     * A failed placement: the row could NOT be governed into a DataDomain. There is deliberately
+     * no DataDomain field — the quarantine decision can never be defeated by a cloned/round-tripped
+     * look-alike value.
+     */
+    public static final class Unresolvable extends DataDomainResolution {
+        private final String reason;
+
+        private Unresolvable(String reason) {
+            this.reason = reason;
+        }
+
+        @Override public boolean isResolved() { return false; }
+
+        @Override public DataDomain dataDomain() {
+            throw new IllegalStateException(
+                    "DataDomainResolution is Unresolvable (" + reason + "); no DataDomain to stamp — "
+                  + "callers must check isResolved() and quarantine instead");
+        }
+
+        @Override public String reason() { return reason; }
+
+        @Override public String toString() {
+            return "Unresolvable[" + reason + "]";
+        }
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolver.java
@@ -1,6 +1,7 @@
 package com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.security.DataDomainPolicy;
 
 /**
  * Resolves the DataDomain to stamp on a newly created record.
@@ -51,5 +52,31 @@ public interface DataDomainResolver {
      */
     default DataDomain resolveForCreate(String functionalArea, String functionalDomain, Object entity, SourceAttributes attrs) {
         return resolveForCreate(functionalArea, functionalDomain, entity);
+    }
+
+    /**
+     * Governed ingest resolution (S3). Resolves a single ingested source row to an explicit,
+     * fail-closed {@link DataDomainResolution} given an EXPLICIT {@code policy} and the row's
+     * {@link SourceAttributes}.
+     *
+     * <p>Unlike {@link #resolveForCreate(String, String, Object, SourceAttributes)} this entry does
+     * NOT read the ambient {@link com.e2eq.framework.model.securityrules.SecurityContext} /
+     * principal and never falls back to a principal or default placement: the caller supplies the
+     * source's policy directly (the source-bound synthetic principal is deferred to S4). When a
+     * matching {@code FROM_SOURCE} entry cannot derive every REQUIRED component, the result is
+     * {@link DataDomainResolution.Unresolvable} — the quarantine decision is on the TYPE TAG, never
+     * on the value of a look-alike DataDomain.</p>
+     *
+     * @param policy           the source's DataDomainPolicy (may be null → unresolvable)
+     * @param functionalArea   the model's functional area
+     * @param functionalDomain the model's functional domain
+     * @param attrs            the ingested source-row values + source-binding metadata
+     * @return a tagged {@link DataDomainResolution}; never null
+     */
+    default DataDomainResolution resolveIngestRow(DataDomainPolicy policy,
+                                                  String functionalArea,
+                                                  String functionalDomain,
+                                                  SourceAttributes attrs) {
+        return DataDomainResolution.unresolvable("resolveIngestRow not supported by this resolver");
     }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolver.java
@@ -32,4 +32,24 @@ public interface DataDomainResolver {
     default DataDomain resolveForCreate(String functionalArea, String functionalDomain, Object entity) {
         return resolveForCreate(functionalArea, functionalDomain);
     }
+
+    /**
+     * Resolve the DataDomain for a source/ingestion create where there is no authenticated
+     * principal and placement must be derived from the ingested row's attribute values plus
+     * the source binding (see {@code FROM_SOURCE} resolution mode).
+     *
+     * <p>The default implementation preserves the legacy contract by ignoring {@code attrs}
+     * and delegating to {@link #resolveForCreate(String, String, Object)}, so all existing
+     * implementations remain valid without change.</p>
+     *
+     * @param functionalArea the model's functional area
+     * @param functionalDomain the model's functional domain
+     * @param entity the concrete entity being persisted (may be null for raw source rows)
+     * @param attrs the ingested source-row values and source-binding metadata
+     * @return a non-null DataDomain. Implementations that support {@code FROM_SOURCE} may
+     *         return a distinguished UNRESOLVABLE sentinel when required components are missing.
+     */
+    default DataDomain resolveForCreate(String functionalArea, String functionalDomain, Object entity, SourceAttributes attrs) {
+        return resolveForCreate(functionalArea, functionalDomain, entity);
+    }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DefaultDataDomainResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DefaultDataDomainResolver.java
@@ -22,12 +22,19 @@ import java.util.Optional;
 public class DefaultDataDomainResolver implements DataDomainResolver {
 
     /**
-     * Distinguished sentinel returned by the {@code FROM_SOURCE} resolution path when a REQUIRED
-     * DataDomain component (orgRefName, accountNum, tenantId) cannot be derived from the source
-     * attributes (null/blank/missing). It is intentionally NOT the principal's DataDomain and NOT
-     * any configured default — S3 (the edge write + quarantine wiring) checks for this exact
-     * instance (via {@code ==}) to route the row to quarantine instead of stamping a fallback
-     * placement. Identity comparison is the contract; do not clone or mutate this instance.
+     * Distinguished sentinel returned by the LEGACY in-band {@code FROM_SOURCE} resolution path
+     * (the 4-arg {@link #resolveForCreate(String, String, Object, SourceAttributes)}) when a
+     * REQUIRED DataDomain component (orgRefName, accountNum, tenantId) cannot be derived from the
+     * source attributes (null/blank/missing).
+     *
+     * <p>NOTE (S3): this sentinel is RETAINED only for the inert 4-arg API and its S1/S2 tests,
+     * which compare it by identity ({@code ==}). The S1 code_review flagged that {@code ==} contract
+     * as fail-OPEN-fragile (a cloned/round-tripped DataDomain with these values is NOT {@code ==}
+     * this instance and would slip through). The GOVERNED ingest path no longer uses this sentinel
+     * at all — it uses the tagged {@link DataDomainResolution} (see {@link #resolveIngestRow}), where
+     * the unresolvable decision is carried by the type, not by a DataDomain value. The 4-arg path
+     * now delegates to that tagged resolution and maps {@code Unresolvable} back to this instance to
+     * preserve byte-identical legacy behavior.</p>
      */
     public static final DataDomain UNRESOLVABLE = DataDomain.builder()
             .orgRefName("__UNRESOLVABLE__")
@@ -220,15 +227,30 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
     }
 
     /**
-     * Evaluate a {@code FROM_SOURCE} entry's component bindings against the supplied source
-     * attributes. Returns a freshly built {@link DataDomain} when all REQUIRED components
-     * (orgRefName, accountNum, tenantId) resolve to non-blank values, otherwise the
-     * {@link #UNRESOLVABLE} sentinel. Never returns null and never returns the principal DD.
+     * Legacy adapter: evaluate a {@code FROM_SOURCE} entry to a bare {@link DataDomain}, mapping the
+     * tagged {@link DataDomainResolution} back to the {@link #UNRESOLVABLE} sentinel so the inert
+     * 4-arg API (and its S1/S2 identity-based tests) keep their byte-identical behavior. New code
+     * MUST use {@link #resolveFromSourceTagged} / {@link #resolveIngestRow} and branch on the tag.
      */
     private DataDomain resolveFromSource(DataDomainPolicyEntry entry, SourceAttributes attrs) {
+        DataDomainResolution res = resolveFromSourceTagged(entry, attrs);
+        return res.isResolved() ? res.dataDomain() : UNRESOLVABLE;
+    }
+
+    /**
+     * Evaluate a {@code FROM_SOURCE} entry's component bindings against the supplied source
+     * attributes, returning a fail-closed tagged result. {@link DataDomainResolution.Resolved} when
+     * all REQUIRED components (orgRefName, accountNum, tenantId) resolve to non-blank values,
+     * otherwise {@link DataDomainResolution.Unresolvable} carrying the reason. Never returns null and
+     * never synthesizes a principal/default placement.
+     */
+    private DataDomainResolution resolveFromSourceTagged(DataDomainPolicyEntry entry, SourceAttributes attrs) {
         DataDomainComponentBinding binding = entry.getComponentBinding();
-        if (binding == null || attrs == null) {
-            return UNRESOLVABLE;
+        if (binding == null) {
+            return DataDomainResolution.unresolvable("FROM_SOURCE entry has no componentBinding");
+        }
+        if (attrs == null) {
+            return DataDomainResolution.unresolvable("no source attributes supplied for FROM_SOURCE entry");
         }
 
         String orgRefName = resolveString(binding.getOrgRefName(), attrs);
@@ -237,7 +259,12 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
 
         // Required components must be present and non-blank.
         if (isBlank(orgRefName) || isBlank(accountNum) || isBlank(tenantId)) {
-            return UNRESOLVABLE;
+            StringBuilder missing = new StringBuilder();
+            if (isBlank(orgRefName)) missing.append("orgRefName ");
+            if (isBlank(accountNum)) missing.append("accountNum ");
+            if (isBlank(tenantId)) missing.append("tenantId ");
+            return DataDomainResolution.unresolvable(
+                    "required DataDomain component(s) could not be derived from source: " + missing.toString().trim());
         }
 
         // Optional components with sensible defaults.
@@ -247,13 +274,68 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
             ownerId = "system";
         }
 
-        return DataDomain.builder()
+        return DataDomainResolution.resolved(DataDomain.builder()
                 .orgRefName(orgRefName)
                 .accountNum(accountNum)
                 .tenantId(tenantId)
                 .dataSegment(dataSegment)
                 .ownerId(ownerId)
-                .build();
+                .build());
+    }
+
+    /**
+     * Governed ingest resolution (S3). Resolves a single ingest row to a fail-closed
+     * {@link DataDomainResolution} using ONLY the explicitly supplied {@code policy} and the row's
+     * {@code attrs}. Does NOT consult {@link SecurityContext}/principal and never falls back to a
+     * principal or configured default — if no matching entry can place the row, the result is
+     * {@link DataDomainResolution.Unresolvable}.
+     *
+     * <p>Key precedence reuses the source-scoped keying from S2 ({@code src/{sourceId}/...} then the
+     * legacy {@code fa:fd → fa:* → *:fd → *:*}). Only {@code FROM_SOURCE} entries can produce a
+     * placement here; a {@code FIXED} entry yields its configured DataDomain; a
+     * {@code FROM_CREDENTIAL} entry is unresolvable on the ingest path (there is no credential).</p>
+     */
+    @Override
+    public DataDomainResolution resolveIngestRow(DataDomainPolicy policy,
+                                                 String functionalArea,
+                                                 String functionalDomain,
+                                                 SourceAttributes attrs) {
+        if (policy == null) {
+            return DataDomainResolution.unresolvable("no DataDomainPolicy supplied for ingest source");
+        }
+        Map<String, DataDomainPolicyEntry> entries = policy.getPolicyEntries();
+        if (entries == null || entries.isEmpty()) {
+            return DataDomainResolution.unresolvable("DataDomainPolicy has no entries");
+        }
+
+        String fa = safe(functionalArea);
+        String fd = safe(functionalDomain);
+        List<String> keys = buildSourceScopedKeys(fa, fd, attrs);
+
+        for (String key : keys) {
+            DataDomainPolicyEntry entry = entries.get(key);
+            if (entry == null) continue;
+
+            DataDomainPolicyEntry.ResolutionMode mode = entry.getResolutionMode();
+            if (mode == null) mode = DataDomainPolicyEntry.ResolutionMode.FROM_CREDENTIAL;
+            switch (mode) {
+                case FROM_SOURCE:
+                    return resolveFromSourceTagged(entry, attrs);
+                case FIXED:
+                    if (entry.getDataDomains() != null && !entry.getDataDomains().isEmpty()) {
+                        DataDomain dd = entry.getDataDomains().get(0);
+                        if (dd != null) return DataDomainResolution.resolved(dd);
+                    }
+                    return DataDomainResolution.unresolvable(
+                            "FIXED policy entry '" + key + "' has no configured DataDomain");
+                case FROM_CREDENTIAL:
+                default:
+                    // The ingest path has no authenticated credential to resolve against.
+                    return DataDomainResolution.unresolvable(
+                            "policy entry '" + key + "' is FROM_CREDENTIAL; not resolvable on the ingest path");
+            }
+        }
+        return DataDomainResolution.unresolvable("no policy entry matched keys " + keys);
     }
 
     private String resolveString(DataDomainComponentBinding.Binding b, SourceAttributes attrs) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DefaultDataDomainResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DefaultDataDomainResolver.java
@@ -2,6 +2,7 @@ package com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import com.e2eq.framework.model.security.DataDomainComponentBinding;
 import com.e2eq.framework.model.security.DataDomainPolicy;
 import com.e2eq.framework.model.security.DataDomainPolicyEntry;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
@@ -18,6 +19,22 @@ import java.util.Optional;
 @ApplicationScoped
 @DefaultBean
 public class DefaultDataDomainResolver implements DataDomainResolver {
+
+    /**
+     * Distinguished sentinel returned by the {@code FROM_SOURCE} resolution path when a REQUIRED
+     * DataDomain component (orgRefName, accountNum, tenantId) cannot be derived from the source
+     * attributes (null/blank/missing). It is intentionally NOT the principal's DataDomain and NOT
+     * any configured default — S3 (the edge write + quarantine wiring) checks for this exact
+     * instance (via {@code ==}) to route the row to quarantine instead of stamping a fallback
+     * placement. Identity comparison is the contract; do not clone or mutate this instance.
+     */
+    public static final DataDomain UNRESOLVABLE = DataDomain.builder()
+            .orgRefName("__UNRESOLVABLE__")
+            .accountNum("__UNRESOLVABLE__")
+            .tenantId("__UNRESOLVABLE__")
+            .dataSegment(0)
+            .ownerId("__UNRESOLVABLE__")
+            .build();
 
     @Inject
     GlobalDataDomainPolicyProvider globalPolicyProvider;
@@ -42,13 +59,13 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
         Optional<PrincipalContext> pcOpt = SecurityContext.getPrincipalContext();
         if (pcOpt.isPresent()) {
             DataDomainPolicy p = pcOpt.get().getDataDomainPolicy();
-            DataDomain resolved = resolveFromPolicy(p, keys, principalDD);
+            DataDomain resolved = resolveFromPolicy(p, keys, principalDD, null);
             if (resolved != null) return resolved;
         }
 
         // 2) Global policy provider
         DataDomainPolicy global = globalPolicyProvider.getPolicy().orElse(null);
-        DataDomain resolved = resolveFromPolicy(global, keys, principalDD);
+        DataDomain resolved = resolveFromPolicy(global, keys, principalDD, null);
         if (resolved != null) return resolved;
 
         // 3) Default behavior
@@ -66,9 +83,56 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
         return resolveForCreate(functionalArea, functionalDomain);
     }
 
+    /**
+     * Source/ingestion create path. Routes matching {@code FROM_SOURCE} policy entries through
+     * value-driven resolution against {@code attrs}. If a required DataDomain component cannot be
+     * derived, returns the {@link #UNRESOLVABLE} sentinel rather than any principal or default
+     * placement. FIXED and FROM_CREDENTIAL entries behave exactly as in the principal path.
+     */
+    @Override
+    public DataDomain resolveForCreate(String functionalArea, String functionalDomain, Object entity, SourceAttributes attrs) {
+        if (attrs == null) {
+            // No source context: preserve legacy entity-aware behavior.
+            return resolveForCreate(functionalArea, functionalDomain, entity);
+        }
+
+        // If the entity already carries a concrete DataDomain, honor it (parity with 3-arg path).
+        if (entity instanceof UnversionedBaseModel baseModel && baseModel.getDataDomain() != null) {
+            return baseModel.getDataDomain();
+        }
+
+        // Principal context is optional for source writes; only used as the default for
+        // FIXED/FROM_CREDENTIAL entries that may also live in the same policy.
+        DataDomain principalDD = SecurityContext.getPrincipalDataDomain().orElse(null);
+
+        String fa = safe(functionalArea);
+        String fd = safe(functionalDomain);
+        List<String> keys = Arrays.asList(
+                fa + ":" + fd,
+                fa + ":*",
+                "*:" + fd,
+                "*:*"
+        );
+
+        // 1) Principal-attached policy via PrincipalContext
+        Optional<PrincipalContext> pcOpt = SecurityContext.getPrincipalContext();
+        if (pcOpt.isPresent()) {
+            DataDomain resolved = resolveFromPolicy(pcOpt.get().getDataDomainPolicy(), keys, principalDD, attrs);
+            if (resolved != null) return resolved;
+        }
+
+        // 2) Global policy provider
+        DataDomainPolicy global = globalPolicyProvider.getPolicy().orElse(null);
+        DataDomain resolved = resolveFromPolicy(global, keys, principalDD, attrs);
+        if (resolved != null) return resolved;
+
+        // 3) No policy matched. With no principal there is nothing to fall back to → unresolvable.
+        return principalDD != null ? principalDD : UNRESOLVABLE;
+    }
+
     private String safe(String v) { return v == null ? "*" : v; }
 
-    private DataDomain resolveFromPolicy(DataDomainPolicy policy, List<String> keys, DataDomain defaultDD) {
+    private DataDomain resolveFromPolicy(DataDomainPolicy policy, List<String> keys, DataDomain defaultDD, SourceAttributes attrs) {
         if (policy == null) return null;
         Map<String, DataDomainPolicyEntry> entries = policy.getPolicyEntries();
         if (entries == null || entries.isEmpty()) return null;
@@ -79,6 +143,8 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
                 DataDomainPolicyEntry.ResolutionMode mode = entry.getResolutionMode();
                 if (mode == null) mode = DataDomainPolicyEntry.ResolutionMode.FROM_CREDENTIAL;
                 switch (mode) {
+                    case FROM_SOURCE:
+                        return resolveFromSource(entry, attrs);
                     case FIXED:
                         if (entry.getDataDomains() != null && !entry.getDataDomains().isEmpty()) {
                             DataDomain dd = entry.getDataDomains().get(0);
@@ -92,5 +158,74 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
             }
         }
         return null;
+    }
+
+    /**
+     * Evaluate a {@code FROM_SOURCE} entry's component bindings against the supplied source
+     * attributes. Returns a freshly built {@link DataDomain} when all REQUIRED components
+     * (orgRefName, accountNum, tenantId) resolve to non-blank values, otherwise the
+     * {@link #UNRESOLVABLE} sentinel. Never returns null and never returns the principal DD.
+     */
+    private DataDomain resolveFromSource(DataDomainPolicyEntry entry, SourceAttributes attrs) {
+        DataDomainComponentBinding binding = entry.getComponentBinding();
+        if (binding == null || attrs == null) {
+            return UNRESOLVABLE;
+        }
+
+        String orgRefName = resolveString(binding.getOrgRefName(), attrs);
+        String accountNum = resolveString(binding.getAccountNum(), attrs);
+        String tenantId = resolveString(binding.getTenantId(), attrs);
+
+        // Required components must be present and non-blank.
+        if (isBlank(orgRefName) || isBlank(accountNum) || isBlank(tenantId)) {
+            return UNRESOLVABLE;
+        }
+
+        // Optional components with sensible defaults.
+        int dataSegment = resolveInt(binding.getDataSegment(), attrs, 0);
+        String ownerId = resolveString(binding.getOwnerId(), attrs);
+        if (isBlank(ownerId)) {
+            ownerId = "system";
+        }
+
+        return DataDomain.builder()
+                .orgRefName(orgRefName)
+                .accountNum(accountNum)
+                .tenantId(tenantId)
+                .dataSegment(dataSegment)
+                .ownerId(ownerId)
+                .build();
+    }
+
+    private String resolveString(DataDomainComponentBinding.Binding b, SourceAttributes attrs) {
+        if (b == null) return null;
+        Object raw = rawValue(b, attrs);
+        return raw == null ? null : String.valueOf(raw);
+    }
+
+    private int resolveInt(DataDomainComponentBinding.Binding b, SourceAttributes attrs, int defaultValue) {
+        if (b == null) return defaultValue;
+        Object raw = rawValue(b, attrs);
+        if (raw == null) return defaultValue;
+        if (raw instanceof Number num) return num.intValue();
+        try {
+            String s = String.valueOf(raw).trim();
+            return s.isEmpty() ? defaultValue : Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private Object rawValue(DataDomainComponentBinding.Binding b, SourceAttributes attrs) {
+        DataDomainComponentBinding.Kind kind = b.getKind();
+        if (kind == DataDomainComponentBinding.Kind.FROM_ATTRIBUTE) {
+            return attrs.get(b.getAttributeName());
+        }
+        // LITERAL (default)
+        return b.getLiteralValue();
+    }
+
+    private boolean isBlank(String v) {
+        return v == null || v.trim().isEmpty();
     }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DefaultDataDomainResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DefaultDataDomainResolver.java
@@ -11,6 +11,7 @@ import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -107,12 +108,7 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
 
         String fa = safe(functionalArea);
         String fd = safe(functionalDomain);
-        List<String> keys = Arrays.asList(
-                fa + ":" + fd,
-                fa + ":*",
-                "*:" + fd,
-                "*:*"
-        );
+        List<String> keys = buildSourceScopedKeys(fa, fd, attrs);
 
         // 1) Principal-attached policy via PrincipalContext
         Optional<PrincipalContext> pcOpt = SecurityContext.getPrincipalContext();
@@ -131,6 +127,69 @@ public class DefaultDataDomainResolver implements DataDomainResolver {
     }
 
     private String safe(String v) { return v == null ? "*" : v; }
+
+    /**
+     * Build the precedence-ordered policy key list for the source/ingestion (4-arg) path.
+     *
+     * <p>When {@code attrs} carries a non-blank {@code sourceId}, a source-scoped namespace is
+     * searched FIRST, most-specific to least-specific:
+     * <pre>
+     *   src/{sourceId}/{entityType}  (only when entityType is non-blank)
+     *   src/{sourceId}/*
+     *   src/*&#47;{entityType}            (only when entityType is non-blank)
+     * </pre>
+     * followed by the existing principal-namespace keys
+     * ({@code fa:fd → fa:* → *:fd → *:*}).</p>
+     *
+     * <p>When {@code attrs} is null or its {@code sourceId} is blank, the returned list is EXACTLY
+     * the legacy four keys, so resolution for ordinary entity creates is byte-identical to today.</p>
+     */
+    private List<String> buildSourceScopedKeys(String fa, String fd, SourceAttributes attrs) {
+        List<String> legacy = Arrays.asList(
+                fa + ":" + fd,
+                fa + ":*",
+                "*:" + fd,
+                "*:*"
+        );
+
+        if (attrs == null || isBlank(attrs.getSourceId())) {
+            return legacy;
+        }
+
+        String sourceId = attrs.getSourceId();
+        String entityType = attrs.getEntityType();
+        boolean hasEntityType = !isBlank(entityType);
+
+        // Defense-in-depth: sourceId/entityType are interpolated into the policy key path
+        // (src/{sourceId}/{entityType}). A value containing a key metacharacter (/ * :) could
+        // forge a collision with a wildcard policy entry (e.g. sourceId="*" selecting a
+        // cross-source "any source" entry) — a policy-selection/authz bypass once sourceId/
+        // entityType arrive over REST (S6). Reject tainted values by falling through to the
+        // legacy keys ("no usable source scope"); NEVER interpolate a tainted value into a key.
+        if (containsKeyMetachar(sourceId) || (hasEntityType && containsKeyMetachar(entityType))) {
+            return legacy;
+        }
+
+        List<String> keys = new ArrayList<>();
+        if (hasEntityType) {
+            keys.add("src/" + sourceId + "/" + entityType);
+        }
+        keys.add("src/" + sourceId + "/*");
+        if (hasEntityType) {
+            keys.add("src/*/" + entityType);
+        }
+        keys.addAll(legacy);
+        return keys;
+    }
+
+    /**
+     * True if {@code v} contains a policy-key metacharacter ({@code / * :}) that would let a
+     * tainted source attribute forge or restructure a key path. Used to reject such values from
+     * the {@code src/...} namespace (fail safe to the legacy keys) before they reach REST at S6.
+     */
+    private boolean containsKeyMetachar(String v) {
+        return v != null && (v.indexOf('/') >= 0 || v.indexOf('*') >= 0 || v.indexOf(':') >= 0);
+    }
 
     private DataDomain resolveFromPolicy(DataDomainPolicy policy, List<String> keys, DataDomain defaultDD, SourceAttributes attrs) {
         if (policy == null) return null;

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/SourceAttributes.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/SourceAttributes.java
@@ -1,0 +1,58 @@
+package com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Read-only wrapper over the values of an ingested source row together with the
+ * source-binding metadata (sourceId, entityType) used by the
+ * {@link com.e2eq.framework.model.security.DataDomainPolicyEntry.ResolutionMode#FROM_SOURCE}
+ * resolution path.
+ *
+ * <p>This is a plain value holder with no persistence or framework coupling so the
+ * FROM_SOURCE resolution can be exercised in pure unit tests (no Mongo, no Quarkus boot).</p>
+ */
+public final class SourceAttributes {
+
+    private final String sourceId;
+    private final String entityType;
+    private final Map<String, Object> values;
+
+    public SourceAttributes(String sourceId, String entityType, Map<String, Object> values) {
+        this.sourceId = sourceId;
+        this.entityType = entityType;
+        // Defensive copy; the wrapper is read-only from the caller's perspective.
+        this.values = (values == null)
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new HashMap<>(values));
+    }
+
+    /** The id of the source/binding this row was ingested from. May be null. */
+    public String getSourceId() {
+        return sourceId;
+    }
+
+    /** The entity type of the ingested row. May be null. */
+    public String getEntityType() {
+        return entityType;
+    }
+
+    /** Raw value of a named attribute, or null if absent. */
+    public Object get(String attributeName) {
+        if (attributeName == null) {
+            return null;
+        }
+        return values.get(attributeName);
+    }
+
+    /** True iff the named attribute is present (non-null value). */
+    public boolean has(String attributeName) {
+        return attributeName != null && values.get(attributeName) != null;
+    }
+
+    /** Immutable view of all ingested attribute values. */
+    public Map<String, Object> getValues() {
+        return values;
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/changesets/AddRealmsSeedSystemOnlyTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/changesets/AddRealmsSeedSystemOnlyTest.java
@@ -1,0 +1,130 @@
+package com.e2eq.framework.model.persistent.morphia.changesets;
+
+import com.e2eq.framework.model.persistent.morphia.RealmRepo;
+import com.e2eq.framework.model.security.Realm;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import dev.morphia.transactions.MorphiaSession;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit-level coverage for the {@code quantum.realm.seed-system-only} guard in {@link AddRealms}.
+ *
+ * <p>{@code execute()} only touches its injected {@link RealmRepo} (recorded here) plus a
+ * {@code session.getDatabase().getName()} log line and {@code emitter.emit(...)}. The session and
+ * emitter are supplied as minimal JDK dynamic proxies, so this runs without Quarkus or Mongo.
+ */
+class AddRealmsSeedSystemOnlyTest {
+
+    @Test
+    void defaultCreatesSystemAndTestRealms() throws Exception {
+        RecordingRealmRepo realmRepo = new RecordingRealmRepo();
+        AddRealms changeSet = newChangeSet(realmRepo, false);
+
+        changeSet.execute(session("system-com"), mongoClient(), emitter());
+
+        List<String> saved = realmRepo.savedRefNames();
+        assertTrue(saved.contains("system-com"), "system realm must be created in default mode");
+        assertTrue(saved.contains("test-quantum-com"), "test realm must be created in default mode");
+        assertEquals(2, saved.size(), "default mode creates exactly the system + test realms");
+    }
+
+    @Test
+    void seedSystemOnlyCreatesOnlySystemRealm() throws Exception {
+        RecordingRealmRepo realmRepo = new RecordingRealmRepo();
+        AddRealms changeSet = newChangeSet(realmRepo, true);
+
+        changeSet.execute(session("system-com"), mongoClient(), emitter());
+
+        List<String> saved = realmRepo.savedRefNames();
+        assertTrue(saved.contains("system-com"), "system realm MUST still be created under seed-system-only");
+        assertFalse(saved.contains("test-quantum-com"), "test realm must NOT be created under seed-system-only");
+        assertEquals(1, saved.size(), "seed-system-only creates exactly the system realm");
+    }
+
+    // ---- helpers ----------------------------------------------------------------------------
+
+    private static AddRealms newChangeSet(RecordingRealmRepo realmRepo, boolean seedSystemOnly) {
+        AddRealms changeSet = new AddRealms();
+        changeSet.realmRepo = realmRepo;
+        changeSet.systemTenantId = "system.com";
+        changeSet.systemOrgRefName = "system.com";
+        changeSet.defaultRealm = "mycompanyxyz-com";
+        changeSet.accountNumber = "0000000000";
+        changeSet.systemRealm = "system-com";
+        changeSet.testRealm = "test-quantum-com";
+        changeSet.testTenantId = "test-quantum.com";
+        changeSet.testOrgRefName = "test-quantum.com";
+        changeSet.testAccountNumber = "0000000001";
+        changeSet.seedSystemOnly = seedSystemOnly;
+        return changeSet;
+    }
+
+    /** Minimal MorphiaSession proxy; only getDatabase().getName() is exercised by execute(). */
+    private static MorphiaSession session(String dbName) {
+        MongoDatabase db = (MongoDatabase) Proxy.newProxyInstance(
+                AddRealmsSeedSystemOnlyTest.class.getClassLoader(),
+                new Class<?>[]{MongoDatabase.class},
+                (proxy, method, args) -> "getName".equals(method.getName()) ? dbName : defaultReturn(method));
+        return (MorphiaSession) Proxy.newProxyInstance(
+                AddRealmsSeedSystemOnlyTest.class.getClassLoader(),
+                new Class<?>[]{MorphiaSession.class},
+                (proxy, method, args) -> "getDatabase".equals(method.getName()) ? db : defaultReturn(method));
+    }
+
+    private static MongoClient mongoClient() {
+        return (MongoClient) Proxy.newProxyInstance(
+                AddRealmsSeedSystemOnlyTest.class.getClassLoader(),
+                new Class<?>[]{MongoClient.class},
+                (proxy, method, args) -> defaultReturn(method));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static MultiEmitter<? super String> emitter() {
+        return (MultiEmitter<? super String>) Proxy.newProxyInstance(
+                AddRealmsSeedSystemOnlyTest.class.getClassLoader(),
+                new Class<?>[]{MultiEmitter.class},
+                (InvocationHandler) (proxy, method, args) ->
+                        "emit".equals(method.getName()) ? proxy : defaultReturn(method));
+    }
+
+    private static Object defaultReturn(Method method) {
+        Class<?> rt = method.getReturnType();
+        if (rt.equals(boolean.class)) return false;
+        if (rt.equals(int.class)) return 0;
+        if (rt.equals(long.class)) return 0L;
+        return null;
+    }
+
+    private static final class RecordingRealmRepo extends RealmRepo {
+        private final List<String> saved = new ArrayList<>();
+
+        List<String> savedRefNames() {
+            return saved;
+        }
+
+        @Override
+        public Optional<Realm> findByRefName(String refName, boolean ignoreRules, String realmId) {
+            // Treat every realm as new so saveOrUpdateRealm takes the save() path.
+            return Optional.empty();
+        }
+
+        @Override
+        public Realm save(MorphiaSession session, Realm value) {
+            saved.add(value.getRefName());
+            return value;
+        }
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolutionTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolutionTest.java
@@ -1,0 +1,151 @@
+package com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.security.DataDomainComponentBinding;
+import com.e2eq.framework.model.security.DataDomainPolicy;
+import com.e2eq.framework.model.security.DataDomainPolicyEntry;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure JUnit (no Mongo, no Quarkus boot) coverage for the S3 tagged-result resolution
+ * ({@link DataDomainResolution}) via {@link DataDomainResolver#resolveIngestRow}. This is the unit
+ * half of the N3 acceptance: Resolved vs Unresolvable, decided by the TYPE TAG and NOT by any
+ * {@code ==} on a look-alike DataDomain. It also asserts the entry takes the policy EXPLICITLY (no
+ * SecurityContext/principal dependency — that is S4).
+ */
+class DataDomainResolutionTest {
+
+    private DefaultDataDomainResolver newResolver() {
+        DefaultDataDomainResolver resolver = new DefaultDataDomainResolver();
+        resolver.globalPolicyProvider = new GlobalDataDomainPolicyProvider();
+        return resolver;
+    }
+
+    private DataDomainPolicy policyWith(String key, DataDomainPolicyEntry entry) {
+        DataDomainPolicy policy = new DataDomainPolicy();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put(key, entry);
+        policy.setPolicyEntries(entries);
+        return policy;
+    }
+
+    private DataDomainPolicyEntry fromSource(DataDomainComponentBinding binding) {
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        return entry;
+    }
+
+    @Test
+    void resolved_allRequiredComponentsPresent_carriesDataDomain_noSecurityContext() {
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+
+        DataDomainPolicy policy = policyWith("ontology:edge", fromSource(binding));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("tenant_id", "acme-tenant");
+        SourceAttributes attrs = new SourceAttributes("src-1", "Order", values);
+
+        // No SecurityContext.setPrincipalContext() at all — the policy is supplied explicitly.
+        DataDomainResolution res = resolver.resolveIngestRow(policy, "ontology", "edge", attrs);
+
+        assertTrue(res.isResolved(), "all required components present → Resolved");
+        assertTrue(res instanceof DataDomainResolution.Resolved);
+        DataDomain dd = res.dataDomain();
+        assertNotNull(dd);
+        assertEquals("SRC-ORG", dd.getOrgRefName());
+        assertEquals("SRC-ACCT", dd.getAccountNum());
+        assertEquals("acme-tenant", dd.getTenantId());
+    }
+
+    @Test
+    void unresolvable_missingRequiredTenant_isTaggedNotAValue() {
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+
+        DataDomainPolicy policy = policyWith("ontology:edge", fromSource(binding));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // tenant_id absent.
+        SourceAttributes attrs = new SourceAttributes("src-1", "Order", new HashMap<>());
+        DataDomainResolution res = resolver.resolveIngestRow(policy, "ontology", "edge", attrs);
+
+        assertFalse(res.isResolved(), "missing required tenant → Unresolvable");
+        assertTrue(res instanceof DataDomainResolution.Unresolvable);
+        assertNotNull(res.reason());
+        assertTrue(res.reason().contains("tenantId"), "reason names the missing component");
+        // The decision is the TAG — there is no DataDomain to mis-compare. Asking for one throws.
+        assertThrows(IllegalStateException.class, res::dataDomain,
+                "Unresolvable carries NO DataDomain; the quarantine decision can never be defeated by a look-alike value");
+    }
+
+    @Test
+    void unresolvable_nullPolicy() {
+        DefaultDataDomainResolver resolver = newResolver();
+        SourceAttributes attrs = new SourceAttributes("src-1", "Order", new HashMap<>());
+        DataDomainResolution res = resolver.resolveIngestRow(null, "ontology", "edge", attrs);
+        assertFalse(res.isResolved());
+    }
+
+    @Test
+    void unresolvable_fromCredentialEntryOnIngestPath_hasNoCredential() {
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_CREDENTIAL);
+        DataDomainPolicy policy = policyWith("ontology:edge", entry);
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("src-1", "Order", new HashMap<>());
+        DataDomainResolution res = resolver.resolveIngestRow(policy, "ontology", "edge", attrs);
+        assertFalse(res.isResolved(), "FROM_CREDENTIAL is unresolvable on the principal-less ingest path");
+    }
+
+    @Test
+    void resolved_fixedEntry_returnsConfiguredDomain() {
+        DataDomain fixed = DataDomain.builder()
+                .orgRefName("FIXED-ORG").accountNum("FIXED-ACCT").tenantId("fixed-tenant")
+                .dataSegment(2).ownerId("system").build();
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FIXED);
+        entry.setDataDomains(List.of(fixed));
+        DataDomainPolicy policy = policyWith("ontology:edge", entry);
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("src-1", "Order", new HashMap<>());
+        DataDomainResolution res = resolver.resolveIngestRow(policy, "ontology", "edge", attrs);
+        assertTrue(res.isResolved());
+        assertEquals("fixed-tenant", res.dataDomain().getTenantId());
+    }
+
+    @Test
+    void sourceScopedKey_isPreferred() {
+        // A src/{sourceId}/{entityType} FROM_SOURCE entry must be selected over a generic one.
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SCOPED-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SCOPED-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.literal("scoped-tenant"));
+
+        DataDomainPolicy policy = policyWith("src/src-1/Order", fromSource(binding));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("src-1", "Order", new HashMap<>());
+        DataDomainResolution res = resolver.resolveIngestRow(policy, "ontology", "edge", attrs);
+        assertTrue(res.isResolved());
+        assertEquals("scoped-tenant", res.dataDomain().getTenantId());
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolverFromSourceTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolverFromSourceTest.java
@@ -1,0 +1,337 @@
+package com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.security.DataDomainComponentBinding;
+import com.e2eq.framework.model.security.DataDomainPolicy;
+import com.e2eq.framework.model.security.DataDomainPolicyEntry;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Pure JUnit (no Mongo, no Quarkus boot) coverage for SLICE 1 of the DataDomainPolicy
+ * write-side: the FROM_SOURCE resolution mode plus the UNRESOLVABLE sentinel.
+ *
+ * Golden parity: FROM_CREDENTIAL and FIXED entries resolve byte-identically through the new
+ * path as they do today, so existing persist behavior cannot regress.
+ */
+class DataDomainResolverFromSourceTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContext.clear();
+    }
+
+    private DataDomain principalDD() {
+        return DataDomain.builder()
+                .orgRefName("PRINCIPAL-ORG")
+                .accountNum("PRINCIPAL-ACCT")
+                .tenantId("principal-tenant")
+                .dataSegment(0)
+                .ownerId("user@example.com")
+                .build();
+    }
+
+    private void installPrincipal(DataDomain dd, DataDomainPolicy policy) {
+        PrincipalContext pc = new PrincipalContext.Builder()
+                .withDefaultRealm("system-com")
+                .withDataDomain(dd)
+                .withUserId("user@example.com")
+                .withRoles(new String[]{"ADMIN"})
+                .withScope("AUTHENTICATED")
+                .build();
+        pc.setDataDomainPolicy(policy);
+        SecurityContext.setPrincipalContext(pc);
+    }
+
+    private DefaultDataDomainResolver newResolver() {
+        DefaultDataDomainResolver resolver = new DefaultDataDomainResolver();
+        resolver.globalPolicyProvider = new GlobalDataDomainPolicyProvider();
+        return resolver;
+    }
+
+    private DataDomainPolicy policyWith(String key, DataDomainPolicyEntry entry) {
+        DataDomainPolicy policy = new DataDomainPolicy();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put(key, entry);
+        policy.setPolicyEntries(entries);
+        return policy;
+    }
+
+    // ----- Golden: FROM_CREDENTIAL parity -----
+
+    @Test
+    void fromCredential_threeArgAndNoPolicy_returnsPrincipalDD() {
+        DataDomain dd = principalDD();
+        installPrincipal(dd, null);
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // SecurityContext.getPrincipalDataDomain() rebuilds a fresh DataDomain each call, so
+        // golden parity is asserted by VALUE (DataDomain has @EqualsAndHashCode), not identity.
+        DataDomain result = resolver.resolveForCreate("area", "domain");
+        assertEquals(dd, result, "with no policy the principal DD must be returned unchanged (by value)");
+    }
+
+    @Test
+    void fromCredential_explicitEntry_returnsPrincipalDD() {
+        DataDomain dd = principalDD();
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_CREDENTIAL);
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // Both the legacy 3-arg path and the new 4-arg path must agree (golden: byte-identical
+        // by value to the current resolver output).
+        DataDomain legacy = resolver.resolveForCreate("area", "domain");
+        DataDomain viaSource = resolver.resolveForCreate("area", "domain", null,
+                new SourceAttributes("src-1", "Customer", new HashMap<>()));
+
+        assertEquals(dd, legacy);
+        assertEquals(legacy, viaSource);
+    }
+
+    // ----- Golden: FIXED parity -----
+
+    @Test
+    void fixed_returnsConfiguredDataDomain_identicalAcrossPaths() {
+        DataDomain dd = principalDD();
+        DataDomain fixed = DataDomain.builder()
+                .orgRefName("FIXED-ORG")
+                .accountNum("FIXED-ACCT")
+                .tenantId("fixed-tenant")
+                .dataSegment(2)
+                .ownerId("system")
+                .build();
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FIXED);
+        entry.setDataDomains(java.util.List.of(fixed));
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        DataDomain legacy = resolver.resolveForCreate("area", "domain");
+        DataDomain viaSource = resolver.resolveForCreate("area", "domain", null,
+                new SourceAttributes("src-1", "Customer", new HashMap<>()));
+
+        assertSame(fixed, legacy, "FIXED returns the configured DataDomain instance");
+        assertSame(fixed, viaSource, "FIXED behaves identically on the 4-arg path");
+    }
+
+    // ----- FROM_SOURCE: happy path -----
+
+    @Test
+    void fromSource_tenantFromAttribute_literalOrgAccount_buildsDataDomain() {
+        DataDomain dd = principalDD();
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+        // dataSegment + ownerId left to defaults.
+
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("tenant_id", "acme-tenant");
+        SourceAttributes attrs = new SourceAttributes("src-1", "Customer", values);
+
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+
+        assertNotNull(result);
+        assertNotSame(DefaultDataDomainResolver.UNRESOLVABLE, result);
+        assertEquals("SRC-ORG", result.getOrgRefName());
+        assertEquals("SRC-ACCT", result.getAccountNum());
+        assertEquals("acme-tenant", result.getTenantId());
+        assertEquals(0, result.getDataSegment());
+        assertEquals("system", result.getOwnerId(), "ownerId defaults to 'system' when unbound");
+    }
+
+    @Test
+    void fromSource_dataSegmentFromAttribute_coercedToInt() {
+        DataDomain dd = principalDD();
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.literal("t-1"));
+        binding.setDataSegment(DataDomainComponentBinding.Binding.fromAttribute("seg"));
+        binding.setOwnerId(DataDomainComponentBinding.Binding.literal("owner-1"));
+
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("seg", 7);
+        SourceAttributes attrs = new SourceAttributes("src-1", "Customer", values);
+
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals(7, result.getDataSegment());
+        assertEquals("owner-1", result.getOwnerId());
+    }
+
+    // ----- FROM_SOURCE: UNRESOLVABLE sentinel -----
+
+    @Test
+    void fromSource_missingRequiredTenant_returnsUnresolvableSentinelNeverPrincipal() {
+        DataDomain dd = principalDD();
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // tenant_id absent.
+        SourceAttributes attrs = new SourceAttributes("src-1", "Customer", new HashMap<>());
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+
+        assertSame(DefaultDataDomainResolver.UNRESOLVABLE, result,
+                "missing required component must return the UNRESOLVABLE sentinel");
+        assertNotSame(dd, result, "UNRESOLVABLE must never be the principal's DD");
+    }
+
+    @Test
+    void fromSource_blankRequiredTenant_returnsUnresolvable() {
+        DataDomain dd = principalDD();
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("tenant_id", "   ");
+        SourceAttributes attrs = new SourceAttributes("src-1", "Customer", values);
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+
+        assertSame(DefaultDataDomainResolver.UNRESOLVABLE, result);
+        assertNotSame(dd, result);
+    }
+
+    @Test
+    void fromSource_tenantKeyPresentButNullValue_returnsUnresolvable_neverNullString() {
+        DataDomain dd = principalDD();
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // Key PRESENT with an explicit null value (not absent). Must coerce to null -> blank ->
+        // UNRESOLVABLE, NEVER the literal string "null" (the String.valueOf(null) trap).
+        Map<String, Object> values = new HashMap<>();
+        values.put("tenant_id", null);
+        SourceAttributes attrs = new SourceAttributes("src-1", "Customer", values);
+
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertSame(DefaultDataDomainResolver.UNRESOLVABLE, result,
+                "key-present-but-null-value must be UNRESOLVABLE, not a tenantId of \"null\"");
+        assertNotSame(dd, result);
+    }
+
+    @Test
+    void fromSource_nullComponentBinding_returnsUnresolvable_noNpe() {
+        DataDomain dd = principalDD();
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        // componentBinding intentionally left null (misconfigured FROM_SOURCE policy).
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("src-1", "Customer", new HashMap<>());
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertSame(DefaultDataDomainResolver.UNRESOLVABLE, result,
+                "FROM_SOURCE with no componentBinding must fail CLOSED to UNRESOLVABLE, not NPE");
+    }
+
+    @Test
+    void fromSource_dataSegmentNonNumericAttribute_defaultsToZero_noException() {
+        DataDomain dd = principalDD();
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("SRC-ORG"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("SRC-ACCT"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.literal("t-1"));
+        binding.setDataSegment(DataDomainComponentBinding.Binding.fromAttribute("seg"));
+
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // Non-numeric dataSegment must NOT escape an exception; it falls back to the default 0.
+        Map<String, Object> values = new HashMap<>();
+        values.put("seg", "not-a-number");
+        SourceAttributes attrs = new SourceAttributes("src-1", "Customer", values);
+
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertNotSame(DefaultDataDomainResolver.UNRESOLVABLE, result);
+        assertEquals(0, result.getDataSegment(), "non-numeric dataSegment attribute defaults to 0");
+    }
+
+    // ----- Back-compat: stored JSON without componentBinding -----
+
+    @Test
+    void legacyJsonWithoutComponentBinding_deserializes_andBehavesAsToday() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        // Pre-existing stored shape: no componentBinding field at all.
+        String json = "{\"resolutionMode\":\"FROM_CREDENTIAL\",\"functionalActionString\":\"CREATE\"}";
+
+        DataDomainPolicyEntry entry = mapper.readValue(json, DataDomainPolicyEntry.class);
+        assertEquals(DataDomainPolicyEntry.ResolutionMode.FROM_CREDENTIAL, entry.getResolutionMode());
+        assertNull(entry.getComponentBinding(), "absent componentBinding deserializes to null");
+
+        // And it resolves to today's behavior (principal DD).
+        DataDomain dd = principalDD();
+        installPrincipal(dd, policyWith("area:domain", entry));
+        DefaultDataDomainResolver resolver = newResolver();
+        assertEquals(dd, resolver.resolveForCreate("area", "domain"));
+    }
+
+    @Test
+    void newEnumValueSerializesRoundTrips() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+        entry.setComponentBinding(binding);
+
+        String json = mapper.writeValueAsString(entry);
+        DataDomainPolicyEntry back = mapper.readValue(json, DataDomainPolicyEntry.class);
+        assertEquals(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE, back.getResolutionMode());
+        assertNotNull(back.getComponentBinding());
+        assertEquals(DataDomainComponentBinding.Kind.FROM_ATTRIBUTE,
+                back.getComponentBinding().getTenantId().getKind());
+        assertEquals("tenant_id", back.getComponentBinding().getTenantId().getAttributeName());
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolverSourceScopedKeyTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/ddpolicy/DataDomainResolverSourceScopedKeyTest.java
@@ -1,0 +1,293 @@
+package com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.security.DataDomainComponentBinding;
+import com.e2eq.framework.model.security.DataDomainPolicy;
+import com.e2eq.framework.model.security.DataDomainPolicyEntry;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/**
+ * Pure JUnit (no Mongo, no Quarkus boot) coverage for SLICE 2 of the DataDomainPolicy write-side:
+ * per-(sourceId, entityType) policy key precedence.
+ *
+ * <p>S2 extends the precedence KEY LIST so a source-scoped policy entry can be matched per
+ * (sourceId, entityType), searched BEFORE the existing {@code fa:fd} keys, WITHOUT changing
+ * behavior when there are no SourceAttributes. The entry-resolution logic (FROM_SOURCE / FIXED /
+ * FROM_CREDENTIAL) from S1 is unchanged; only WHICH keys are tried, and in what order, changes.</p>
+ */
+class DataDomainResolverSourceScopedKeyTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContext.clear();
+    }
+
+    private DataDomain principalDD() {
+        return DataDomain.builder()
+                .orgRefName("PRINCIPAL-ORG")
+                .accountNum("PRINCIPAL-ACCT")
+                .tenantId("principal-tenant")
+                .dataSegment(0)
+                .ownerId("user@example.com")
+                .build();
+    }
+
+    private void installPrincipal(DataDomain dd, DataDomainPolicy policy) {
+        PrincipalContext pc = new PrincipalContext.Builder()
+                .withDefaultRealm("system-com")
+                .withDataDomain(dd)
+                .withUserId("user@example.com")
+                .withRoles(new String[]{"ADMIN"})
+                .withScope("AUTHENTICATED")
+                .build();
+        pc.setDataDomainPolicy(policy);
+        SecurityContext.setPrincipalContext(pc);
+    }
+
+    private DefaultDataDomainResolver newResolver() {
+        DefaultDataDomainResolver resolver = new DefaultDataDomainResolver();
+        resolver.globalPolicyProvider = new GlobalDataDomainPolicyProvider();
+        return resolver;
+    }
+
+    private DataDomainPolicy policyWith(Map<String, DataDomainPolicyEntry> entries) {
+        DataDomainPolicy policy = new DataDomainPolicy();
+        policy.setPolicyEntries(entries);
+        return policy;
+    }
+
+    /** A FIXED entry that returns a DataDomain whose orgRefName is the given marker. */
+    private DataDomainPolicyEntry fixedEntry(String orgMarker) {
+        DataDomain dd = DataDomain.builder()
+                .orgRefName(orgMarker)
+                .accountNum("ACCT-" + orgMarker)
+                .tenantId("tenant-" + orgMarker)
+                .dataSegment(0)
+                .ownerId("system")
+                .build();
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FIXED);
+        entry.setDataDomains(java.util.List.of(dd));
+        return entry;
+    }
+
+    /** A FROM_SOURCE entry building tenant from an attribute, org/account literal from marker. */
+    private DataDomainPolicyEntry fromSourceEntry(String orgMarker) {
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal(orgMarker));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("ACCT-" + orgMarker));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+        return entry;
+    }
+
+    // ----- Regression: no SourceAttributes never consults a src/* entry -----
+
+    @Test
+    void noSourceAttributes_threeArgPath_neverConsultsSrcEntry_resolvesViaFaFd() {
+        DataDomain dd = principalDD();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        // A src/* entry that, if ever consulted, would win and return a distinguishable org.
+        entries.put("src/S/Order", fixedEntry("SRC-SCOPED-SHOULD-NEVER-WIN"));
+        // The legacy fa:fd entry which is the only one allowed to match on the 3-arg path.
+        entries.put("area:domain", fixedEntry("FA-FD-WINNER"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // 3-arg path: attrs is null, so the key list is EXACTLY fa:fd -> ... -> *:* and the
+        // src/S/Order entry is unreachable.
+        DataDomain result = resolver.resolveForCreate("area", "domain");
+        assertEquals("FA-FD-WINNER", result.getOrgRefName(),
+                "3-arg path must resolve via fa:fd and NEVER consult a src/* entry");
+    }
+
+    @Test
+    void nullAttrs_fourArgPath_neverConsultsSrcEntry_byteIdenticalToThreeArg() {
+        DataDomain dd = principalDD();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src/S/Order", fixedEntry("SRC-SCOPED-SHOULD-NEVER-WIN"));
+        entries.put("area:domain", fixedEntry("FA-FD-WINNER"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        DataDomain legacy = resolver.resolveForCreate("area", "domain");
+        // 4-arg with NULL attrs: the src/* keys must NOT be added; identical to the 3-arg path.
+        DataDomain viaNullAttrs = resolver.resolveForCreate("area", "domain", null, null);
+        assertEquals(legacy, viaNullAttrs,
+                "4-arg path with null attrs is byte-identical to the 3-arg path (no src/* keys)");
+        assertEquals("FA-FD-WINNER", viaNullAttrs.getOrgRefName());
+    }
+
+    // ----- Source-scoped match wins over *:* -----
+
+    @Test
+    void sourceScopedEntry_matchesAndWinsOverStarStar() {
+        DataDomain dd = principalDD();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src/S/Order", fromSourceEntry("SRC-S-ORDER"));
+        entries.put("*:*", fixedEntry("STAR-STAR"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("tenant_id", "acme-tenant");
+        SourceAttributes attrs = new SourceAttributes("S", "Order", values);
+
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertNotSame(DefaultDataDomainResolver.UNRESOLVABLE, result);
+        assertEquals("SRC-S-ORDER", result.getOrgRefName(),
+                "src/S/Order must be matched and win over a coexisting *:* entry");
+        assertEquals("acme-tenant", result.getTenantId());
+    }
+
+    // ----- Precedence within the source namespace -----
+
+    @Test
+    void sourceNamespacePrecedence_mostSpecificWins() {
+        DataDomain dd = principalDD();
+
+        // All three present; src/S/Order is the most specific and must win.
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src/S/Order", fixedEntry("MOST-SPECIFIC"));
+        entries.put("src/S/*", fixedEntry("SOURCE-WILDCARD"));
+        entries.put("src/*/Order", fixedEntry("ENTITY-WILDCARD"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("S", "Order", new HashMap<>());
+
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals("MOST-SPECIFIC", result.getOrgRefName(),
+                "src/S/Order beats src/S/* beats src/*/Order");
+
+        // Remove the most specific: src/S/* must now win over src/*/Order.
+        Map<String, DataDomainPolicyEntry> entries2 = new HashMap<>();
+        entries2.put("src/S/*", fixedEntry("SOURCE-WILDCARD"));
+        entries2.put("src/*/Order", fixedEntry("ENTITY-WILDCARD"));
+        installPrincipal(dd, policyWith(entries2));
+        DataDomain result2 = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals("SOURCE-WILDCARD", result2.getOrgRefName(),
+                "src/S/* beats src/*/Order");
+
+        // Remove src/S/* too: src/*/Order is the only source key left and must win.
+        Map<String, DataDomainPolicyEntry> entries3 = new HashMap<>();
+        entries3.put("src/*/Order", fixedEntry("ENTITY-WILDCARD"));
+        installPrincipal(dd, policyWith(entries3));
+        DataDomain result3 = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals("ENTITY-WILDCARD", result3.getOrgRefName(),
+                "src/*/Order matches when no more-specific source key exists");
+    }
+
+    // ----- Source keys searched BEFORE fa:fd -----
+
+    @Test
+    void sourceScopedEntry_takesPrecedenceOverCoexistingFaFd() {
+        DataDomain dd = principalDD();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src/S/Order", fixedEntry("SOURCE-WINS"));
+        entries.put("area:domain", fixedEntry("FA-FD"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("S", "Order", new HashMap<>());
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals("SOURCE-WINS", result.getOrgRefName(),
+                "source-scoped keys are searched before fa:fd");
+    }
+
+    // ----- Null / blank entityType: src/{sourceId}/* still matches, no NPE -----
+
+    @Test
+    void nullEntityType_sourceWildcardStillMatches_noNpe() {
+        DataDomain dd = principalDD();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src/S/*", fixedEntry("SOURCE-WILDCARD"));
+        // A src/*/Order that must NOT be reachable since entityType is null.
+        entries.put("src/*/Order", fixedEntry("ENTITY-WILDCARD-UNREACHABLE"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("S", null, new HashMap<>());
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals("SOURCE-WILDCARD", result.getOrgRefName(),
+                "src/S/* matches with a null entityType and no NPE");
+    }
+
+    @Test
+    void blankEntityType_sourceWildcardStillMatches_noNpe() {
+        DataDomain dd = principalDD();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src/S/*", fixedEntry("SOURCE-WILDCARD"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        SourceAttributes attrs = new SourceAttributes("S", "   ", new HashMap<>());
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals("SOURCE-WILDCARD", result.getOrgRefName(),
+                "blank entityType still resolves via src/S/* with no NPE");
+    }
+
+    // ----- Blank sourceId: no src/* keys are added, falls back to fa:fd -----
+
+    @Test
+    void blankSourceId_noSrcKeysAdded_resolvesViaFaFd() {
+        DataDomain dd = principalDD();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src//Order", fixedEntry("SHOULD-NEVER-WIN"));
+        entries.put("area:domain", fixedEntry("FA-FD-WINNER"));
+        installPrincipal(dd, policyWith(entries));
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // Blank sourceId: source namespace must be skipped entirely.
+        SourceAttributes attrs = new SourceAttributes("  ", "Order", new HashMap<>());
+        DataDomain result = resolver.resolveForCreate("area", "domain", null, attrs);
+        assertEquals("FA-FD-WINNER", result.getOrgRefName(),
+                "blank sourceId adds no src/* keys; falls through to fa:fd");
+    }
+
+    // ----- Defense-in-depth: tainted sourceId/entityType (key metachars) fall to legacy -----
+
+    @Test
+    void taintedSourceIdOrEntityType_withKeyMetachar_fallsThroughToLegacy_neverForgesWildcardMatch() {
+        DataDomain dd = principalDD();
+        DefaultDataDomainResolver resolver = newResolver();
+
+        // Wildcard entries a forged value would try to select, plus the legitimate fa:fd fallback.
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("src/*/Order", fixedEntry("CROSS-SOURCE-WILDCARD-MUST-NOT-WIN"));
+        entries.put("src/S/*", fixedEntry("SOURCE-WILDCARD-MUST-NOT-WIN"));
+        entries.put("area:domain", fixedEntry("FA-FD-WINNER"));
+        installPrincipal(dd, policyWith(entries));
+
+        // sourceId="*" would (without the guard) build src/*/Order and forge a match against the
+        // cross-source wildcard entry. It must be rejected -> fall through to fa:fd.
+        DataDomain r1 = resolver.resolveForCreate("area", "domain", null,
+                new SourceAttributes("*", "Order", new HashMap<>()));
+        assertEquals("FA-FD-WINNER", r1.getOrgRefName(),
+                "sourceId='*' must be rejected, never match src/*/Order");
+
+        // entityType="*" would (without the guard) build src/S/* and forge a match against the
+        // source-wildcard entry. It must be rejected -> fall through to fa:fd.
+        DataDomain r2 = resolver.resolveForCreate("area", "domain", null,
+                new SourceAttributes("S", "*", new HashMap<>()));
+        assertEquals("FA-FD-WINNER", r2.getOrgRefName(),
+                "entityType='*' must be rejected, never match src/S/*");
+
+        // Path-injection via '/' (and ':' into the legacy namespace) must also be rejected.
+        DataDomain r3 = resolver.resolveForCreate("area", "domain", null,
+                new SourceAttributes("x/y", "Order", new HashMap<>()));
+        assertEquals("FA-FD-WINNER", r3.getOrgRefName(),
+                "sourceId containing '/' must be rejected, falls through to fa:fd");
+    }
+}

--- a/quantum-oauth-server/src/main/java/com/e2eq/framework/oauth/resource/JwksResource.java
+++ b/quantum-oauth-server/src/main/java/com/e2eq/framework/oauth/resource/JwksResource.java
@@ -9,6 +9,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
@@ -22,19 +24,22 @@ import java.security.interfaces.RSAPublicKey;
 @PermitAll
 public class JwksResource {
 
+    @ConfigProperty(name = "auth.jwt.key-id", defaultValue = "quantum-auth")
+    String keyId;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String jwks() {
+    public Response jwks() {
         try {
             PublicKey publicKey = TokenUtils.readPublicKey(TokenUtils.getPublicKeyLocation());
             RSAKey rsaKey = new RSAKey.Builder((RSAPublicKey) publicKey)
-                    .keyID(TokenUtils.getPrivateKeyLocation())
+                    .keyID(keyId)
                     .build();
             JWKSet jwkSet = new JWKSet(rsaKey);
             // JWKSet.toString() emits RFC 7517 JSON (public members only).
             // Do NOT use toJSONObject().toString() — that returns java.util.Map's
             // {k=v} form, which is not valid JSON and breaks JWKS clients.
-            return jwkSet.toString();
+            return Response.ok(jwkSet.toString(), MediaType.APPLICATION_JSON_TYPE).build();
         } catch (Exception e) {
             Log.error("Failed to build JWKS", e);
             throw new IllegalStateException("Unable to serve JWKS", e);

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/QuarantinedEdge.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/QuarantinedEdge.java
@@ -1,0 +1,68 @@
+package com.e2eq.ontology.model;
+
+import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import dev.morphia.annotations.Entity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * A raw ingest edge that could NOT be governed into a DataDomain placement and was therefore
+ * routed to quarantine instead of being written to the {@code edges} collection (S3).
+ *
+ * <p>Fail-closed contract: the governed ingest path ({@link com.e2eq.ontology.repo.OntologyEdgeRepo#ingestEdges})
+ * NEVER synthesizes a default/{@code __unowned} DataDomain for an unplaceable row. The row's raw
+ * triple, the source it came from, the attributes that were attempted, and the failing policy
+ * key + reason are captured here so the placement can be diagnosed and (later, S7) replayed once
+ * the source policy or the row is corrected. Deliberately carries NO {@code dataDomain} field —
+ * a quarantined edge has no governed placement by definition.</p>
+ *
+ * <p><b>Access scoping (decision):</b> this is an <b>ADMIN-only</b> queue. It is realm-partitioned
+ * (persisted under the active security-context realm, not in {@code edges}) but intentionally
+ * <b>domainless</b>, so it has no org/account/tenant row scoping within a realm. Because
+ * {@link #attemptedAttributes} can contain tenant-identifying values from a row whose tenant could
+ * NOT be resolved, access MUST be gated by the {@code edge_quarantine} functional domain
+ * ({@link #bmFunctionalDomain()}) granted only to admin/system identities. The S7 replay path
+ * (re-driving quarantined rows) MUST NOT be exposed until that permission rule is wired.</p>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Entity(value = "ontology_edge_quarantine", useDiscriminator = false)
+public class QuarantinedEdge extends UnversionedBaseModel {
+
+    // Raw edge triple as presented by the source.
+    private String src;
+    private String srcType;
+    private String p;
+    private String dst;
+    private String dstType;
+
+    // Provenance of the failed ingest.
+    private String sourceId;
+    private String entityType;
+
+    // The attributes that were offered to the resolver (the ingest row values + source metadata).
+    private Map<String, Object> attemptedAttributes;
+
+    // Why placement failed. policyKey is the most-specific key that was attempted (best-effort,
+    // for diagnosis); reason is the resolver's Unresolvable reason. (S7 lineage block defers; we
+    // capture key+reason now so it can be wired later.)
+    private String policyKey;
+    private String reason;
+
+    private Date quarantinedAt;
+
+    @Override
+    public String bmFunctionalArea() {
+        return "ontology";
+    }
+
+    @Override
+    public String bmFunctionalDomain() {
+        return "edge_quarantine";
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
@@ -67,6 +67,18 @@ public class TenantOntologyTBox extends UnversionedBaseModel {
     // Metadata
     private Integer version;            // Optional version number
     private String description;         // Optional description
+
+    // B5: realm-governance vocabulary tier. The set of ontology predicates ADMITTED
+    // for policy (security-rule) use in this realm. null == legacy "all declared
+    // predicates admitted". A predicate declared in the TBox (properties) but NOT in
+    // this set is "provisional": usable for facts/edges but rejected when referenced
+    // by a security rule.
+    //
+    // OUT-OF-BAND from pack identity/hash: this is realm-governance state, NOT part of
+    // the canonical TBox content. It MUST NOT be fed into toTBox()/convertProperties()
+    // or anything reaching CanonicalTBoxHasher — two docs differing only in
+    // admittedPredicates must hash identically.
+    private java.util.Set<String> admittedPredicates;
     
     public TenantOntologyTBox(TBox tbox, String tboxHash, String yamlHash, String source, String softwareVersion) {
         this.tboxHash = tboxHash;

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
@@ -29,11 +29,17 @@ import java.util.Set;
                @Field("dataDomain.tenantId"),
                @Field("tboxHash")
            }),
-    @Index(options = @IndexOptions(name = "idx_tenant_tbox_active"), 
+    @Index(options = @IndexOptions(name = "idx_tenant_tbox_active"),
            fields = {
                @Field("dataDomain.tenantId"),
                @Field("active"),
                @Field("appliedAt")
+           }),
+    // Rollback selects the most-recently genuinely-activated TBox (B2): index lastActivatedAt.
+    @Index(options = @IndexOptions(name = "idx_tenant_tbox_last_activated"),
+           fields = {
+               @Field("dataDomain.tenantId"),
+               @Field("lastActivatedAt")
            }),
     @Index(options = @IndexOptions(name = "idx_tenant_tbox_version"), 
            fields = {
@@ -47,7 +53,8 @@ public class TenantOntologyTBox extends UnversionedBaseModel {
     
     private String tboxHash;           // SHA-256 hash of TBox content
     private String yamlHash;           // Hash of source YAML (for correlation)
-    private Date appliedAt;            // When this TBox was applied
+    private Date appliedAt;            // When this TBox was submitted/persisted (NOT activation time)
+    private Date lastActivatedAt;      // When this TBox was last genuinely activated (null if never activated)
     private String source;             // Source description (YAML path, etc.)
     private boolean active;            // Whether this is the active TBox for the tenant
     private String softwareVersion;   // Software version this TBox is compatible with

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/EdgeIngestResult.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/EdgeIngestResult.java
@@ -1,0 +1,43 @@
+package com.e2eq.ontology.repo;
+
+import com.e2eq.ontology.core.EdgeRecord;
+
+/**
+ * Per-record outcome of a governed ingest (S3): the row was either {@code ACCEPTED} (placed into a
+ * governed DataDomain and upserted into the {@code edges} collection) or {@code QUARANTINED} (could
+ * not be placed; written to {@code ontology_edge_quarantine}, nothing written to {@code edges}).
+ */
+public final class EdgeIngestResult {
+
+    public enum Status { ACCEPTED, QUARANTINED }
+
+    private final Status status;
+    private final EdgeRecord edge;
+    private final String reason;
+
+    private EdgeIngestResult(Status status, EdgeRecord edge, String reason) {
+        this.status = status;
+        this.edge = edge;
+        this.reason = reason;
+    }
+
+    public static EdgeIngestResult accepted(EdgeRecord edge) {
+        return new EdgeIngestResult(Status.ACCEPTED, edge, null);
+    }
+
+    public static EdgeIngestResult quarantined(EdgeRecord edge, String reason) {
+        return new EdgeIngestResult(Status.QUARANTINED, edge, reason);
+    }
+
+    public Status getStatus() { return status; }
+    public EdgeRecord getEdge() { return edge; }
+    public String getReason() { return reason; }
+
+    public boolean isAccepted() { return status == Status.ACCEPTED; }
+    public boolean isQuarantined() { return status == Status.QUARANTINED; }
+
+    @Override
+    public String toString() {
+        return "EdgeIngestResult{" + status + (reason != null ? ", reason=" + reason : "") + "}";
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/EdgeIngestSummary.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/EdgeIngestSummary.java
@@ -1,0 +1,40 @@
+package com.e2eq.ontology.repo;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Batch summary for a governed ingest (S3). Good rows persist, bad rows quarantine; a single
+ * poison row never throws and never denies the rest of the tenant's batch. The summary surfaces
+ * the accepted/quarantined counts plus the per-record {@link EdgeIngestResult}s so callers can
+ * react to a non-zero {@code quarantinedCount} without losing the accepted rows.
+ */
+public final class EdgeIngestSummary {
+
+    private final int acceptedCount;
+    private final int quarantinedCount;
+    private final List<EdgeIngestResult> results;
+
+    public EdgeIngestSummary(List<EdgeIngestResult> results) {
+        this.results = (results == null) ? Collections.emptyList() : Collections.unmodifiableList(results);
+        int accepted = 0;
+        int quarantined = 0;
+        for (EdgeIngestResult r : this.results) {
+            if (r.isAccepted()) accepted++;
+            else if (r.isQuarantined()) quarantined++;
+        }
+        this.acceptedCount = accepted;
+        this.quarantinedCount = quarantined;
+    }
+
+    public int getAcceptedCount() { return acceptedCount; }
+    public int getQuarantinedCount() { return quarantinedCount; }
+    public List<EdgeIngestResult> getResults() { return results; }
+
+    public boolean hasQuarantines() { return quarantinedCount > 0; }
+
+    @Override
+    public String toString() {
+        return "EdgeIngestSummary{accepted=" + acceptedCount + ", quarantined=" + quarantinedCount + "}";
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeRepo.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeRepo.java
@@ -2,10 +2,14 @@ package com.e2eq.ontology.repo;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.morphia.MorphiaRepo;
+import com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy.DataDomainResolution;
+import com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy.DataDomainResolver;
+import com.e2eq.framework.model.persistent.morphia.interceptors.ddpolicy.SourceAttributes;
 import com.e2eq.ontology.core.EdgeRecord;
 import com.e2eq.ontology.core.OntologyRegistry;
 import com.e2eq.ontology.exceptions.CardinalityViolationException;
 import com.e2eq.ontology.model.OntologyEdge;
+import com.e2eq.ontology.model.QuarantinedEdge;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import dev.morphia.Datastore;
 import dev.morphia.query.Query;
@@ -37,6 +41,11 @@ public class OntologyEdgeRepo extends MorphiaRepo<OntologyEdge> {
    // Uses Instance<> for lazy resolution
    @Inject
    Instance<com.e2eq.ontology.runtime.TenantOntologyRegistryProvider> registryProviderInstance;
+
+   // Governed-ingest resolver (S3). Lazy Instance<> so standalone/unit constructions of this repo
+   // (and any startup ordering) do not hard-require the resolver bean.
+   @Inject
+   Instance<DataDomainResolver> dataDomainResolverInstance;
 
    public void deleteAll() {
       deleteAll(getSecurityContextRealmId());
@@ -517,6 +526,153 @@ public class OntologyEdgeRepo extends MorphiaRepo<OntologyEdge> {
                 }
             }
         }
+    }
+
+    // ========================================================================
+    // Governed source ingest (S3) — fail-closed edge write with quarantine
+    // ========================================================================
+
+    /**
+     * Governed ingest entry point for edges arriving from an external source (S3). This is the
+     * FIRST edge-write path that runs the DataDomain resolver: each row is resolved against the
+     * source's explicit {@link SourcePolicyContext#getPolicy() policy} to a fail-closed
+     * {@link DataDomainResolution}.
+     *
+     * <p>Per row:</p>
+     * <ul>
+     *   <li><b>Resolved</b> → stamp the resolved DataDomain and {@link #upsert} as usual (ACCEPTED).</li>
+     *   <li><b>Unresolvable</b> → write a {@link QuarantinedEdge} to {@code ontology_edge_quarantine},
+     *       write NOTHING to the {@code edges} collection, and NEVER synthesize a default/{@code
+     *       __unowned} domain (QUARANTINED).</li>
+     * </ul>
+     *
+     * <p>Partial-batch semantics: good rows persist and bad rows quarantine independently. A single
+     * poison row must NOT deny the rest of the tenant's ingest, so this method does not throw on an
+     * unplaceable (or otherwise rejected) row — it records it and continues, surfacing the
+     * {@code quarantinedCount} in the returned {@link EdgeIngestSummary}.</p>
+     *
+     * <p>This method deliberately does NOT touch the existing {@link #upsert}/{@link #upsertDerived}/
+     * {@link #bulkUpsertEdgeRecords}/{@link #upsertMany} paths — those legitimately carry an
+     * already-governed, caller-supplied DataDomain and remain unchanged.</p>
+     *
+     * @param ctx   the source policy context (sourceId + explicit DataDomainPolicy + base bindings)
+     * @param edges the raw ingest edges (DataDomainInfo on these is ignored; placement is resolved)
+     * @return a per-record + counted batch summary; never null
+     */
+    public EdgeIngestSummary ingestEdges(SourcePolicyContext ctx, Collection<EdgeRecord> edges) {
+        if (ctx == null) {
+            throw new IllegalArgumentException("SourcePolicyContext must be provided for governed ingest");
+        }
+        List<EdgeIngestResult> results = new ArrayList<>();
+        if (edges == null || edges.isEmpty()) {
+            return new EdgeIngestSummary(results);
+        }
+
+        DataDomainResolver resolver = (dataDomainResolverInstance != null && dataDomainResolverInstance.isResolvable())
+                ? dataDomainResolverInstance.get()
+                : null;
+
+        for (EdgeRecord e : edges) {
+            if (e == null) {
+                continue;
+            }
+            String entityType = e.getSrcType();
+            // Build the source attributes for this row: the literal base bindings first, then the
+            // row's own structural fields. The resolver reads FROM_ATTRIBUTE bindings out of these.
+            Map<String, Object> values = new HashMap<>(ctx.getBaseBindings());
+            values.put("src", e.getSrc());
+            values.put("srcType", e.getSrcType());
+            values.put("p", e.getP());
+            values.put("dst", e.getDst());
+            values.put("dstType", e.getDstType());
+            if (e.getProv() != null) {
+                // Expose provenance values (e.g. tenant_id carried in prov) without clobbering structural keys.
+                for (Map.Entry<String, Object> pe : e.getProv().entrySet()) {
+                    values.putIfAbsent(pe.getKey(), pe.getValue());
+                }
+            }
+            SourceAttributes attrs = new SourceAttributes(ctx.getSourceId(), entityType, values);
+
+            DataDomainResolution resolution = (resolver != null)
+                    ? resolver.resolveIngestRow(ctx.getPolicy(), "ontology", "edge", attrs)
+                    : DataDomainResolution.unresolvable("no DataDomainResolver available for governed ingest");
+
+            if (resolution.isResolved()) {
+                DataDomain dd = resolution.dataDomain();
+                try {
+                    // Stamp the governed domain and upsert via the existing, unchanged path.
+                    upsert(dd, e.getSrcType(), e.getSrc(), e.getP(), e.getDstType(), e.getDst(), e.isInferred(), e.getProv());
+                    results.add(EdgeIngestResult.accepted(e));
+                } catch (RuntimeException upsertEx) {
+                    // A resolvable row that the edge layer rejects (e.g. cardinality violation) must
+                    // not abort the whole batch either — quarantine it with the rejection reason.
+                    Log.warnf("Ingest row resolved but upsert rejected it; quarantining: %s", upsertEx.getMessage());
+                    quarantineSafely(ctx, e, attrs, upsertEx.getMessage(), results);
+                }
+            } else {
+                quarantineSafely(ctx, e, attrs, resolution.reason(), results);
+            }
+        }
+        return new EdgeIngestSummary(results);
+    }
+
+    /**
+     * Best-effort most-specific policy key hint for diagnostics on a quarantined row. This mirrors
+     * the resolver's source-scoped key shape but is only a HINT recorded on the QuarantinedEdge; the
+     * authoritative placement decision is the resolver's tagged result, not this string.
+     */
+    private String keyHintFor(SourceAttributes attrs) {
+        String sid = attrs.getSourceId();
+        String et = attrs.getEntityType();
+        if (sid != null && !sid.isBlank() && et != null && !et.isBlank()) {
+            return "src/" + sid + "/" + et;
+        }
+        if (sid != null && !sid.isBlank()) {
+            return "src/" + sid + "/*";
+        }
+        return "ontology:edge";
+    }
+
+    /**
+     * Quarantine a row WITHOUT ever throwing (the never-throw-on-poison contract). If the quarantine
+     * write itself fails, the row is STILL kept out of {@code edges} (fail-closed is preserved); only
+     * the quarantine record is lost, logged at ERROR for follow-up. Always records a QUARANTINED
+     * result so the row is accounted for in the {@link EdgeIngestSummary}.
+     */
+    private void quarantineSafely(SourcePolicyContext ctx, EdgeRecord e, SourceAttributes attrs,
+                                  String reason, java.util.List<EdgeIngestResult> results) {
+        try {
+            quarantine(ctx, e, attrs, keyHintFor(attrs), reason);
+        } catch (RuntimeException qEx) {
+            // Fail-closed is intact (the row never reached `edges`); we only lose the quarantine record.
+            Log.errorf("Quarantine WRITE failed for unplaceable ingest row (row kept OUT of edges; "
+                            + "quarantine record lost): src=%s p=%s dst=%s reason=%s quarantineError=%s",
+                    e.getSrc(), e.getP(), e.getDst(), reason, qEx.getMessage());
+        }
+        results.add(EdgeIngestResult.quarantined(e, reason));
+    }
+
+    /**
+     * Persist a {@link QuarantinedEdge} for an unplaceable ingest row. Writes ONLY to the
+     * {@code ontology_edge_quarantine} collection; never to {@code edges}. Uses the active
+     * security-context realm (there is no governed DataDomain to derive a realm from — that is the
+     * whole reason the row is quarantined).
+     */
+    private void quarantine(SourcePolicyContext ctx, EdgeRecord e, SourceAttributes attrs, String policyKey, String reason) {
+        QuarantinedEdge q = new QuarantinedEdge();
+        q.setRefName(ctx.getSourceId() + "|" + e.getSrc() + "|" + e.getP() + "|" + e.getDst() + "|" + System.nanoTime());
+        q.setSrc(e.getSrc());
+        q.setSrcType(e.getSrcType());
+        q.setP(e.getP());
+        q.setDst(e.getDst());
+        q.setDstType(e.getDstType());
+        q.setSourceId(ctx.getSourceId());
+        q.setEntityType(attrs.getEntityType());
+        q.setAttemptedAttributes(new HashMap<>(attrs.getValues()));
+        q.setPolicyKey(policyKey);
+        q.setReason(reason);
+        q.setQuarantinedAt(new Date());
+        ds().save(q);
     }
 
     /**

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/SourcePolicyContext.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/SourcePolicyContext.java
@@ -1,0 +1,53 @@
+package com.e2eq.ontology.repo;
+
+import com.e2eq.framework.model.security.DataDomainPolicy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The governance context for a single source's ingest batch (S3).
+ *
+ * <p>Carries the {@code sourceId} the batch was ingested from, the source's
+ * {@link DataDomainPolicy} (taken EXPLICITLY — the source-bound synthetic principal /
+ * SecurityCallScope is deferred to S4), and any literal base bindings to fold into each row's
+ * {@code SourceAttributes} (e.g. a fixed orgRefName/accountNum supplied by the source registration
+ * rather than present in every row).</p>
+ *
+ * <p>Plain value holder with no Mongo/Quarkus coupling so the ingest resolution can be exercised in
+ * unit tests.</p>
+ */
+public final class SourcePolicyContext {
+
+    private final String sourceId;
+    private final DataDomainPolicy policy;
+    private final Map<String, Object> baseBindings;
+
+    public SourcePolicyContext(String sourceId, DataDomainPolicy policy, Map<String, Object> baseBindings) {
+        this.sourceId = sourceId;
+        this.policy = policy;
+        this.baseBindings = (baseBindings == null)
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new HashMap<>(baseBindings));
+    }
+
+    public SourcePolicyContext(String sourceId, DataDomainPolicy policy) {
+        this(sourceId, policy, null);
+    }
+
+    /** The id of the source this batch was ingested from. */
+    public String getSourceId() {
+        return sourceId;
+    }
+
+    /** The source's DataDomainPolicy used to govern placement. May be null → all rows quarantine. */
+    public DataDomainPolicy getPolicy() {
+        return policy;
+    }
+
+    /** Literal base bindings folded into every row's SourceAttributes. Never null. */
+    public Map<String, Object> getBaseBindings() {
+        return baseBindings;
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/TenantOntologyTBoxRepo.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/TenantOntologyTBoxRepo.java
@@ -77,6 +77,32 @@ public class TenantOntologyTBoxRepo extends MorphiaRepo<TenantOntologyTBox> {
     }
 
     /**
+     * Find the TBox to roll back to when deactivating {@code excludeHash}: the most
+     * recently <em>genuinely activated</em> TBox for the tenant whose hash is NOT
+     * {@code excludeHash}. Selection is by activation time ({@code lastActivatedAt}),
+     * not submit time ({@code appliedAt}); a submitted-but-never-activated candidate
+     * (no {@code lastActivatedAt}) is never chosen, even if its {@code appliedAt} is
+     * later. Returns empty when the tenant has no other ever-activated TBox.
+     */
+    public Optional<TenantOntologyTBox> findPreviousActive(DataDomain dataDomain, String excludeHash) {
+        validateDataDomain(dataDomain);
+        Query<TenantOntologyTBox> q = ds().find(TenantOntologyTBox.class)
+                .filter(dataDomainFilters(dataDomain))
+                .filter(Filters.exists("lastActivatedAt"))
+                .filter(Filters.ne("lastActivatedAt", null));
+        if (excludeHash != null && !excludeHash.isBlank()) {
+            q = q.filter(Filters.ne("tboxHash", excludeHash));
+        }
+
+        FindOptions options = new FindOptions()
+                .sort(Sort.descending("lastActivatedAt"))
+                .limit(1);
+
+        List<TenantOntologyTBox> results = q.iterator(options).toList();
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
+    /**
      * Deactivate all TBoxes for a tenant (before activating a new one)
      */
     public void deactivateAll(DataDomain dataDomain) {

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/AdmittedVocabularyResult.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/AdmittedVocabularyResult.java
@@ -1,0 +1,80 @@
+package com.e2eq.ontology.runtime;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * B5 vocabulary tier: explicit 3-state result of resolving a realm's
+ * admitted-predicate set for security-rule (policy) use.
+ *
+ * <p>This type exists to close a fail-OPEN security downgrade. The previous
+ * 2-state {@code Optional<Set<String>>} contract funneled BOTH "this realm has
+ * no governed admitted set (legacy)" AND "the Mongo read threw" into
+ * {@code Optional.empty()}, which the policy guard mapped to "all declared
+ * predicates admitted". The net effect: once a realm became GOVERNED, a
+ * transient Mongo read failure silently downgraded it to accept-every-predicate.
+ * Distinguishing the read-failure state lets the guard fail CLOSED instead.</p>
+ *
+ * <ul>
+ *   <li>{@link Kind#LEGACY} — no active tenant TBox, or an active TBox whose
+ *       {@code admittedPredicates} field is {@code null}. Back-compat: all
+ *       declared predicates are admitted (fail-OPEN is correct for un-governed
+ *       realms; zero regression).</li>
+ *   <li>{@link Kind#GOVERNED} — an active tenant TBox with a non-null admitted
+ *       set. The set defines exactly which declared predicates may be referenced
+ *       by rules (Slice-1/2 enforcement).</li>
+ *   <li>{@link Kind#UNAVAILABLE} — the admitted-set read threw (Mongo blip /
+ *       outage). The guard MUST fail CLOSED: treat as "no predicates admitted for
+ *       rule references" so rule registration referencing any predicate is
+ *       rejected rather than silently allowed. This is an explicit availability
+ *       tradeoff (rule (re)loading for a GOVERNED realm is rejected during a
+ *       Mongo outage) chosen over a security downgrade on a blip.</li>
+ * </ul>
+ *
+ * @param kind     which of the three states this result represents
+ * @param admitted the admitted-predicate set; non-null and unmodifiable ONLY for
+ *                 {@link Kind#GOVERNED}, empty/unused otherwise
+ */
+public record AdmittedVocabularyResult(Kind kind, Set<String> admitted) {
+
+    public enum Kind { LEGACY, GOVERNED, UNAVAILABLE }
+
+    private static final AdmittedVocabularyResult LEGACY_INSTANCE =
+            new AdmittedVocabularyResult(Kind.LEGACY, Set.of());
+    private static final AdmittedVocabularyResult UNAVAILABLE_INSTANCE =
+            new AdmittedVocabularyResult(Kind.UNAVAILABLE, Set.of());
+
+    /** No governed admitted set (legacy / un-governed realm): all declared admitted. */
+    public static AdmittedVocabularyResult legacy() {
+        return LEGACY_INSTANCE;
+    }
+
+    /** Governed realm: only {@code admitted} predicates may be referenced by rules. */
+    public static AdmittedVocabularyResult governed(Set<String> admitted) {
+        Set<String> safe = admitted == null ? Set.of() : Set.copyOf(admitted);
+        return new AdmittedVocabularyResult(Kind.GOVERNED, safe);
+    }
+
+    /** The read threw: the guard must fail CLOSED (no predicates admitted for rules). */
+    public static AdmittedVocabularyResult unavailable() {
+        return UNAVAILABLE_INSTANCE;
+    }
+
+    public boolean isLegacy()      { return kind == Kind.LEGACY; }
+    public boolean isGoverned()    { return kind == Kind.GOVERNED; }
+    public boolean isUnavailable() { return kind == Kind.UNAVAILABLE; }
+
+    /**
+     * Back-compat projection onto the old 2-state contract: GOVERNED -&gt; the set,
+     * LEGACY and UNAVAILABLE -&gt; empty. Use ONLY where a caller cannot distinguish
+     * the read-failure state; the policy guard must NOT use this (it would re-open
+     * the fail-OPEN downgrade). Provided so the legacy
+     * {@code admittedPredicatesForCurrentRealm()} method keeps its exact behavior.
+     */
+    public Optional<Set<String>> asLegacyOptional() {
+        return kind == Kind.GOVERNED
+                ? Optional.of(Collections.unmodifiableSet(admitted))
+                : Optional.empty();
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
@@ -2,12 +2,14 @@ package com.e2eq.ontology.runtime;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.morphia.MorphiaDataStoreWrapper;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.security.runtime.RuleContext;
 import com.e2eq.ontology.core.*;
 import com.e2eq.ontology.core.OntologyRegistry.TBox;
 import com.e2eq.ontology.mongo.MorphiaOntologyLoader;
 import com.e2eq.ontology.model.OntologyTBox;
+import com.e2eq.ontology.model.TenantOntologyTBox;
 import com.e2eq.ontology.repo.OntologyTBoxRepo;
 import com.e2eq.ontology.repo.TenantOntologyTBoxRepo;
 import com.e2eq.ontology.service.OntologyMetaService;
@@ -192,6 +194,25 @@ public class TenantOntologyRegistryProvider {
     }
 
     /**
+     * Build the realm's TBox PURELY from its sources (annotations + Morphia scan +
+     * YAML overlay), WITHOUT consulting the activation-preferring read path and
+     * WITHOUT mutating the per-realm registry cache.
+     * <p>
+     * This is the registry the {@code OntologyReindexer} just produced/applied:
+     * callers that need to pin/markApplied the rebuilt <em>source</em> TBox (rather
+     * than an activation-preferring registry that might return an admission-activated
+     * tenant TBox instead) must use this, not {@link #getRegistryForRealm(String)}.
+     * When no tenant TBox has been activated, this is identical to what
+     * {@code getRegistryForRealm} would have returned, so behaviour is unchanged.
+     * </p>
+     * @param realm the realm to build the source TBox for
+     * @return a freshly built, source-derived OntologyRegistry (not cached)
+     */
+    public OntologyRegistry buildSourceRegistry(String realm) {
+        return buildRegistryForRealm(realm);
+    }
+
+    /**
      * Check if a realm has a cached registry.
      */
     public boolean hasCachedRegistry(String realm) {
@@ -203,6 +224,58 @@ public class TenantOntologyRegistryProvider {
      */
     public Set<String> getCachedRealms() {
         return Collections.unmodifiableSet(realmRegistries.keySet());
+    }
+
+    // --- Canonical realm -> DataDomain derivation ----------------------------
+
+    /**
+     * Canonical realm -&gt; {@link DataDomain} derivation shared by the admission
+     * write path ({@code TBoxAdmissionService.dataDomainFor}) and the realm read
+     * path ({@link #loadOrBuildRegistryForRealm}). Centralizing it here is what
+     * guarantees the tenant-active store is keyed identically on write and read,
+     * so activation can never silently fail to be observed because the two sides
+     * derived different DataDomains (closes follow-up N3).
+     *
+     * <p><b>Principal-independent by contract.</b> This function is a PURE
+     * function of the {@code realm} string: it makes NO reference to the ambient
+     * {@link SecurityContext}/{@link PrincipalContext}. For a given realm it
+     * returns byte-identical org/account/tenantId/owner/dataSegment regardless of
+     * which caller (HTTP request under a JWT principal, the
+     * {@code OntologyReindexer} system principal, or no principal at all) invokes
+     * it. The fixed per-realm convention is:
+     * {@code tenantId == org == account == owner == realm} and
+     * {@code dataSegment == 0}.</p>
+     *
+     * <p>This is the single realm-deterministic key used by BOTH the admission
+     * write ({@code TBoxAdmissionService.dataDomainFor}) and the realm read
+     * ({@code findActiveTBox(realmDataDomain(realm))}). Because every caller now
+     * computes the identical key for a realm, the per-realm registry cache
+     * ({@code realmRegistries.computeIfAbsent(realm, ...)}) is also correct:
+     * whichever thread warms the cache first derives the same lookup key, so the
+     * first-warmer-wins behaviour can no longer pin a principal-dependent key.</p>
+     *
+     * <p>The tenant-active lookup ({@code TenantOntologyTBoxRepo.findActiveTBox})
+     * keys only on org/account/tenantId/dataSegment (not owner), all of which are
+     * constants of {@code realm} here, so write == read is deterministic per realm.
+     * Admission may additionally layer an explicit request-body DataDomain on top
+     * of this base, but it must not diverge from this key for {realm}-scoped
+     * endpoints (enforced in {@code TBoxAdmissionService.dataDomainFor}).</p>
+     *
+     * @param realm the realm (== tenantId); must be non-blank
+     * @return the canonical, principal-independent DataDomain for the realm
+     */
+    public static DataDomain realmDataDomain(String realm) {
+        // PURE function of realm: do NOT read SecurityContext/PrincipalContext here.
+        // The lookup key MUST be identical for the same realm across every caller
+        // (HTTP-under-JWT, OntologyReindexer system principal, or no principal),
+        // otherwise admission-write and realm-read can drift onto different keys
+        // and an activation is silently missed (the multi-principal blocker).
+        String tenantId = realm;
+        String org = realm;
+        String account = realm;
+        String owner = realm;
+        int segment = 0;
+        return new DataDomain(org, account, tenantId, segment, owner);
     }
 
     // --- Private Methods ---
@@ -224,6 +297,34 @@ public class TenantOntologyRegistryProvider {
                 .orElse(true);
         boolean forceRebuild = config.getOptionalValue("quantum.ontology.tbox.force-rebuild", Boolean.class)
                 .orElse(false);
+
+        // 0. B2 read-path unification: prefer an ACTIVATED TenantOntologyTBox for
+        // this realm if one exists. This is strictly additive — behavior changes
+        // ONLY when admission has activated a tenant TBox for realmDataDomain(realm);
+        // realms with no active tenant TBox fall through UNCHANGED to the legacy
+        // findLatest()/build path below. realmDataDomain() is the SAME derivation
+        // the admission write path uses, so write and read can never drift.
+        //
+        // This is intentionally NOT gated by force-rebuild: force-rebuild governs
+        // rebuilding the legacy/source-derived TBox, whereas an activated tenant
+        // TBox is an explicit admission decision that must be observed on reads.
+        try {
+            Optional<TenantOntologyTBox> activeTenantTBox =
+                    tenantTboxRepo.findActiveTBox(realmDataDomain(realm));
+            if (activeTenantTBox.isPresent()) {
+                TenantOntologyTBox doc = activeTenantTBox.get();
+                Log.infof("Realm %s: using ACTIVE TenantOntologyTBox (hash: %s) for read path",
+                        realm, doc.getTboxHash());
+                return new PersistedOntologyRegistry(
+                        doc.toTBox(),
+                        doc.getTboxHash(),
+                        doc.getYamlHash(),
+                        false);
+            }
+        } catch (Throwable t) {
+            Log.warnf("Failed to load active TenantOntologyTBox for realm %s, "
+                    + "falling back to legacy load: %s", realm, t.getMessage());
+        }
 
         // 1. Try to load from persisted TBox first (if persistence is enabled)
         if (persistTBox && !forceRebuild) {

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
@@ -81,6 +81,44 @@ public class TenantOntologyRegistryProvider {
     }
 
     /**
+     * B5 vocabulary tier: the set of ontology predicates ADMITTED for policy
+     * (security-rule) use in the current security-context realm.
+     * <p>
+     * Resolves the realm the SAME way {@link #getRegistry()} does (via the current
+     * SecurityContext, falling back to {@code defaultRealm}), then reads the realm's
+     * ACTIVE {@link TenantOntologyTBox} fresh (NOT cached — admission state changes
+     * out-of-band). Returns:
+     * <ul>
+     *   <li>{@code Optional.of(set)} when an active tenant TBox exists and its
+     *       {@code admittedPredicates} field is non-null (governed realm); the set
+     *       defines exactly which declared predicates may be referenced by rules.</li>
+     *   <li>{@code Optional.empty()} otherwise — no active tenant doc, or a legacy
+     *       doc with a null {@code admittedPredicates} field — meaning "all declared
+     *       predicates admitted" (back-compat).</li>
+     * </ul>
+     * Read fresh on every call and fully null-safe.
+     * </p>
+     * @return the admitted-predicate set for the current realm, or empty for legacy
+     */
+    public java.util.Optional<java.util.Set<String>> admittedPredicatesForCurrentRealm() {
+        String realm = getCurrentRealm();
+        try {
+            Optional<TenantOntologyTBox> activeTenantTBox =
+                    tenantTboxRepo.findActiveTBox(realmDataDomain(realm));
+            if (activeTenantTBox.isPresent()) {
+                java.util.Set<String> admitted = activeTenantTBox.get().getAdmittedPredicates();
+                if (admitted != null) {
+                    return java.util.Optional.of(admitted);
+                }
+            }
+        } catch (Throwable t) {
+            Log.debugf("admittedPredicatesForCurrentRealm: could not resolve active tenant TBox for "
+                    + "realm %s, treating as legacy (all admitted): %s", realm, t.getMessage());
+        }
+        return java.util.Optional.empty();
+    }
+
+    /**
      * Get the ontology registry for a specific realm.
      * <p>
      * If no cached registry exists, attempts to load from persisted TBox.

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
@@ -81,41 +81,91 @@ public class TenantOntologyRegistryProvider {
     }
 
     /**
-     * B5 vocabulary tier: the set of ontology predicates ADMITTED for policy
-     * (security-rule) use in the current security-context realm.
+     * B5 vocabulary tier: resolve the THREE-state admitted-predicate disposition
+     * for policy (security-rule) use in the current security-context realm.
      * <p>
      * Resolves the realm the SAME way {@link #getRegistry()} does (via the current
      * SecurityContext, falling back to {@code defaultRealm}), then reads the realm's
      * ACTIVE {@link TenantOntologyTBox} fresh (NOT cached — admission state changes
      * out-of-band). Returns:
      * <ul>
-     *   <li>{@code Optional.of(set)} when an active tenant TBox exists and its
-     *       {@code admittedPredicates} field is non-null (governed realm); the set
-     *       defines exactly which declared predicates may be referenced by rules.</li>
-     *   <li>{@code Optional.empty()} otherwise — no active tenant doc, or a legacy
-     *       doc with a null {@code admittedPredicates} field — meaning "all declared
-     *       predicates admitted" (back-compat).</li>
+     *   <li>{@link AdmittedVocabularyResult#governed(java.util.Set)} when an active
+     *       tenant TBox exists and its {@code admittedPredicates} field is non-null
+     *       (governed realm); the set defines exactly which declared predicates may
+     *       be referenced by rules. Decided at the {@code admitted != null} branch
+     *       below.</li>
+     *   <li>{@link AdmittedVocabularyResult#legacy()} when there is no active tenant
+     *       doc, or a legacy doc with a {@code null admittedPredicates} field —
+     *       meaning "all declared predicates admitted" (back-compat). Decided at the
+     *       fall-through {@code return legacy()} below.</li>
+     *   <li>{@link AdmittedVocabularyResult#unavailable()} when the read THREW (the
+     *       {@code catch (Throwable)} branch). This is the security-critical case:
+     *       the caller (policy guard) must fail CLOSED rather than treat the blip as
+     *       legacy/all-admitted. We do NOT silently downgrade a GOVERNED realm on a
+     *       transient Mongo failure.</li>
      * </ul>
      * Read fresh on every call and fully null-safe.
      * </p>
-     * @return the admitted-predicate set for the current realm, or empty for legacy
+     *
+     * <p><b>Availability tradeoff (surfaced for review):</b> mapping the read
+     * failure to UNAVAILABLE means that during a Mongo outage, security-rule
+     * (re)loading for a GOVERNED realm is rejected (fail CLOSED). This is a
+     * deliberate trade of availability for security — it prevents a transient blip
+     * from re-opening every declared predicate. It intentionally does NOT add a
+     * bounded stale-TTL cache (B4, out of scope); it only fails closed and emits an
+     * observable signal so the downgrade-attempt is visible.</p>
+     *
+     * @return the 3-state admitted-vocabulary disposition for the current realm
      */
-    public java.util.Optional<java.util.Set<String>> admittedPredicatesForCurrentRealm() {
+    public AdmittedVocabularyResult admittedVocabularyForCurrentRealm() {
         String realm = getCurrentRealm();
+        // realmDataDomain(realm) is pure logic — compute it OUTSIDE the try so a bug there
+        // surfaces normally rather than being masked as a read failure (UNAVAILABLE).
+        var dataDomain = realmDataDomain(realm);
+        Optional<TenantOntologyTBox> activeTenantTBox;
         try {
-            Optional<TenantOntologyTBox> activeTenantTBox =
-                    tenantTboxRepo.findActiveTBox(realmDataDomain(realm));
-            if (activeTenantTBox.isPresent()) {
-                java.util.Set<String> admitted = activeTenantTBox.get().getAdmittedPredicates();
-                if (admitted != null) {
-                    return java.util.Optional.of(admitted);
-                }
-            }
+            // ONLY the Mongo read may signal UNAVAILABLE. The null-check / GOVERNED-vs-LEGACY
+            // construction below is pure logic and must NOT be reclassified as a read failure,
+            // or a programming bug would masquerade as a transient outage.
+            activeTenantTBox = tenantTboxRepo.findActiveTBox(dataDomain);
         } catch (Throwable t) {
-            Log.debugf("admittedPredicatesForCurrentRealm: could not resolve active tenant TBox for "
-                    + "realm %s, treating as legacy (all admitted): %s", realm, t.getMessage());
+            // UNAVAILABLE: the read threw. Do NOT collapse to legacy/all-admitted —
+            // that is the fail-OPEN security downgrade this method exists to close.
+            // Log WITH the throwable (stack) so the fail-closed event is diagnosable
+            // (t.getMessage() is often null, e.g. for NPEs).
+            Log.warn("admittedVocabularyForCurrentRealm: admitted-set read FAILED for realm " + realm
+                    + "; returning UNAVAILABLE so the policy guard fails CLOSED (no predicates admitted "
+                    + "for rule references) instead of silently downgrading to all-admitted", t);
+            return AdmittedVocabularyResult.unavailable();
         }
-        return java.util.Optional.empty();
+        if (activeTenantTBox.isPresent()) {
+            java.util.Set<String> admitted = activeTenantTBox.get().getAdmittedPredicates();
+            if (admitted != null) {
+                // GOVERNED: enforce exactly this set for rule references.
+                return AdmittedVocabularyResult.governed(admitted);
+            }
+        }
+        // LEGACY: no active doc, or active doc with null admittedPredicates.
+        return AdmittedVocabularyResult.legacy();
+    }
+
+    /**
+     * Legacy 2-state projection of {@link #admittedVocabularyForCurrentRealm()}:
+     * GOVERNED -&gt; the admitted set, LEGACY and UNAVAILABLE -&gt; {@code empty()}.
+     * <p>
+     * <b>Do NOT use this from the policy guard.</b> It cannot distinguish the
+     * read-failure (UNAVAILABLE) state from legacy and therefore re-opens the
+     * fail-OPEN downgrade. It is retained only for any back-compat caller that
+     * predates the 3-state contract; new code must call
+     * {@link #admittedVocabularyForCurrentRealm()} and fail closed on UNAVAILABLE.
+     * </p>
+     * @return the admitted-predicate set for the current realm, or empty for legacy
+     * @deprecated prefer {@link #admittedVocabularyForCurrentRealm()} which exposes
+     *             the UNAVAILABLE state required to fail closed.
+     */
+    @Deprecated
+    public java.util.Optional<java.util.Set<String>> admittedPredicatesForCurrentRealm() {
+        return admittedVocabularyForCurrentRealm().asLegacyOptional();
     }
 
     /**

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/service/OntologyReindexer.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/service/OntologyReindexer.java
@@ -199,8 +199,16 @@ public class OntologyReindexer {
                     Optional<String> src = metaService.getMeta(realmId).map(m -> m.getSource());
                     Optional<Path> p = src.filter(s -> s != null && !s.equals("<none>")).map(Path::of).filter(Files::exists);
                     var res = metaService.observeYaml(realmId, p, "/ontology.yaml");
-                    // Get tboxHash from runtime registry and yamlVersion from metadata
-                    var appliedRegistry = registryProvider.getRegistryForRealm(realmId);
+                    // Pin/markApplied from the REBUILT SOURCE TBox we just produced
+                    // (annotations + Morphia scan + YAML), NOT from the activation-
+                    // preferring getRegistryForRealm(): after B2 read-path unification
+                    // that read path returns an admission-activated tenant TBox when one
+                    // exists, which would make the reindexer pin the activated hash
+                    // instead of the source TBox it just reindexed (a regression).
+                    // buildSourceRegistry() bypasses the activation preference and does
+                    // not touch the cache; with no activation present it is identical to
+                    // the prior getRegistryForRealm() result, so behaviour is unchanged.
+                    var appliedRegistry = registryProvider.buildSourceRegistry(realmId);
                     String tboxHash = appliedRegistry.getTBoxHash();
                     Integer yamlVersion = res.meta().getYamlVersion();
                     metaService.markApplied(realmId, res.currentHash(), tboxHash, yamlVersion);

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/model/TenantOntologyTBoxAdmittedHashInvarianceTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/model/TenantOntologyTBoxAdmittedHashInvarianceTest.java
@@ -1,0 +1,80 @@
+package com.e2eq.ontology.model;
+
+import com.e2eq.ontology.core.CanonicalTBoxHasher;
+import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.PropertyDef;
+import com.e2eq.ontology.core.OntologyRegistry.TBox;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * B5 SLICE 1 — HASH INVARIANCE (the load-bearing test).
+ *
+ * <p>The realm-governance {@code admittedPredicates} field on
+ * {@link TenantOntologyTBox} is out-of-band from pack identity: it MUST NOT
+ * reach {@link CanonicalTBoxHasher}. Two docs identical except for
+ * {@code admittedPredicates} must produce the same canonical TBox hash, because
+ * {@code toTBox()} does not surface that field.</p>
+ */
+public class TenantOntologyTBoxAdmittedHashInvarianceTest {
+
+    private static final CanonicalTBoxHasher.PackMetadata META =
+            new CanonicalTBoxHasher.PackMetadata("realm-pack", "Realm Pack", 1, "closed", null, null);
+
+    private static TenantOntologyTBox docWith(Set<String> admitted) {
+        Map<String, ClassDef> classes = Map.of(
+                "Associate", new ClassDef("Associate", Set.of(), Set.of(), Set.of()),
+                "Location", new ClassDef("Location", Set.of(), Set.of(), Set.of()));
+        Map<String, PropertyDef> properties = Map.of(
+                "canSeeLocation", new PropertyDef("canSeeLocation",
+                        Optional.of("Associate"), Optional.of("Location"),
+                        false, Optional.empty(), false, false, false, Set.of(), false),
+                "ownsTerritory", new PropertyDef("ownsTerritory",
+                        Optional.empty(), Optional.empty(),
+                        false, Optional.empty(), false, false, false, Set.of(), false));
+        TBox tbox = new TBox(classes, properties, List.of());
+        TenantOntologyTBox doc = new TenantOntologyTBox(tbox, "h", "y", "submit", "1.0.0");
+        doc.setAdmittedPredicates(admitted);
+        return doc;
+    }
+
+    @Test
+    void admittedPredicatesDoesNotChangeCanonicalHash() {
+        TenantOntologyTBox legacy = docWith(null);                              // null == all admitted
+        TenantOntologyTBox partial = docWith(Set.of("canSeeLocation"));         // one provisional
+        TenantOntologyTBox full = docWith(Set.of("canSeeLocation", "ownsTerritory"));
+        TenantOntologyTBox empty = docWith(Set.of());                          // all provisional
+
+        String legacyHash = CanonicalTBoxHasher.hashTBox(legacy.toTBox(), META);
+        String partialHash = CanonicalTBoxHasher.hashTBox(partial.toTBox(), META);
+        String fullHash = CanonicalTBoxHasher.hashTBox(full.toTBox(), META);
+        String emptyHash = CanonicalTBoxHasher.hashTBox(empty.toTBox(), META);
+
+        assertNotNull(legacyHash);
+        assertEquals(legacyHash, partialHash,
+                "setting admittedPredicates must NOT change the canonical TBox hash");
+        assertEquals(legacyHash, fullHash,
+                "a different admittedPredicates value must NOT change the canonical TBox hash");
+        assertEquals(legacyHash, emptyHash,
+                "an empty admittedPredicates set must NOT change the canonical TBox hash");
+    }
+
+    @Test
+    void toTBoxDoesNotCarryAdmittedPredicates() {
+        // The realm-governance field is invisible to the TBox record entirely:
+        // toTBox() only exposes classes/properties/chains. (No admitted accessor exists
+        // on TBox, so this is verified by the hash-invariance assertion above plus the
+        // structural equality of the produced TBoxes.)
+        TenantOntologyTBox a = docWith(Set.of("canSeeLocation"));
+        TenantOntologyTBox b = docWith(Set.of("ownsTerritory"));
+        assertEquals(a.toTBox().properties().keySet(), b.toTBox().properties().keySet());
+        assertEquals(a.toTBox().classes().keySet(), b.toTBox().classes().keySet());
+    }
+}

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
@@ -1,0 +1,216 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.security.DataDomainComponentBinding;
+import com.e2eq.framework.model.security.DataDomainPolicy;
+import com.e2eq.framework.model.security.DataDomainPolicyEntry;
+import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import com.e2eq.ontology.core.DataDomainInfo;
+import com.e2eq.ontology.core.EdgeRecord;
+import com.e2eq.ontology.model.OntologyEdge;
+import com.e2eq.ontology.model.QuarantinedEdge;
+import com.e2eq.ontology.repo.EdgeIngestResult;
+import com.e2eq.ontology.repo.EdgeIngestSummary;
+import com.e2eq.ontology.repo.OntologyEdgeRepo;
+import com.e2eq.ontology.repo.SourcePolicyContext;
+import dev.morphia.Datastore;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * N3 acceptance (S3): the governed, fail-closed edge-ingest path with quarantine.
+ *
+ * <p>Asserts that {@link OntologyEdgeRepo#ingestEdges} resolves each row through the DataDomain
+ * resolver and either stamps the resolved domain into the {@code edges} collection or, when the
+ * row cannot be placed, writes a {@link QuarantinedEdge} to {@code ontology_edge_quarantine} and
+ * NOTHING to {@code edges} — never synthesizing a default/{@code __unowned} domain.</p>
+ */
+@QuarkusTest
+public class OntologyEdgeIngestQuarantineTest {
+
+    private static final String REALM = "ingest-quarantine-test";
+
+    @Inject
+    OntologyEdgeRepo edgeRepo;
+
+    private DataDomain principalDD;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContext.clear();
+    }
+
+    @BeforeEach
+    void setup() {
+        // A principal/security context so ingestEdges' upsert and ds() resolve to a known realm.
+        principalDD = new DataDomain();
+        principalDD.setOrgRefName("ingest-org");
+        principalDD.setAccountNum("9999999999");
+        principalDD.setTenantId("ingest-tenant");
+        principalDD.setOwnerId("system");
+        principalDD.setDataSegment(0);
+
+        DomainContext domainContext = DomainContext.builder()
+                .tenantId("ingest-tenant")
+                .defaultRealm(REALM)
+                .orgRefName("ingest-org")
+                .accountId("9999999999")
+                .dataSegment(0)
+                .build();
+
+        PrincipalContext principal = new PrincipalContext.Builder()
+                .withUserId("system@ingest")
+                .withDefaultRealm(REALM)
+                .withDomainContext(domainContext)
+                .withDataDomain(principalDD)
+                .withRoles(new String[]{"admin"})
+                .withScope("AUTHENTICATED")
+                .build();
+        SecurityContext.setPrincipalContext(principal);
+        SecurityContext.setResourceContext(ResourceContext.DEFAULT_ANONYMOUS_CONTEXT);
+
+        // Clean both collections in this realm.
+        edgeRepo.deleteAll(REALM);
+        Datastore ds = edgeRepo.ds(REALM);
+        ds.getCollection(OntologyEdge.class).deleteMany(new org.bson.Document());
+        ds.getCollection(QuarantinedEdge.class).deleteMany(new org.bson.Document());
+    }
+
+    /**
+     * A FROM_SOURCE policy that requires tenant_id (+org/account literals) from the row. Rows that
+     * carry tenant_id resolve; rows that don't are unplaceable → quarantine.
+     */
+    private SourcePolicyContext sourceCtx() {
+        DataDomainComponentBinding binding = new DataDomainComponentBinding();
+        binding.setOrgRefName(DataDomainComponentBinding.Binding.literal("ingest-org"));
+        binding.setAccountNum(DataDomainComponentBinding.Binding.literal("9999999999"));
+        binding.setTenantId(DataDomainComponentBinding.Binding.fromAttribute("tenant_id"));
+
+        DataDomainPolicyEntry entry = new DataDomainPolicyEntry();
+        entry.setResolutionMode(DataDomainPolicyEntry.ResolutionMode.FROM_SOURCE);
+        entry.setComponentBinding(binding);
+
+        DataDomainPolicy policy = new DataDomainPolicy();
+        Map<String, DataDomainPolicyEntry> entries = new HashMap<>();
+        entries.put("ontology:edge", entry);
+        policy.setPolicyEntries(entries);
+
+        return new SourcePolicyContext("feed-1", policy);
+    }
+
+    private EdgeRecord row(String src, String dst, Map<String, Object> prov) {
+        // DataDomainInfo is deliberately set to something the resolver does NOT use; placement is
+        // governed by the policy, not by the caller-supplied domain.
+        DataDomainInfo bogus = new DataDomainInfo("BOGUS-ORG", "0000000000", "bogus-tenant", 0);
+        EdgeRecord e = new EdgeRecord(bogus, "Order", src, "placedBy", "Customer", dst, false, prov, new java.util.Date());
+        return e;
+    }
+
+    private long edgeCount() {
+        return edgeRepo.ds(REALM).getCollection(OntologyEdge.class).countDocuments();
+    }
+
+    private long quarantineCount() {
+        return edgeRepo.ds(REALM).getCollection(QuarantinedEdge.class).countDocuments();
+    }
+
+    @Test
+    void unplaceableRow_quarantined_zeroEdges_oneQuarantine_noSynthesizedDomain() {
+        // No tenant_id in prov → resolver returns Unresolvable.
+        EdgeRecord bad = row("ORDER-BAD", "CUST-BAD", new HashMap<>());
+
+        EdgeIngestSummary summary = edgeRepo.ingestEdges(sourceCtx(), List.of(bad));
+
+        assertEquals(0, edgeCount(), "no edge document may be written for an unplaceable row");
+        assertEquals(1, quarantineCount(), "exactly one quarantine document");
+        assertEquals(0, summary.getAcceptedCount());
+        assertEquals(1, summary.getQuarantinedCount());
+
+        // The quarantined edge carries the failing reason and source, and there is NO synthesized
+        // / __unowned domain anywhere in the edges collection (it is empty).
+        QuarantinedEdge q = edgeRepo.ds(REALM).find(QuarantinedEdge.class).first();
+        assertNotNull(q);
+        assertEquals("ORDER-BAD", q.getSrc());
+        assertEquals("feed-1", q.getSourceId());
+        assertNotNull(q.getReason());
+        assertTrue(q.getReason().toLowerCase().contains("tenant"), "reason should name the missing component");
+
+        // No edge has a synthesized/__unowned domain.
+        List<OntologyEdge> all = edgeRepo.ds(REALM).find(OntologyEdge.class).iterator().toList();
+        assertTrue(all.isEmpty(), "edges collection must be unchanged (empty)");
+        for (OntologyEdge e : all) {
+            assertFalse("__unowned".equals(e.getDataDomain().getTenantId()));
+            assertFalse("__UNRESOLVABLE__".equals(e.getDataDomain().getOrgRefName()));
+        }
+    }
+
+    @Test
+    void resolvableRow_oneScopedEdge_noQuarantine() {
+        Map<String, Object> prov = new HashMap<>();
+        prov.put("tenant_id", "ingest-tenant");
+        EdgeRecord good = row("ORDER-OK", "CUST-OK", prov);
+
+        EdgeIngestSummary summary = edgeRepo.ingestEdges(sourceCtx(), List.of(good));
+
+        assertEquals(1, edgeCount(), "exactly one edge document for a resolvable row");
+        assertEquals(0, quarantineCount(), "no quarantine for a resolvable row");
+        assertEquals(1, summary.getAcceptedCount());
+        assertEquals(0, summary.getQuarantinedCount());
+
+        OntologyEdge e = edgeRepo.ds(REALM).find(OntologyEdge.class).first();
+        assertNotNull(e);
+        assertEquals("ingest-org", e.getDataDomain().getOrgRefName());
+        assertEquals("9999999999", e.getDataDomain().getAccountNum());
+        assertEquals("ingest-tenant", e.getDataDomain().getTenantId());
+        assertEquals("ORDER-OK", e.getSrc());
+        assertEquals("CUST-OK", e.getDst());
+    }
+
+    @Test
+    void mixedBatch_oneResolvable_oneNot_oneEdge_oneQuarantine_resultsEnumerateBoth() {
+        Map<String, Object> goodProv = new HashMap<>();
+        goodProv.put("tenant_id", "ingest-tenant");
+        EdgeRecord good = row("ORDER-OK", "CUST-OK", goodProv);
+        EdgeRecord bad = row("ORDER-BAD", "CUST-BAD", new HashMap<>());
+
+        List<EdgeRecord> batch = new ArrayList<>();
+        batch.add(good);
+        batch.add(bad);
+
+        EdgeIngestSummary summary = edgeRepo.ingestEdges(sourceCtx(), batch);
+
+        assertEquals(1, edgeCount(), "exactly 1 edge persisted (the resolvable one)");
+        assertEquals(1, quarantineCount(), "exactly 1 quarantine (the unplaceable one)");
+        assertEquals(1, summary.getAcceptedCount());
+        assertEquals(1, summary.getQuarantinedCount());
+        assertEquals(2, summary.getResults().size(), "per-record results enumerate both rows");
+
+        boolean sawAccepted = false, sawQuarantined = false;
+        for (EdgeIngestResult r : summary.getResults()) {
+            if (r.isAccepted()) sawAccepted = true;
+            if (r.isQuarantined()) sawQuarantined = true;
+        }
+        assertTrue(sawAccepted && sawQuarantined, "results enumerate both an ACCEPTED and a QUARANTINED row");
+
+        // The persisted edge is the good one with the governed domain.
+        OntologyEdge e = edgeRepo.ds(REALM).find(OntologyEdge.class).first();
+        assertEquals("ORDER-OK", e.getSrc());
+        assertEquals("ingest-tenant", e.getDataDomain().getTenantId());
+    }
+}

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderAdmittedTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderAdmittedTest.java
@@ -1,0 +1,101 @@
+package com.e2eq.ontology.runtime;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.TBox;
+import com.e2eq.ontology.model.TenantOntologyTBox;
+import com.e2eq.ontology.repo.OntologyTBoxRepo;
+import com.e2eq.ontology.repo.TenantOntologyTBoxRepo;
+import com.e2eq.ontology.service.OntologyMetaService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * B5 SLICE 1 — provider resolution of the realm's admitted-predicate set
+ * (no Quarkus / no Mongo / no SecurityContext, so the realm resolves to
+ * {@code defaultRealm}, which we set directly on the package-private field).
+ */
+public class TenantOntologyRegistryProviderAdmittedTest {
+
+    private static final String REALM = "acme-realm";
+
+    private TenantOntologyRegistryProvider newProvider(TenantOntologyTBoxRepo tenantRepo) {
+        TenantOntologyRegistryProvider p = new TenantOntologyRegistryProvider();
+        p.tenantTboxRepo = tenantRepo;
+        p.tboxRepo = mock(OntologyTBoxRepo.class);
+        p.metaService = mock(OntologyMetaService.class);
+        p.defaultRealm = REALM; // no SecurityContext in this test -> getCurrentRealm() == defaultRealm
+        return p;
+    }
+
+    private static TenantOntologyTBox docWithAdmitted(Set<String> admitted) {
+        TBox tbox = new TBox(
+                Map.of("Associate", new ClassDef("Associate", Set.of(), Set.of(), Set.of())),
+                Map.of(), List.of());
+        TenantOntologyTBox doc = new TenantOntologyTBox(tbox, "h", "y", "submit", "1.0.0");
+        doc.setActive(true);
+        doc.setAdmittedPredicates(admitted);
+        return doc;
+    }
+
+    @Test
+    void returnsAdmittedSetWhenActiveDocHasNonNullField() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenReturn(Optional.of(docWithAdmitted(Set.of("canSeeLocation"))));
+
+        Optional<Set<String>> admitted = newProvider(tenantRepo).admittedPredicatesForCurrentRealm();
+
+        assertTrue(admitted.isPresent());
+        assertEquals(Set.of("canSeeLocation"), admitted.get());
+        verify(tenantRepo).findActiveTBox(eq(TenantOntologyRegistryProvider.realmDataDomain(REALM)));
+    }
+
+    @Test
+    void emptyWhenActiveDocHasNullAdmittedField_legacy() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenReturn(Optional.of(docWithAdmitted(null)));
+
+        assertTrue(newProvider(tenantRepo).admittedPredicatesForCurrentRealm().isEmpty(),
+                "null admittedPredicates field == legacy (all admitted) == Optional.empty()");
+    }
+
+    @Test
+    void emptyWhenNoActiveDoc() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class))).thenReturn(Optional.empty());
+
+        assertTrue(newProvider(tenantRepo).admittedPredicatesForCurrentRealm().isEmpty());
+    }
+
+    @Test
+    void emptyAndNullSafeWhenRepoThrows() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenThrow(new RuntimeException("mongo down"));
+
+        assertTrue(newProvider(tenantRepo).admittedPredicatesForCurrentRealm().isEmpty(),
+                "must be null-safe and treat resolution failure as legacy (all admitted)");
+    }
+
+    @Test
+    void readsFreshOnEachCall_notCached() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenReturn(Optional.of(docWithAdmitted(Set.of("a"))))
+                .thenReturn(Optional.of(docWithAdmitted(Set.of("a", "b"))));
+
+        TenantOntologyRegistryProvider provider = newProvider(tenantRepo);
+        assertEquals(Set.of("a"), provider.admittedPredicatesForCurrentRealm().get());
+        assertEquals(Set.of("a", "b"), provider.admittedPredicatesForCurrentRealm().get());
+        verify(tenantRepo, times(2)).findActiveTBox(any(DataDomain.class));
+    }
+}

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderAdmittedTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderAdmittedTest.java
@@ -86,6 +86,62 @@ public class TenantOntologyRegistryProviderAdmittedTest {
                 "must be null-safe and treat resolution failure as legacy (all admitted)");
     }
 
+    // --- B5 3-state disposition (admittedVocabularyForCurrentRealm) -----------
+
+    @Test
+    void governed_whenActiveDocHasNonNullAdmittedSet() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenReturn(Optional.of(docWithAdmitted(Set.of("canSeeLocation"))));
+
+        AdmittedVocabularyResult r = newProvider(tenantRepo).admittedVocabularyForCurrentRealm();
+
+        assertEquals(AdmittedVocabularyResult.Kind.GOVERNED, r.kind());
+        assertEquals(Set.of("canSeeLocation"), r.admitted());
+    }
+
+    @Test
+    void legacy_whenActiveDocHasNullAdmittedField() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenReturn(Optional.of(docWithAdmitted(null)));
+
+        assertEquals(AdmittedVocabularyResult.Kind.LEGACY,
+                newProvider(tenantRepo).admittedVocabularyForCurrentRealm().kind());
+    }
+
+    @Test
+    void legacy_whenNoActiveDoc() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class))).thenReturn(Optional.empty());
+
+        assertEquals(AdmittedVocabularyResult.Kind.LEGACY,
+                newProvider(tenantRepo).admittedVocabularyForCurrentRealm().kind());
+    }
+
+    @Test
+    void unavailable_whenRepoThrows_notLegacy() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenThrow(new RuntimeException("mongo down"));
+
+        AdmittedVocabularyResult r = newProvider(tenantRepo).admittedVocabularyForCurrentRealm();
+
+        assertEquals(AdmittedVocabularyResult.Kind.UNAVAILABLE, r.kind(),
+                "a read failure must surface as UNAVAILABLE (fail-closed), not LEGACY (fail-open)");
+    }
+
+    @Test
+    void legacyOptionalProjection_mapsUnavailableToEmpty_backCompat() {
+        // The deprecated 2-state method must preserve its exact prior behavior:
+        // read failure -> Optional.empty() (so pre-existing callers/tests stay green).
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        when(tenantRepo.findActiveTBox(any(DataDomain.class)))
+                .thenThrow(new RuntimeException("mongo down"));
+
+        assertTrue(newProvider(tenantRepo).admittedPredicatesForCurrentRealm().isEmpty());
+    }
+
     @Test
     void readsFreshOnEachCall_notCached() {
         TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderMultiPrincipalTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderMultiPrincipalTest.java
@@ -1,0 +1,167 @@
+package com.e2eq.ontology.runtime;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import com.e2eq.ontology.core.OntologyRegistry;
+import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.TBox;
+import com.e2eq.ontology.model.OntologyTBox;
+import com.e2eq.ontology.model.TenantOntologyTBox;
+import com.e2eq.ontology.repo.OntologyTBoxRepo;
+import com.e2eq.ontology.repo.TenantOntologyTBoxRepo;
+import com.e2eq.ontology.service.OntologyMetaService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Multi-principal correctness guard for the B2 read-path unification blocker.
+ *
+ * <p>The realm read lookup ({@code findActiveTBox(realmDataDomain(realm))}) and the
+ * admission write ({@code TBoxAdmissionService.dataDomainFor}) BOTH key on
+ * {@link TenantOntologyRegistryProvider#realmDataDomain(String)}. If that derivation
+ * mixed in the ambient {@link PrincipalContext} DataDomain (the original bug), two
+ * callers in the SAME realm but under DIFFERENT principals (e.g. the
+ * {@code OntologyReindexer} system principal vs. an HTTP admin under their JWT) would
+ * compute DIFFERENT keys, and an activation written under one principal would be
+ * invisible to a read under the other.</p>
+ *
+ * <p>These tests assert {@code realmDataDomain(realm)} is a PURE function of the
+ * realm string — byte-identical under two different ambient principals — and that a
+ * tenant TBox activated under {@code realmDataDomain(REALM)} resolves on reads
+ * performed under either principal. They FAIL against the old ambient-mixing
+ * derivation and PASS after Change 1.</p>
+ */
+public class TenantOntologyRegistryProviderMultiPrincipalTest {
+
+    private static final String REALM = "acme-realm";
+
+    @AfterEach
+    void clearContext() {
+        SecurityContext.clear();
+    }
+
+    private PrincipalContext principalWith(String org, String account, String owner, int segment) {
+        DataDomain dd = new DataDomain(org, account, REALM, segment, owner);
+        return new PrincipalContext.Builder()
+                .withDefaultRealm(REALM)
+                .withDataDomain(dd)
+                .withUserId("user@" + org)
+                .withScope("ALL")
+                .build();
+    }
+
+    /**
+     * Core blocker assertion: realmDataDomain(realm) is principal-INDEPENDENT.
+     * <p>Compute it under principal A (org "ontology", account "0000000000"), then
+     * under a totally different principal B (org "acmeOrg", account "9999999999",
+     * different segment), same realm. The two results MUST be equal. Under the old
+     * ambient-mixing code the org/account/owner/segment were overridden from the
+     * principal, so the two keys diverged and this fails.</p>
+     */
+    @Test
+    void realmDataDomainIsPrincipalIndependent() {
+        SecurityContext.setPrincipalContext(principalWith("ontology", "0000000000", "system", 0));
+        DataDomain underA = TenantOntologyRegistryProvider.realmDataDomain(REALM);
+        SecurityContext.clearPrincipalContext();
+
+        SecurityContext.setPrincipalContext(principalWith("acmeOrg", "9999999999", "adminUser", 7));
+        DataDomain underB = TenantOntologyRegistryProvider.realmDataDomain(REALM);
+        SecurityContext.clearPrincipalContext();
+
+        // Same realm -> byte-identical key regardless of ambient principal.
+        assertEquals(underA, underB,
+                "realmDataDomain(realm) must be a pure function of realm, not the ambient principal");
+        // And with NO principal at all.
+        DataDomain underNone = TenantOntologyRegistryProvider.realmDataDomain(REALM);
+        assertEquals(underA, underNone,
+                "realmDataDomain(realm) must be identical with no ambient principal");
+
+        // Spell out the canonical fixed-per-realm convention so a regression is obvious.
+        assertEquals(REALM, underA.getTenantId());
+        assertEquals(REALM, underA.getOrgRefName());
+        assertEquals(REALM, underA.getAccountNum());
+        assertEquals(REALM, underA.getOwnerId());
+        assertEquals(0, underA.getDataSegment());
+    }
+
+    /**
+     * End-to-end read resolution under two different principals: an active tenant
+     * TBox is written under {@code realmDataDomain(REALM)}; two reads simulated under
+     * DIFFERENT ambient principals (different org/account, same realm) BOTH resolve
+     * the SAME activated TBox because the lookup key is principal-independent.
+     */
+    @Test
+    void twoPrincipalsResolveSameActivatedTBox() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        OntologyTBoxRepo legacyRepo = mock(OntologyTBoxRepo.class);
+        OntologyMetaService metaService = mock(OntologyMetaService.class);
+
+        // The single key under which the active tenant TBox is stored == realmDataDomain(REALM).
+        DataDomain activeKey = TenantOntologyRegistryProvider.realmDataDomain(REALM);
+
+        TBox tenantTBox = new TBox(
+                Map.of("TenantOnlyClass", new ClassDef("TenantOnlyClass", Set.of(), Set.of(), Set.of())),
+                Map.of(),
+                List.of());
+        TenantOntologyTBox doc = new TenantOntologyTBox(tenantTBox, "tenant-hash", "tenant-yaml", "submit", "1.0.0");
+        doc.setActive(true);
+
+        // The repo only returns the doc when queried with the SAME key it was stored under.
+        // (Captures the realm-deterministic-key contract: a divergent key -> empty.)
+        when(tenantRepo.findActiveTBox(any(DataDomain.class))).thenAnswer(inv -> {
+            DataDomain queried = inv.getArgument(0);
+            return queried.equals(activeKey) ? Optional.of(doc) : Optional.empty();
+        });
+
+        // Legacy fallback would surface a different class; if a read drifts onto a
+        // different key it would fall through to here and we'd detect it.
+        TBox legacyTBox = new TBox(
+                Map.of("LegacyOnlyClass", new ClassDef("LegacyOnlyClass", Set.of(), Set.of(), Set.of())),
+                Map.of(),
+                List.of());
+        OntologyTBox legacyDoc = new OntologyTBox(legacyTBox, "legacy-hash", "legacy-yaml", "ontology.yaml");
+        lenient().when(legacyRepo.findLatest()).thenReturn(Optional.of(legacyDoc));
+
+        AtomicReference<OntologyRegistry> underA = new AtomicReference<>();
+        AtomicReference<OntologyRegistry> underB = new AtomicReference<>();
+
+        // Read 1 under principal A. Fresh provider (no cache) per read so the cache
+        // cannot mask a per-principal key divergence.
+        SecurityContext.setPrincipalContext(principalWith("ontology", "0000000000", "system", 0));
+        underA.set(newProvider(tenantRepo, legacyRepo, metaService).getRegistryForRealm(REALM));
+        SecurityContext.clearPrincipalContext();
+
+        // Read 2 under principal B (different org/account, same realm).
+        SecurityContext.setPrincipalContext(principalWith("acmeOrg", "9999999999", "adminUser", 7));
+        underB.set(newProvider(tenantRepo, legacyRepo, metaService).getRegistryForRealm(REALM));
+        SecurityContext.clearPrincipalContext();
+
+        assertTrue(underA.get().classOf("TenantOnlyClass").isPresent(),
+                "read under principal A must resolve the activated tenant TBox");
+        assertTrue(underB.get().classOf("TenantOnlyClass").isPresent(),
+                "read under principal B (different principal, same realm) must resolve the SAME activated tenant TBox");
+        assertFalse(underA.get().classOf("LegacyOnlyClass").isPresent());
+        assertFalse(underB.get().classOf("LegacyOnlyClass").isPresent());
+    }
+
+    private TenantOntologyRegistryProvider newProvider(TenantOntologyTBoxRepo tenantRepo,
+                                                       OntologyTBoxRepo legacyRepo,
+                                                       OntologyMetaService metaService) {
+        TenantOntologyRegistryProvider p = new TenantOntologyRegistryProvider();
+        p.tenantTboxRepo = tenantRepo;
+        p.tboxRepo = legacyRepo;
+        p.metaService = metaService;
+        return p;
+    }
+}

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderReadPathTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProviderReadPathTest.java
@@ -1,0 +1,137 @@
+package com.e2eq.ontology.runtime;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.ontology.core.OntologyRegistry;
+import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.TBox;
+import com.e2eq.ontology.model.OntologyTBox;
+import com.e2eq.ontology.model.TenantOntologyTBox;
+import com.e2eq.ontology.repo.OntologyTBoxRepo;
+import com.e2eq.ontology.repo.TenantOntologyTBoxRepo;
+import com.e2eq.ontology.service.OntologyMetaService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * B2 read-path unification (provider level, no Quarkus / no Mongo).
+ *
+ * <p>Drives {@link TenantOntologyRegistryProvider#getRegistryForRealm(String)}
+ * (which delegates to the package-private {@code loadOrBuildRegistryForRealm})
+ * with both repos mocked, asserting:</p>
+ * <ol>
+ *   <li>when an ACTIVE {@link TenantOntologyTBox} exists for
+ *       {@code realmDataDomain(realm)}, the registry is built from it; and</li>
+ *   <li>when none exists, the load falls back UNCHANGED to the legacy
+ *       {@code tboxRepo.findLatest()} path.</li>
+ * </ol>
+ */
+public class TenantOntologyRegistryProviderReadPathTest {
+
+    private static final String REALM = "acme-realm";
+
+    private TenantOntologyRegistryProvider newProvider(TenantOntologyTBoxRepo tenantRepo,
+                                                       OntologyTBoxRepo legacyRepo,
+                                                       OntologyMetaService metaService) {
+        TenantOntologyRegistryProvider p = new TenantOntologyRegistryProvider();
+        // Fields are package-private @Inject; same-package test sets them directly.
+        p.tenantTboxRepo = tenantRepo;
+        p.tboxRepo = legacyRepo;
+        p.metaService = metaService;
+        return p;
+    }
+
+    @Test
+    void prefersActiveTenantTBoxWhenPresent() {
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        OntologyTBoxRepo legacyRepo = mock(OntologyTBoxRepo.class);
+        OntologyMetaService metaService = mock(OntologyMetaService.class);
+
+        // Active tenant TBox carries a class unique to it: "TenantOnlyClass".
+        TBox tenantTBox = new TBox(
+                Map.of("TenantOnlyClass", new ClassDef("TenantOnlyClass", Set.of(), Set.of(), Set.of())),
+                Map.of(),
+                List.of());
+        TenantOntologyTBox doc = new TenantOntologyTBox(tenantTBox, "tenant-hash", "tenant-yaml", "submit", "1.0.0");
+        doc.setActive(true);
+
+        when(tenantRepo.findActiveTBox(any(DataDomain.class))).thenReturn(Optional.of(doc));
+
+        TenantOntologyRegistryProvider provider = newProvider(tenantRepo, legacyRepo, metaService);
+        OntologyRegistry registry = provider.getRegistryForRealm(REALM);
+
+        assertNotNull(registry);
+        assertTrue(registry.classOf("TenantOnlyClass").isPresent(),
+                "registry must be built from the ACTIVE TenantOntologyTBox");
+
+        // The lookup key is the canonical realmDataDomain(realm).
+        verify(tenantRepo).findActiveTBox(eq(TenantOntologyRegistryProvider.realmDataDomain(REALM)));
+        // Legacy path must NOT be consulted when an active tenant TBox exists.
+        verify(legacyRepo, never()).findLatest();
+    }
+
+    @Test
+    void fallsBackToLegacyFindLatestWhenNoActiveTenantTBox() {
+        // This module's test application.properties sets force-rebuild=true (which
+        // bypasses the legacy persisted load). For THIS test we want to exercise the
+        // legacy findLatest() persisted path, so override config to persist=true /
+        // force-rebuild=false and drop the cached MicroProfile config so the
+        // provider rebuilds it.
+        System.setProperty("quantum.ontology.tbox.persist", "true");
+        System.setProperty("quantum.ontology.tbox.force-rebuild", "false");
+        org.eclipse.microprofile.config.spi.ConfigProviderResolver resolver =
+                org.eclipse.microprofile.config.spi.ConfigProviderResolver.instance();
+        try {
+            resolver.releaseConfig(resolver.getConfig());
+        } catch (Throwable ignored) {
+        }
+
+        TenantOntologyTBoxRepo tenantRepo = mock(TenantOntologyTBoxRepo.class);
+        OntologyTBoxRepo legacyRepo = mock(OntologyTBoxRepo.class);
+        OntologyMetaService metaService = mock(OntologyMetaService.class);
+
+        // No active tenant TBox for this realm.
+        when(tenantRepo.findActiveTBox(any(DataDomain.class))).thenReturn(Optional.empty());
+
+        // Legacy store has a TBox with a class unique to it: "LegacyOnlyClass".
+        TBox legacyTBox = new TBox(
+                Map.of("LegacyOnlyClass", new ClassDef("LegacyOnlyClass", Set.of(), Set.of(), Set.of())),
+                Map.of(),
+                List.of());
+        OntologyTBox legacyDoc = new OntologyTBox(legacyTBox, "legacy-hash", "legacy-yaml", "ontology.yaml");
+        when(legacyRepo.findLatest()).thenReturn(Optional.of(legacyDoc));
+
+        // Make the legacy yaml-hash gate pass: observed currentHash == persisted yamlHash.
+        when(metaService.observeYaml(ArgumentMatchers.<Optional<java.nio.file.Path>>any(), anyString()))
+                .thenReturn(new OntologyMetaService.Result(null, "legacy-yaml"));
+        when(metaService.getMeta()).thenReturn(Optional.empty());
+
+        try {
+            TenantOntologyRegistryProvider provider = newProvider(tenantRepo, legacyRepo, metaService);
+            OntologyRegistry registry = provider.getRegistryForRealm(REALM);
+
+            assertNotNull(registry);
+            assertTrue(registry.classOf("LegacyOnlyClass").isPresent(),
+                    "registry must fall back to the legacy findLatest() TBox when no active tenant TBox exists");
+            assertFalse(registry.classOf("TenantOnlyClass").isPresent());
+
+            verify(tenantRepo).findActiveTBox(eq(TenantOntologyRegistryProvider.realmDataDomain(REALM)));
+            verify(legacyRepo).findLatest();
+        } finally {
+            // Restore module test defaults so other tests in this JVM are unaffected.
+            System.clearProperty("quantum.ontology.tbox.persist");
+            System.clearProperty("quantum.ontology.tbox.force-rebuild");
+            try {
+                resolver.releaseConfig(resolver.getConfig());
+            } catch (Throwable ignored) {
+            }
+        }
+    }
+}

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/PolicyVocabularyGuard.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/PolicyVocabularyGuard.java
@@ -59,18 +59,44 @@ public class PolicyVocabularyGuard {
                     check.ruleName(), e.getMessage());
             registry = null;
         }
-        check(check, registry);
+        // B5 vocabulary tier: resolve the realm's admitted-predicate set. When present
+        // the validator enforces the provisional/admitted tier; when empty it falls back
+        // to the legacy single-arg validator (all declared predicates admitted).
+        java.util.Optional<java.util.Set<String>> admitted = java.util.Optional.empty();
+        if (registry != null) {
+            try {
+                admitted = registryProvider.admittedPredicatesForCurrentRealm();
+            } catch (RuntimeException e) {
+                Log.debugf("Skipping vocabulary tier for '%s': admitted set unavailable (%s)",
+                        check.ruleName(), e.getMessage());
+            }
+        }
+        check(check, registry, admitted.orElse(null));
         if (functionalDomainValidationEnabled) {
             checkFunctionalDomain(check, functionalDomainSnapshot());
         }
     }
 
-    /** Core predicate logic, separated from CDI resolution for direct unit testing. */
+    /**
+     * Legacy entry point: all declared predicates are admitted (no provisional tier).
+     * Equivalent to {@code check(check, registry, null)}.
+     */
     static void check(RuleVocabularyCheck check, OntologyRegistry registry) {
+        check(check, registry, null);
+    }
+
+    /**
+     * Core predicate logic, separated from CDI resolution for direct unit testing.
+     *
+     * @param admittedPredicates the realm's admitted-predicate set, or {@code null}
+     *        to admit every declared predicate (legacy behavior).
+     */
+    static void check(RuleVocabularyCheck check, OntologyRegistry registry,
+                      java.util.Set<String> admittedPredicates) {
         if (registry == null || registry.properties().isEmpty()) {
             return; // no ontology vocabulary configured — nothing to validate against
         }
-        new RuleVocabularyValidator(registry).validateOrThrow(List.of(
+        new RuleVocabularyValidator(registry, admittedPredicates).validateOrThrow(List.of(
                 new RuleVocabularyValidator.RuleSource(check.ruleName(), check.scriptsAndFilters())));
     }
 

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/PolicyVocabularyGuard.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/PolicyVocabularyGuard.java
@@ -2,6 +2,7 @@ package com.e2eq.ontology.policy;
 
 import com.e2eq.framework.model.securityrules.RuleVocabularyCheck;
 import com.e2eq.ontology.core.OntologyRegistry;
+import com.e2eq.ontology.runtime.AdmittedVocabularyResult;
 import com.e2eq.ontology.runtime.TenantOntologyRegistryProvider;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -10,6 +11,7 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Enforcement wiring for rule vocabulary validation (Q3 in the unified ontology design
@@ -47,6 +49,22 @@ public class PolicyVocabularyGuard {
     /** Lazy snapshot of the FunctionalDomain registry (domain refName -> action refNames). */
     private volatile java.util.Map<String, java.util.Set<String>> functionalDomainSnapshot;
 
+    /**
+     * B5 observability: number of rule-vocabulary checks that hit the UNAVAILABLE
+     * (Mongo read failed) path and therefore failed CLOSED. This is the "downgrade
+     * attempt was rejected" signal — a non-zero/rising value means a GOVERNED realm
+     * is being protected from a fail-OPEN downgrade during a Mongo blip/outage.
+     * Mirrors the intended Micrometer counter {@code ontology.vocabulary.read_unavailable};
+     * exposed as a plain counter so the policy-bridge needs no metrics dependency and
+     * the WARN log remains the primary observable signal.
+     */
+    static final AtomicLong READ_UNAVAILABLE_COUNT = new AtomicLong();
+
+    /** B5: current value of the read-unavailable (fail-closed) counter. */
+    public static long readUnavailableCount() {
+        return READ_UNAVAILABLE_COUNT.get();
+    }
+
     void onRuleVocabularyCheck(@Observes RuleVocabularyCheck check) {
         if (!enabled) {
             return;
@@ -59,19 +77,25 @@ public class PolicyVocabularyGuard {
                     check.ruleName(), e.getMessage());
             registry = null;
         }
-        // B5 vocabulary tier: resolve the realm's admitted-predicate set. When present
-        // the validator enforces the provisional/admitted tier; when empty it falls back
-        // to the legacy single-arg validator (all declared predicates admitted).
-        java.util.Optional<java.util.Set<String>> admitted = java.util.Optional.empty();
+        // B5 vocabulary tier: resolve the realm's 3-state admitted-predicate disposition.
+        //   GOVERNED    -> enforce exactly the admitted set (provisional/admitted tier).
+        //   LEGACY      -> legacy validator: all declared predicates admitted (back-compat).
+        //   UNAVAILABLE -> the admitted-set read FAILED; fail CLOSED (admit nothing for
+        //                  rule refs) and record the downgrade-attempt signal. We do NOT
+        //                  treat a transient Mongo blip as legacy/all-admitted.
+        AdmittedVocabularyResult vocab = AdmittedVocabularyResult.legacy();
         if (registry != null) {
             try {
-                admitted = registryProvider.admittedPredicatesForCurrentRealm();
+                vocab = registryProvider.admittedVocabularyForCurrentRealm();
             } catch (RuntimeException e) {
-                Log.debugf("Skipping vocabulary tier for '%s': admitted set unavailable (%s)",
+                // The provider already maps read failures to UNAVAILABLE internally; an
+                // exception escaping here is itself a read failure -> fail CLOSED too.
+                Log.warnf("Rule vocabulary tier resolution threw for '%s'; failing CLOSED (%s)",
                         check.ruleName(), e.getMessage());
+                vocab = AdmittedVocabularyResult.unavailable();
             }
         }
-        check(check, registry, admitted.orElse(null));
+        checkVocabulary(check, registry, vocab);
         if (functionalDomainValidationEnabled) {
             checkFunctionalDomain(check, functionalDomainSnapshot());
         }
@@ -82,21 +106,60 @@ public class PolicyVocabularyGuard {
      * Equivalent to {@code check(check, registry, null)}.
      */
     static void check(RuleVocabularyCheck check, OntologyRegistry registry) {
-        check(check, registry, null);
+        check(check, registry, (java.util.Set<String>) null);
     }
 
     /**
      * Core predicate logic, separated from CDI resolution for direct unit testing.
+     * 2-state back-compat overload (LEGACY when {@code admittedPredicates == null},
+     * GOVERNED otherwise). Callers that must fail CLOSED on a read failure use the
+     * {@link AdmittedVocabularyResult} overload instead.
      *
      * @param admittedPredicates the realm's admitted-predicate set, or {@code null}
      *        to admit every declared predicate (legacy behavior).
      */
     static void check(RuleVocabularyCheck check, OntologyRegistry registry,
                       java.util.Set<String> admittedPredicates) {
+        checkVocabulary(check, registry, admittedPredicates == null
+                ? AdmittedVocabularyResult.legacy()
+                : AdmittedVocabularyResult.governed(admittedPredicates));
+    }
+
+    /**
+     * Core predicate logic over the B5 3-state vocabulary disposition.
+     * <ul>
+     *   <li>LEGACY -&gt; legacy validator (all declared admitted).</li>
+     *   <li>GOVERNED -&gt; enforce the admitted set (provisional rejected).</li>
+     *   <li>UNAVAILABLE -&gt; fail CLOSED: every declared predicate referenced by a
+     *       rule is rejected, AND the {@link #READ_UNAVAILABLE_COUNT} counter is
+     *       incremented (downgrade-attempt observable). This is an availability
+     *       tradeoff: during a Mongo outage, rule (re)loading for a GOVERNED realm is
+     *       rejected rather than silently downgraded to accept-every-predicate.</li>
+     * </ul>
+     */
+    static void checkVocabulary(RuleVocabularyCheck check, OntologyRegistry registry,
+                                AdmittedVocabularyResult vocab) {
         if (registry == null || registry.properties().isEmpty()) {
             return; // no ontology vocabulary configured — nothing to validate against
         }
-        new RuleVocabularyValidator(registry, admittedPredicates).validateOrThrow(List.of(
+        if (vocab == null) {
+            vocab = AdmittedVocabularyResult.legacy();
+        }
+        RuleVocabularyValidator validator;
+        switch (vocab.kind()) {
+            case UNAVAILABLE -> {
+                READ_UNAVAILABLE_COUNT.incrementAndGet();
+                Log.warnf("Rule '%s' vocabulary check failing CLOSED: admitted-predicate set is "
+                        + "UNAVAILABLE (Mongo read failed). Refusing to downgrade to all-admitted; "
+                        + "any declared predicate referenced by this rule is rejected until the read "
+                        + "recovers [metric ontology.vocabulary.read_unavailable]", check.ruleName());
+                validator = RuleVocabularyValidator.failClosed(registry);
+            }
+            case GOVERNED -> validator = new RuleVocabularyValidator(registry, vocab.admitted());
+            case LEGACY -> validator = new RuleVocabularyValidator(registry, null);
+            default -> validator = new RuleVocabularyValidator(registry, null);
+        }
+        validator.validateOrThrow(List.of(
                 new RuleVocabularyValidator.RuleSource(check.ruleName(), check.scriptsAndFilters())));
     }
 

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/RuleVocabularyValidator.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/RuleVocabularyValidator.java
@@ -64,13 +64,23 @@ public final class RuleVocabularyValidator {
     /**
      * Predicates admitted for policy use in this realm. {@code null} means
      * "all declared predicates are admitted" (legacy / back-compat): every
-     * predicate the registry declares is accepted for rule use.
+     * predicate the registry declares is accepted for rule use — UNLESS
+     * {@link #failClosed} is set, in which case NO predicate is admitted.
      */
     private final Set<String> admittedPredicates;
 
+    /**
+     * B5 fail-CLOSED mode. When {@code true}, the realm's admitted set could not be
+     * read (Mongo UNAVAILABLE) and we must NOT fall back to all-admitted: every
+     * declared predicate referenced by a rule is treated as {@link Reason#PROVISIONAL}
+     * (not admitted). This converts a transient read failure into a rule-registration
+     * rejection rather than a silent security downgrade to accept-every-predicate.
+     */
+    private final boolean failClosed;
+
     /** Back-compat: all declared predicates are admitted (no provisional tier). */
     public RuleVocabularyValidator(OntologyRegistry registry) {
-        this(registry, null);
+        this(registry, null, false);
     }
 
     /**
@@ -78,8 +88,32 @@ public final class RuleVocabularyValidator {
      *        to admit every declared predicate (legacy behavior).
      */
     public RuleVocabularyValidator(OntologyRegistry registry, Set<String> admittedPredicates) {
+        this(registry, admittedPredicates, false);
+    }
+
+    /**
+     * @param admittedPredicates the realm's admitted-predicate set, or {@code null}
+     *        to admit every declared predicate (legacy behavior). Ignored when
+     *        {@code failClosed} is {@code true}.
+     * @param failClosed when {@code true} (B5 UNAVAILABLE), admit NO predicate for
+     *        rule use: every declared predicate referenced by a rule is rejected as
+     *        provisional. Use this when the admitted set could not be read so the
+     *        guard fails closed instead of downgrading to all-admitted.
+     */
+    public RuleVocabularyValidator(OntologyRegistry registry, Set<String> admittedPredicates, boolean failClosed) {
         this.registry = registry;
         this.admittedPredicates = admittedPredicates;
+        this.failClosed = failClosed;
+    }
+
+    /**
+     * B5 fail-CLOSED factory: the admitted set is UNAVAILABLE (Mongo read failed).
+     * No declared predicate is admitted for rule references; absent predicates are
+     * still {@link Reason#ABSENT}. Use this rather than the legacy single-arg ctor
+     * on the read-failure path so a transient blip does not re-open the vocabulary.
+     */
+    public static RuleVocabularyValidator failClosed(OntologyRegistry registry) {
+        return new RuleVocabularyValidator(registry, null, true);
     }
 
     public List<Violation> validate(Collection<RuleSource> rules) {
@@ -93,6 +127,11 @@ public final class RuleVocabularyValidator {
                     if (registry.propertyOf(predicate).isEmpty()) {
                         // Not declared in the TBox at all.
                         violations.add(new Violation(rule.ruleName(), matcher.group(1), predicate, Reason.ABSENT));
+                    } else if (failClosed) {
+                        // B5 UNAVAILABLE: admitted set could not be read -> admit nothing.
+                        // A declared predicate referenced by a rule is rejected as provisional
+                        // rather than silently allowed (fail CLOSED, no security downgrade).
+                        violations.add(new Violation(rule.ruleName(), matcher.group(1), predicate, Reason.PROVISIONAL));
                     } else if (admittedPredicates != null && !admittedPredicates.contains(predicate)) {
                         // Declared but not admitted for policy use in this realm.
                         violations.add(new Violation(rule.ruleName(), matcher.group(1), predicate, Reason.PROVISIONAL));

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/RuleVocabularyValidator.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/RuleVocabularyValidator.java
@@ -32,9 +32,26 @@ public final class RuleVocabularyValidator {
     private static final Pattern PREDICATE_CALL = Pattern.compile(
             "\\b(hasEdge|notHasEdge|hasIncomingEdge|hasAnyEdges|hasAllEdges|relatedIds)\\s*\\(\\s*[\"']([A-Za-z_][\\w.-]*)[\"']");
 
-    public record Violation(String ruleName, String helperFunction, String predicate) {
+    /**
+     * Why a rule's predicate reference is rejected.
+     * <ul>
+     *   <li>{@link #ABSENT} — the predicate is not declared in the TBox at all
+     *       (undeclared / renamed-away). Today's behavior.</li>
+     *   <li>{@link #PROVISIONAL} — the predicate IS declared in the TBox but has
+     *       not been admitted for policy use in this realm (B5 vocabulary tier).</li>
+     * </ul>
+     */
+    public enum Reason { ABSENT, PROVISIONAL }
+
+    public record Violation(String ruleName, String helperFunction, String predicate, Reason reason) {
         @Override
         public String toString() {
+            if (reason == Reason.PROVISIONAL) {
+                return "rule '" + ruleName + "' references provisional ontology predicate '" + predicate
+                        + "' via " + helperFunction + "(...); it is declared but not admitted for policy use"
+                        + " — POST /v1/ontology/{realm}/vocabulary/" + predicate + ":promote to admit it"
+                        + " before referencing it in a security rule";
+            }
             return "rule '" + ruleName + "' references unknown ontology predicate '" + predicate
                     + "' via " + helperFunction + "(...)";
         }
@@ -44,8 +61,25 @@ public final class RuleVocabularyValidator {
 
     private final OntologyRegistry registry;
 
+    /**
+     * Predicates admitted for policy use in this realm. {@code null} means
+     * "all declared predicates are admitted" (legacy / back-compat): every
+     * predicate the registry declares is accepted for rule use.
+     */
+    private final Set<String> admittedPredicates;
+
+    /** Back-compat: all declared predicates are admitted (no provisional tier). */
     public RuleVocabularyValidator(OntologyRegistry registry) {
+        this(registry, null);
+    }
+
+    /**
+     * @param admittedPredicates the realm's admitted-predicate set, or {@code null}
+     *        to admit every declared predicate (legacy behavior).
+     */
+    public RuleVocabularyValidator(OntologyRegistry registry, Set<String> admittedPredicates) {
         this.registry = registry;
+        this.admittedPredicates = admittedPredicates;
     }
 
     public List<Violation> validate(Collection<RuleSource> rules) {
@@ -57,8 +91,13 @@ public final class RuleVocabularyValidator {
                 while (matcher.find()) {
                     String predicate = matcher.group(2);
                     if (registry.propertyOf(predicate).isEmpty()) {
-                        violations.add(new Violation(rule.ruleName(), matcher.group(1), predicate));
+                        // Not declared in the TBox at all.
+                        violations.add(new Violation(rule.ruleName(), matcher.group(1), predicate, Reason.ABSENT));
+                    } else if (admittedPredicates != null && !admittedPredicates.contains(predicate)) {
+                        // Declared but not admitted for policy use in this realm.
+                        violations.add(new Violation(rule.ruleName(), matcher.group(1), predicate, Reason.PROVISIONAL));
                     }
+                    // else: declared and (admittedPredicates == null || admitted) -> accept.
                 }
             }
         }

--- a/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/PolicyVocabularyGuardTest.java
+++ b/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/PolicyVocabularyGuardTest.java
@@ -3,6 +3,7 @@ package com.e2eq.ontology.policy;
 import com.e2eq.framework.model.securityrules.RuleVocabularyCheck;
 import com.e2eq.ontology.core.InMemoryOntologyRegistry;
 import com.e2eq.ontology.core.OntologyRegistry;
+import com.e2eq.ontology.runtime.AdmittedVocabularyResult;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -102,6 +104,65 @@ class PolicyVocabularyGuardTest {
                 () -> PolicyVocabularyGuard.check(undeclared,
                         registryWith("canSeeLocation", "ownsTerritory"), null));
         assertTrue(failure.getMessage().contains("renamedAway"));
+    }
+
+    // --- B5 3-state vocabulary disposition ------------------------------------
+
+    @Test
+    void unavailableFailsClosed_rejectsDeclaredPredicateAndIncrementsCounter() {
+        // GOVERNED realm whose admitted set could not be read (Mongo blip).
+        // Even though canSeeLocation IS declared, the rule must be rejected
+        // (fail CLOSED) rather than silently admitted, and the counter must rise.
+        RuleVocabularyCheck check = new RuleVocabularyCheck("gov-rule",
+                List.of("hasEdge(\"canSeeLocation\", x)"));
+
+        long before = PolicyVocabularyGuard.readUnavailableCount();
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> PolicyVocabularyGuard.checkVocabulary(check, registryWith("canSeeLocation"),
+                        AdmittedVocabularyResult.unavailable()));
+
+        assertTrue(failure.getMessage().contains("canSeeLocation"));
+        assertTrue(failure.getMessage().contains("provisional"),
+                "fail-closed treats declared predicates as provisional (not admitted)");
+        assertEquals(before + 1, PolicyVocabularyGuard.readUnavailableCount(),
+                "UNAVAILABLE path must increment the read-unavailable counter");
+    }
+
+    @Test
+    void unavailableWithNoOntologyConfigured_isNoopAndDoesNotCount() {
+        // Empty registry == app does not use the ontology -> nothing to validate,
+        // no fail-closed, no counter bump.
+        RuleVocabularyCheck check = new RuleVocabularyCheck("any-rule",
+                List.of("hasEdge(\"whatever\", x)"));
+
+        long before = PolicyVocabularyGuard.readUnavailableCount();
+        assertDoesNotThrow(() -> PolicyVocabularyGuard.checkVocabulary(check, registryWith(),
+                AdmittedVocabularyResult.unavailable()));
+        assertEquals(before, PolicyVocabularyGuard.readUnavailableCount());
+    }
+
+    @Test
+    void legacyResultAdmitsAllDeclared() {
+        RuleVocabularyCheck check = new RuleVocabularyCheck("legacy-rule",
+                List.of("hasEdge(\"ownsTerritory\", x)"));
+
+        assertDoesNotThrow(() -> PolicyVocabularyGuard.checkVocabulary(check,
+                registryWith("canSeeLocation", "ownsTerritory"), AdmittedVocabularyResult.legacy()));
+    }
+
+    @Test
+    void governedResultRejectsProvisionalAndPassesAdmitted() {
+        RuleVocabularyCheck provisional = new RuleVocabularyCheck("prov-rule",
+                List.of("hasEdge(\"ownsTerritory\", x)"));
+        assertThrows(IllegalStateException.class, () -> PolicyVocabularyGuard.checkVocabulary(provisional,
+                registryWith("canSeeLocation", "ownsTerritory"),
+                AdmittedVocabularyResult.governed(Set.of("canSeeLocation"))));
+
+        RuleVocabularyCheck admittedRule = new RuleVocabularyCheck("ok-rule",
+                List.of("hasEdge(\"canSeeLocation\", x)"));
+        assertDoesNotThrow(() -> PolicyVocabularyGuard.checkVocabulary(admittedRule,
+                registryWith("canSeeLocation", "ownsTerritory"),
+                AdmittedVocabularyResult.governed(Set.of("canSeeLocation"))));
     }
 
     @Test

--- a/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/PolicyVocabularyGuardTest.java
+++ b/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/PolicyVocabularyGuardTest.java
@@ -64,6 +64,47 @@ class PolicyVocabularyGuardTest {
     }
 
     @Test
+    void provisionalPredicateRejectedWhenAdmittedSetPresent() {
+        // ownsTerritory is declared but NOT admitted -> registration must throw.
+        RuleVocabularyCheck check = new RuleVocabularyCheck("prov-rule",
+                List.of("hasEdge(\"ownsTerritory\", x)"));
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> PolicyVocabularyGuard.check(check, registryWith("canSeeLocation", "ownsTerritory"),
+                        Set.of("canSeeLocation")));
+
+        assertTrue(failure.getMessage().contains("ownsTerritory"));
+        assertTrue(failure.getMessage().contains("provisional"));
+        assertTrue(failure.getMessage().contains(":promote"));
+    }
+
+    @Test
+    void admittedPredicatePassesWhenAdmittedSetPresent() {
+        RuleVocabularyCheck check = new RuleVocabularyCheck("ok-rule",
+                List.of("hasEdge(\"canSeeLocation\", x)"));
+
+        assertDoesNotThrow(() -> PolicyVocabularyGuard.check(check,
+                registryWith("canSeeLocation", "ownsTerritory"), Set.of("canSeeLocation")));
+    }
+
+    @Test
+    void emptyAdmittedSetPreservesLegacyBehavior() {
+        // null admitted set (Optional.empty().orElse(null)) == legacy: all declared accepted.
+        RuleVocabularyCheck declared = new RuleVocabularyCheck("legacy-rule",
+                List.of("hasEdge(\"ownsTerritory\", x)"));
+        assertDoesNotThrow(() -> PolicyVocabularyGuard.check(declared,
+                registryWith("canSeeLocation", "ownsTerritory"), null));
+
+        // ... and an undeclared predicate still fails (ABSENT) under legacy.
+        RuleVocabularyCheck undeclared = new RuleVocabularyCheck("legacy-rule",
+                List.of("hasEdge(\"renamedAway\", x)"));
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> PolicyVocabularyGuard.check(undeclared,
+                        registryWith("canSeeLocation", "ownsTerritory"), null));
+        assertTrue(failure.getMessage().contains("renamedAway"));
+    }
+
+    @Test
     void functionalDomainValidationSkipsWhenRegistryEmptyAndPassesWildcards() {
         RuleVocabularyCheck anyDomain = new RuleVocabularyCheck("r", List.of(), "sales", "anything", "view");
         assertDoesNotThrow(() -> PolicyVocabularyGuard.checkFunctionalDomain(anyDomain, Map.of()));

--- a/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/RuleVocabularyValidatorTest.java
+++ b/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/RuleVocabularyValidatorTest.java
@@ -66,6 +66,115 @@ class RuleVocabularyValidatorTest {
         assertTrue(failure.getMessage().contains("bad-rule"));
     }
 
+    private static OntologyRegistry registryWith(String... predicates) {
+        Map<String, OntologyRegistry.PropertyDef> properties = new java.util.HashMap<>();
+        for (String p : predicates) {
+            properties.put(p, new OntologyRegistry.PropertyDef(p,
+                    Optional.empty(), Optional.empty(), false, Optional.empty(),
+                    false, false, false, Set.of(), false));
+        }
+        return new InMemoryOntologyRegistry(new OntologyRegistry.TBox(Map.of(), properties, List.of()));
+    }
+
+    @Test
+    void admittedPredicateAccepted() {
+        // canSeeLocation declared AND admitted -> accepted.
+        RuleVocabularyValidator validator = new RuleVocabularyValidator(
+                registryWith("canSeeLocation", "ownsTerritory"), Set.of("canSeeLocation"));
+
+        List<RuleVocabularyValidator.Violation> violations = validator.validate(List.of(
+                new RuleVocabularyValidator.RuleSource("ok-rule",
+                        List.of("hasEdge(\"canSeeLocation\", x)"))));
+
+        assertEquals(List.of(), violations);
+    }
+
+    @Test
+    void declaredButNotAdmittedIsProvisionalWithPromoteMessage() {
+        // ownsTerritory declared but NOT in the admitted set -> PROVISIONAL.
+        RuleVocabularyValidator validator = new RuleVocabularyValidator(
+                registryWith("canSeeLocation", "ownsTerritory"), Set.of("canSeeLocation"));
+
+        List<RuleVocabularyValidator.Violation> violations = validator.validate(List.of(
+                new RuleVocabularyValidator.RuleSource("prov-rule",
+                        List.of("hasEdge(\"ownsTerritory\", x)"))));
+
+        assertEquals(1, violations.size());
+        RuleVocabularyValidator.Violation v = violations.get(0);
+        assertEquals("ownsTerritory", v.predicate());
+        assertEquals(RuleVocabularyValidator.Reason.PROVISIONAL, v.reason());
+        assertTrue(v.toString().contains("provisional"));
+        assertTrue(v.toString().contains(":promote"));
+        assertTrue(v.toString().contains("ownsTerritory"));
+        assertTrue(v.toString().contains("not admitted for policy use"));
+    }
+
+    @Test
+    void undeclaredIsAbsentRegardlessOfAdmittedSet() {
+        // renamedAway is not declared at all -> ABSENT (not PROVISIONAL).
+        RuleVocabularyValidator validator = new RuleVocabularyValidator(
+                registryWith("canSeeLocation"), Set.of("canSeeLocation"));
+
+        List<RuleVocabularyValidator.Violation> violations = validator.validate(List.of(
+                new RuleVocabularyValidator.RuleSource("absent-rule",
+                        List.of("hasEdge(\"renamedAway\", x)"))));
+
+        assertEquals(1, violations.size());
+        RuleVocabularyValidator.Violation v = violations.get(0);
+        assertEquals("renamedAway", v.predicate());
+        assertEquals(RuleVocabularyValidator.Reason.ABSENT, v.reason());
+        assertTrue(v.toString().contains("unknown ontology predicate"));
+    }
+
+    @Test
+    void legacyNullAdmittedSetAcceptsAllDeclared() {
+        // Single-arg ctor (admittedPredicates == null) -> every declared predicate accepted.
+        RuleVocabularyValidator validator = new RuleVocabularyValidator(
+                registryWith("canSeeLocation", "ownsTerritory"));
+
+        List<RuleVocabularyValidator.Violation> violations = validator.validate(List.of(
+                new RuleVocabularyValidator.RuleSource("legacy-rule",
+                        List.of("hasEdge(\"canSeeLocation\", x) || hasEdge(\"ownsTerritory\", y)"))));
+
+        assertEquals(List.of(), violations);
+
+        // ... but an undeclared predicate is still ABSENT under legacy.
+        List<RuleVocabularyValidator.Violation> undeclared = validator.validate(List.of(
+                new RuleVocabularyValidator.RuleSource("legacy-rule",
+                        List.of("hasEdge(\"nope\", x)"))));
+        assertEquals(1, undeclared.size());
+        assertEquals(RuleVocabularyValidator.Reason.ABSENT, undeclared.get(0).reason());
+    }
+
+    @Test
+    void provisionalPredicateStillResolvesForFactEdgePath_noDeadlock() {
+        // The fact/edge path (and reasoner) resolves predicates via registry.propertyOf,
+        // which is unaffected by the admitted-set tier: a declared-but-not-admitted
+        // predicate is fully resolvable for non-rule use. ONLY rule registration
+        // (validate(...)) enforces admission, so non-rule usage never deadlocks waiting
+        // on promotion.
+        OntologyRegistry registry = registryWith("canSeeLocation", "ownsTerritory");
+        Set<String> admitted = Set.of("canSeeLocation"); // ownsTerritory is provisional
+
+        // Edge/fact path: predicate resolves regardless of admission tier.
+        assertTrue(registry.propertyOf("ownsTerritory").isPresent(),
+                "provisional predicate must still resolve via propertyOf (edge/fact path)");
+
+        // Rule path: same provisional predicate IS flagged when referenced by a rule.
+        RuleVocabularyValidator validator = new RuleVocabularyValidator(registry, admitted);
+        List<RuleVocabularyValidator.Violation> ruleViolations = validator.validate(List.of(
+                new RuleVocabularyValidator.RuleSource("rule-using-prov",
+                        List.of("hasEdge(\"ownsTerritory\", x)"))));
+        assertEquals(1, ruleViolations.size());
+        assertEquals(RuleVocabularyValidator.Reason.PROVISIONAL, ruleViolations.get(0).reason());
+
+        // A RuleSource with no ontology helper calls (e.g. a plain fact/edge filter) is
+        // never flagged — admission is only consulted for actual rule predicate refs.
+        assertEquals(List.of(), validator.validate(List.of(
+                new RuleVocabularyValidator.RuleSource("non-rule-content",
+                        List.of("dataDomain.tenantId:${pTenantId}")))));
+    }
+
     @Test
     void ignoresNonOntologyScriptContent() {
         RuleVocabularyValidator validator = new RuleVocabularyValidator(registry());


### PR DESCRIPTION
The framework-side of the governed-ontology work + the new system-DB seeding flags. 10 commits, all fast-forward over 1.4.0-SNAPSHOT.

- **seed-system-only flags** (this PR's headline): `quantum.realm.seed-system-only` (AddRealms skips test realm) + `quantum.baseline-identity.seed-system-only` (skip default/test-tenant admins) — opt-in, default-false, non-breaking. So a cross-tenant SYSTEM database seeds no tenant-shaped artifacts; system realm + system identity retained.
- DataDomainPolicy write-side S1–S3 (FROM_SOURCE resolution, per-(source,entityType) keying, fail-closed quarantine).
- QueryGateway row+field governance enforcement (security fix).
- B5 provisional/admitted vocabulary tier (fail-closed) + TBox admission read-path unification.
- adoc docs.

Pairs with quantum-enterprise PRs #3 (merged) + #4. NOTE: the ontology-service image must be rebuilt after this lands so the framework jar carries the seed-system-only flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)