### PR TITLE
Framework: seed-system-only excludes default/test realms from startup resolution

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedStartupRunner.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedStartupRunner.java
@@ -91,6 +91,18 @@ public class SeedStartupRunner {
     @ConfigProperty(name = "quantum.seed-pack.apply.realms")
     Optional<String> startupRealmsCsv;
 
+    /**
+     * When true, the default (fallback) startup seed realm set is restricted to the cross-tenant
+     * SYSTEM realm only: the tenant-shaped TEST realm and the DEFAULT realm are not scanned (the
+     * default realm is kept only when it equals the system realm). Explicit
+     * {@code quantum.seed-pack.apply.realms} entries and {@code applySeedsOnStartup=true} realm
+     * flags are still honored, so a caller can opt a specific realm back in. Reuses the existing
+     * {@code quantum.realm.seed-system-only} flag so a "system-only" database neither creates nor
+     * even scans the test realm. Defaults to false so existing behavior is unchanged (non-breaking).
+     */
+    @ConfigProperty(name = "quantum.realm.seed-system-only", defaultValue = "false")
+    boolean seedSystemOnly;
+
     public void onStart() {
         if (!enabled || !applyOnStartup) {
             Log.info("SeedStartupRunner disabled by configuration (quantum.seed-pack.enabled / quantum.seed-pack.apply.on-startup)");
@@ -405,14 +417,22 @@ public class SeedStartupRunner {
             return realms;
         }
 
-        // Default behavior only if nothing was configured: system/default/test realms (deduped)
+        // Default behavior only if nothing was configured: system/default/test realms (deduped).
         if (!csvConfigured) {
             String system = envConfigUtils.getSystemRealm();
-            String def = envConfigUtils.getDefaultRealm();
-            String test = envConfigUtils.getTestRealm();
             realms.add(system);
-            if (!Objects.equals(system, def)) realms.add(def);
-            if (!Objects.equals(system, test) && !Objects.equals(def, test)) realms.add(test);
+            if (seedSystemOnly) {
+                // System-only mode: do NOT scan the default or test realms. The system realm above
+                // is the only fallback; the default realm is implicitly included only when it
+                // equals the system realm (already added). Explicit apply.realms / realm flags above
+                // can still opt a specific realm back in.
+                Log.debug("SeedStartupRunner: quantum.realm.seed-system-only=true, restricting default startup realms to the system realm");
+            } else {
+                String def = envConfigUtils.getDefaultRealm();
+                String test = envConfigUtils.getTestRealm();
+                if (!Objects.equals(system, def)) realms.add(def);
+                if (!Objects.equals(system, test) && !Objects.equals(def, test)) realms.add(test);
+            }
         }
         return realms;
     }

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedStartupRunnerSeedSystemOnlyRealmsTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedStartupRunnerSeedSystemOnlyRealmsTest.java
@@ -1,0 +1,92 @@
+package com.e2eq.framework.service.seed;
+
+import com.e2eq.framework.model.persistent.morphia.RealmRepo;
+import com.e2eq.framework.model.security.Realm;
+import com.e2eq.framework.util.EnvConfigUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit-level coverage for the {@code quantum.realm.seed-system-only} guard in
+ * {@link SeedStartupRunner#resolveStartupRealms()}.
+ *
+ * <p>The private {@code resolveStartupRealms()} reads the CSV config, the {@link RealmRepo}
+ * flagged realms, and (in the fallback branch) the {@link EnvConfigUtils} realm names. A stub
+ * {@link RealmRepo} returns no flagged realms so this runs without Quarkus or Mongo; the private
+ * method is invoked via reflection.
+ */
+class SeedStartupRunnerSeedSystemOnlyRealmsTest {
+
+    @SuppressWarnings("unchecked")
+    private static List<String> resolve(SeedStartupRunner runner) throws Exception {
+        Method m = SeedStartupRunner.class.getDeclaredMethod("resolveStartupRealms");
+        m.setAccessible(true);
+        return (List<String>) m.invoke(runner);
+    }
+
+    private static EnvConfigUtils envConfig() {
+        EnvConfigUtils env = new EnvConfigUtils();
+        env.setSystemRealm("system-com");
+        env.setDefaultRealm("mycompanyxyz-com");
+        env.setTestRealm("test-system-com");
+        return env;
+    }
+
+    private static SeedStartupRunner newRunner(boolean seedSystemOnly, Optional<String> applyRealmsCsv) {
+        SeedStartupRunner runner = new SeedStartupRunner();
+        runner.envConfigUtils = envConfig();
+        runner.realmRepo = new NoFlaggedRealmsRepo();
+        runner.startupRealmsCsv = applyRealmsCsv;
+        runner.seedSystemOnly = seedSystemOnly;
+        return runner;
+    }
+
+    @Test
+    void defaultFallbackResolvesSystemDefaultAndTestRealms() throws Exception {
+        List<String> realms = resolve(newRunner(false, Optional.empty()));
+
+        assertTrue(realms.contains("system-com"), "system realm must be resolved in default mode");
+        assertTrue(realms.contains("mycompanyxyz-com"), "default realm must be resolved in default mode");
+        assertTrue(realms.contains("test-system-com"), "test realm must be resolved in default mode");
+        assertEquals(3, realms.size(), "default fallback resolves system + default + test realms");
+    }
+
+    @Test
+    void seedSystemOnlyResolvesOnlySystemRealm() throws Exception {
+        List<String> realms = resolve(newRunner(true, Optional.empty()));
+
+        assertTrue(realms.contains("system-com"), "system realm must still be resolved under seed-system-only");
+        assertFalse(realms.contains("mycompanyxyz-com"),
+                "default realm must NOT be resolved under seed-system-only");
+        assertFalse(realms.contains("test-system-com"),
+                "test realm must NOT be resolved under seed-system-only");
+        assertEquals(1, realms.size(), "seed-system-only resolves exactly the system realm");
+    }
+
+    @Test
+    void seedSystemOnlyStillHonorsExplicitApplyRealms() throws Exception {
+        List<String> realms = resolve(newRunner(true, Optional.of("mycompanyxyz-com")));
+
+        assertTrue(realms.contains("mycompanyxyz-com"),
+                "an explicit quantum.seed-pack.apply.realms entry must still be resolved under seed-system-only");
+        assertFalse(realms.contains("test-system-com"),
+                "test realm must NOT be resolved (it was not explicitly opted in)");
+        assertEquals(1, realms.size(), "only the explicitly opted-in realm is resolved (no fallback when CSV set)");
+    }
+
+    /** Stub RealmRepo returning no applySeedsOnStartup-flagged realms; keeps the test off Mongo. */
+    private static final class NoFlaggedRealmsRepo extends RealmRepo {
+        @Override
+        public List<Realm> findRealmsWithSeedsEnabled() {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/migration/base/MigrationService.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/migration/base/MigrationService.java
@@ -64,6 +64,18 @@ public class MigrationService {
    @ConfigProperty(name = "quantum.migration.apply.realms")
    Optional<String> startupRealmsCsv;
 
+   /**
+    * When true, startup realm resolution is restricted to the cross-tenant SYSTEM realm only:
+    * the tenant-shaped TEST realm and the DEFAULT realm are dropped from the scan (the default
+    * realm is kept only when it equals the system realm). An explicit
+    * {@code quantum.migration.apply.realms} entry is still honored, so a caller can opt a specific
+    * realm back in. Reuses the existing {@code quantum.realm.seed-system-only} flag so a
+    * "system-only" database neither creates nor even scans the test realm. Defaults to false so
+    * existing multi-tenant/dev behavior is unchanged (non-breaking).
+    */
+   @ConfigProperty(name = "quantum.realm.seed-system-only", defaultValue = "false")
+   boolean seedSystemOnly;
+
    @Inject
    DatabaseVersionRepo databaseVersionRepo;
 
@@ -120,7 +132,10 @@ public class MigrationService {
       if (includeSystemRealm) {
          realms.add(systemRealm);
       }
-      if (existingDatabaseNames.contains(defaultRealm)) {
+      // System-only mode: do NOT auto-include the default (or test) realm in the scan. The
+      // default realm is kept only when it equals the system realm. Explicit apply.realms
+      // entries below are still honored so a caller can opt a specific realm back in.
+      if (!seedSystemOnly && existingDatabaseNames.contains(defaultRealm)) {
          realms.add(defaultRealm);
       }
 

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/migration/base/MigrationServiceSeedSystemOnlyRealmsTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/migration/base/MigrationServiceSeedSystemOnlyRealmsTest.java
@@ -1,0 +1,75 @@
+package com.e2eq.framework.model.persistent.migration.base;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit-level coverage for the {@code quantum.realm.seed-system-only} guard in
+ * {@link MigrationService#resolveStartupRealms(List, boolean)}.
+ *
+ * <p>{@code resolveStartupRealms} only reads the package-private/protected config fields
+ * (systemRealm/defaultRealm/testRealm/startupRealmsCsv/seedSystemOnly) and the supplied list of
+ * existing database names, so it runs without Quarkus or Mongo when those fields are set directly.
+ */
+class MigrationServiceSeedSystemOnlyRealmsTest {
+
+    private static MigrationService newService(boolean seedSystemOnly, Optional<String> applyRealmsCsv) {
+        MigrationService svc = new MigrationService();
+        svc.systemRealm = "system-com";
+        svc.defaultRealm = "mycompanyxyz-com";
+        svc.testRealm = "test-system-com";
+        svc.startupRealmsCsv = applyRealmsCsv;
+        svc.seedSystemOnly = seedSystemOnly;
+        return svc;
+    }
+
+    @Test
+    void defaultIncludesSystemAndDefaultRealms() {
+        MigrationService svc = newService(false, Optional.empty());
+
+        List<String> realms = svc.resolveStartupRealms(
+                List.of("system-com", "mycompanyxyz-com"), true);
+
+        assertTrue(realms.contains("system-com"), "system realm must be resolved in default mode");
+        assertTrue(realms.contains("mycompanyxyz-com"),
+                "existing default realm must be resolved in default mode");
+        assertEquals(2, realms.size(), "default mode resolves exactly system + existing default realm");
+    }
+
+    @Test
+    void seedSystemOnlyResolvesOnlySystemRealm() {
+        MigrationService svc = newService(true, Optional.empty());
+
+        // Both default and test realm databases exist, but neither should be scanned.
+        List<String> realms = svc.resolveStartupRealms(
+                List.of("system-com", "mycompanyxyz-com", "test-system-com"), true);
+
+        assertTrue(realms.contains("system-com"), "system realm must still be resolved under seed-system-only");
+        assertFalse(realms.contains("mycompanyxyz-com"),
+                "default realm must NOT be resolved under seed-system-only");
+        assertFalse(realms.contains("test-system-com"),
+                "test realm must NOT be resolved under seed-system-only");
+        assertEquals(1, realms.size(), "seed-system-only resolves exactly the system realm");
+    }
+
+    @Test
+    void seedSystemOnlyStillHonorsExplicitApplyRealms() {
+        MigrationService svc = newService(true, Optional.of("mycompanyxyz-com"));
+
+        List<String> realms = svc.resolveStartupRealms(
+                List.of("system-com", "mycompanyxyz-com", "test-system-com"), true);
+
+        assertTrue(realms.contains("system-com"), "system realm must be resolved under seed-system-only");
+        assertTrue(realms.contains("mycompanyxyz-com"),
+                "an explicit quantum.migration.apply.realms entry must still be resolved under seed-system-only");
+        assertFalse(realms.contains("test-system-com"),
+                "test realm must NOT be resolved (it was not explicitly opted in)");
+        assertEquals(2, realms.size(), "system + explicitly opted-in realm");
+    }
+}


### PR DESCRIPTION
Follow-up to #55. When quantum.realm.seed-system-only=true, both realm-resolution paths (migration + seed) restrict to the system realm only, so a system DB no longer scans/logs a test-system-com realm. Opt-in, default-false, 6/6 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)