### PR TITLE
feat(auth): JWKS-consistent kid + delegated central-issuer identity

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -104,6 +104,14 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     @ConfigProperty(name = "quantum.security.filter.enforcePreAuth", defaultValue = "true")
     boolean enforcePreAuth;
 
+    // Delegated identity: when true, a token from the trusted central issuer whose subject is NOT
+    // present in the local credential store is trusted by its (already JWKS-validated) claims, and the
+    // principal is built from those claims — no local credential/database lookup. This lets a service
+    // delegate identity entirely to the central auth service (via its REST API/SDK) without sharing a
+    // database. Default false preserves the strict local-credential behavior.
+    @ConfigProperty(name = "quantum.auth.trust-token-claims", defaultValue = "false")
+    boolean trustTokenClaims;
+
     @Inject
     com.e2eq.framework.security.runtime.RuleContext ruleContext;
 
@@ -661,6 +669,11 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         }
 
         if (!ocreds.isPresent()) {
+            // Delegated identity: the credential store may live in another service/database we must not
+            // reach. When enabled, build the principal from the already-JWKS-validated token claims.
+            if (trustTokenClaims) {
+                return buildDelegatedClaimsContext(sub, realmOverride);
+            }
             throw new IllegalStateException(String.format(
                 "Subject %s not found in credentialUserIdPassword collection in realm:%s",
                 sub, envConfigUtils.getSystemRealm()));
@@ -696,6 +709,47 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                 .withDataDomainPolicy(creds.getDataDomainPolicy())
                 .build();
         return new ContextBuildResult(context, creds);
+    }
+
+    /**
+     * Builds a PrincipalContext purely from a validated central-issuer token's claims, with NO local
+     * credential/database lookup. Used when {@code quantum.auth.trust-token-claims=true} and the token's
+     * subject is not present locally: the service delegates identity to the issuer (whose token is
+     * already JWKS-validated for signature/issuer/audience). Identity = userId/preferred_username claim
+     * (or the subject), roles = the token groups; the operating data realm comes from X-Realm, else the
+     * service's configured system realm. Richer profile data, if needed, is fetched from the issuer's
+     * REST API via the generated SDK — never from a shared database.
+     */
+    private ContextBuildResult buildDelegatedClaimsContext(String sub, String realmOverride) {
+        String userId = claimString("userId");
+        if (userId == null) userId = claimString("preferred_username");
+        if (userId == null) userId = claimString("username");
+        if (userId == null) userId = sub;
+
+        String contextRealm = (realmOverride != null && !realmOverride.isBlank())
+                ? realmOverride
+                : envConfigUtils.getSystemRealm();
+        String[] roles = resolveEffectiveRoles(securityIdentity, null, contextRealm);
+
+        Log.infof("Delegated identity: principal from trusted-issuer token claims (iss=%s, sub=%s, userId=%s, realm=%s, roles=%s)",
+                jwt.getIssuer(), sub, userId, contextRealm, java.util.Arrays.toString(roles));
+
+        PrincipalContext context = new PrincipalContext.Builder()
+                .withDefaultRealm(contextRealm)
+                .withDataDomain(securityUtils.getSystemDataDomain())
+                .withUserId(userId)
+                .withRoles(roles)
+                .withScope("AUTHENTICATED")
+                .build();
+        return new ContextBuildResult(context, null);
+    }
+
+    /** Returns the given JWT claim as a non-blank String, or null. */
+    private String claimString(String name) {
+        Object v = jwt.getClaim(name);
+        if (v == null) return null;
+        String s = v.toString();
+        return s.isBlank() ? null : s;
     }
 
     /**

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
@@ -45,6 +45,11 @@ public class TokenUtils {
         private static volatile String privateKeyLocation = DEFAULT_PRIVATE_KEY_LOCATION;
         private static volatile String publicKeyLocation = DEFAULT_PUBLIC_KEY_LOCATION;
 
+        // JWS "kid" written into signed tokens. When set (e.g. from auth.jwt.key-id), it MUST
+        // match the kid published in the JWKS so JWKS-based verifiers can resolve the key. When
+        // null, we fall back to the private key location for backward compatibility.
+        private static volatile String signingKeyId = null;
+
         private static volatile PrivateKey cachedPrivateKey;
         private static volatile PublicKey cachedPublicKey;
         private static volatile JwtKeyResolver keyResolver = new DefaultJwtKeyResolver();
@@ -75,6 +80,25 @@ public class TokenUtils {
                                 publicKeyLocation = publicKeyLoc;
                         }
                 }
+        }
+
+        /**
+         * Configure the JWS key id ("kid") stamped into signed tokens. Set this to the same value
+         * the JWKS advertises (auth.jwt.key-id) so JWKS-based verifiers can resolve the signing key.
+         */
+        public static void configureSigningKeyId(String keyId) {
+                if (keyId != null && !keyId.isBlank()) {
+                        signingKeyId = keyId;
+                }
+        }
+
+        /**
+         * The kid to stamp into signed tokens: the configured signing key id when present, otherwise
+         * the private key location (legacy behavior).
+         */
+        private static String resolveSigningKeyId() {
+                String kid = signingKeyId;
+                return (kid != null && !kid.isBlank()) ? kid : privateKeyLocation;
         }
 
         /**
@@ -162,7 +186,7 @@ public class TokenUtils {
 		if (orgRefName != null && !orgRefName.isBlank()) claimsBuilder.claim("orgRefName", orgRefName);
 		if (accountNum != null && !accountNum.isBlank()) claimsBuilder.claim("accountNum", accountNum);
 
-		return claimsBuilder.jws().keyId(privateKeyLocation).sign(privateKey);
+		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
 	}
 
 	public static String generateRefreshToken(String subject,  long durationInSeconds, String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
@@ -176,7 +200,7 @@ public class TokenUtils {
 		claimsBuilder.audience("b2bi-api-client-refresh");
 		claimsBuilder.expiresAt(currentTimeInSecs + durationInSeconds + REFRESH_ADDITIONAL_DURATION_SECONDS);
 		claimsBuilder.claim("scope", REFRESH_SCOPE);
-		return claimsBuilder.jws().keyId(privateKeyLocation).sign(privateKey);
+		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
 	}
 
         public static PrivateKey readPrivateKey(final String pemResName) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtilsConfigurer.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtilsConfigurer.java
@@ -23,6 +23,8 @@ public class TokenUtilsConfigurer {
 
     private static final String PRIVATE_KEY_CONFIG = "quantum.jwt.private-key-location";
     private static final String PUBLIC_KEY_CONFIG = "quantum.jwt.public-key-location";
+    // Same property the JWKS endpoint publishes its kid from, so signed tokens and the JWKS agree.
+    private static final String KEY_ID_CONFIG = "auth.jwt.key-id";
 
     @Inject
     JwtKeyResolver jwtKeyResolver;
@@ -37,6 +39,14 @@ public class TokenUtilsConfigurer {
 
         validateConfiguredKeyLocations(activeProfiles, privateKeyConfig, publicKeyConfig);
         TokenUtils.configureKeyResolver(jwtKeyResolver);
+
+        // Stamp signed tokens with the same kid the JWKS advertises (auth.jwt.key-id), so JWKS-based
+        // verifiers (other services validating this issuer's tokens) can resolve the signing key.
+        String signingKeyId = config.getConfigValue(KEY_ID_CONFIG).getValue();
+        if (signingKeyId != null && !signingKeyId.isBlank()) {
+            TokenUtils.configureSigningKeyId(signingKeyId);
+            Log.infof("TokenUtils signing kid set to '%s' (from %s)", signingKeyId, KEY_ID_CONFIG);
+        }
 
         if (privLoc != null || pubLoc != null) {
             Log.infof("Configuring TokenUtils key locations from %s/%s for profiles %s",


### PR DESCRIPTION
Enables services to validate tokens from a central issuer (quantum-auth) and delegate identity to it **without sharing a database** — the foundation for moving the b2bi/tax/customs studios onto quantum-auth.

## 1. kid fix (`TokenUtils` / `TokenUtilsConfigurer`)
Signed tokens stamped the JWS `kid` with the private-key **file path**, which never matched the JWKS `kid` (`auth.jwt.key-id`) — so any JWKS-based verifier failed with `Verification key is unresolvable`. `TokenUtils` now signs with the configured `auth.jwt.key-id` (wired through `TokenUtilsConfigurer`), falling back to the key location when unset. **Non-breaking.**

## 2. Delegated-claims mode (`SecurityFilter`)
New `quantum.auth.trust-token-claims` flag (**default false**). When a JWKS-validated token's subject isn't in the local credential store, the principal is built from the token's claims (`sub`, `groups`→roles, `userId`/`preferred_username`) instead of throwing 500 — **no local credential/DB lookup**. Data realm from `X-Realm`, else the system realm.

## Verification
- Full `quantum-framework` suite on a clean Mongo: **424 run, 0 failures, 0 errors**.
- Proven end-to-end: the customs studio (Quarkus) validates a quantum-auth token via JWKS and authenticates purely from claims (200), no shared DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)