### PR TITLE
feat(mcp): defect tracking API exposed as MCP tools

### DIFF
--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpDefectTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpDefectTools.java
@@ -1,0 +1,168 @@
+package com.e2eq.framework.mcp;
+
+import com.e2eq.framework.mcp.defect.Defect;
+import com.e2eq.framework.mcp.defect.DefectRepo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Exposes defect tracking as MCP tools so agents (Claude, Cursor, etc.) can file,
+ * list, inspect, and triage defects directly over MCP — the "defect API in MCP".
+ *
+ * <p>Delegates to {@link DefectRepo}, reusing the same realm resolution, security
+ * context, and audit as the REST {@code /mcp/defects} surface. Results are returned
+ * as JSON strings, matching the other MCP tool classes in this module.</p>
+ *
+ * @see com.e2eq.framework.mcp.defect.DefectResource
+ */
+@Authenticated
+public class McpDefectTools {
+
+    @Inject
+    DefectRepo defectRepo;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Tool(description = "File a new defect/issue. Returns the created defect including its generated refName. "
+            + "Severity is one of low|medium|high|critical (default medium); the defect starts in status 'open'.")
+    String defect_create(
+            @ToolArg(description = "Short summary line for the defect") String title,
+            @ToolArg(description = "Full description: what is wrong, how to reproduce, and relevant context") String description,
+            @ToolArg(description = "Severity: low|medium|high|critical. Default: medium") String severity,
+            @ToolArg(description = "Subsystem/area, e.g. 'quantum-ontology-service'") String area,
+            @ToolArg(description = "Finer-grained component within the area (optional)") String component,
+            @ToolArg(description = "Who is reporting this (optional; defaults to the caller identity)") String reporter) {
+        try {
+            Defect defect = new Defect();
+            defect.setRefName("defect-" + UUID.randomUUID());
+            defect.setTitle(title);
+            defect.setDisplayName(title != null && !title.isBlank() ? title : defect.getRefName());
+            defect.setDescription(description);
+            defect.setSeverity(normalizeSeverity(severity));
+            defect.setStatus("open");
+            defect.setArea(area);
+            defect.setComponent(component);
+            defect.setReporter(reporter);
+            Defect saved = defectRepo.save(defect);
+            return objectMapper.writeValueAsString(toMap(saved));
+        } catch (Exception e) {
+            return errorJson("DefectCreateFailed", e);
+        }
+    }
+
+    @Tool(description = "List defects, optionally filtered by status (open|in-progress|resolved|closed), "
+            + "severity (low|medium|high|critical), and/or area. Filters are case-insensitive.")
+    String defect_list(
+            @ToolArg(description = "Optional status filter: open|in-progress|resolved|closed") String status,
+            @ToolArg(description = "Optional severity filter: low|medium|high|critical") String severity,
+            @ToolArg(description = "Optional area filter") String area) {
+        try {
+            List<Map<String, Object>> matches = defectRepo.getAllList().stream()
+                    .filter(d -> blankOrEquals(status, d.getStatus()))
+                    .filter(d -> blankOrEquals(severity, d.getSeverity()))
+                    .filter(d -> blankOrEquals(area, d.getArea()))
+                    .map(this::toMap)
+                    .collect(Collectors.toList());
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("count", matches.size());
+            result.put("defects", matches);
+            return objectMapper.writeValueAsString(result);
+        } catch (Exception e) {
+            return errorJson("DefectListFailed", e);
+        }
+    }
+
+    @Tool(description = "Get a single defect by its refName.")
+    String defect_get(
+            @ToolArg(description = "The defect refName (as returned by defect_create / defect_list)") String refName) {
+        try {
+            Optional<Defect> found = defectRepo.findByRefName(refName);
+            if (found.isEmpty()) {
+                return "{\"error\":\"DefectNotFound\",\"message\":\"No defect with refName '" + escapeJson(refName) + "'\"}";
+            }
+            return objectMapper.writeValueAsString(toMap(found.get()));
+        } catch (Exception e) {
+            return errorJson("DefectGetFailed", e);
+        }
+    }
+
+    @Tool(description = "Update a defect's triage fields by refName. Only non-blank arguments are applied. "
+            + "Use this to change status (open|in-progress|resolved|closed), record a resolution, reassign, or re-prioritize.")
+    String defect_update(
+            @ToolArg(description = "The defect refName to update") String refName,
+            @ToolArg(description = "New status: open|in-progress|resolved|closed (optional)") String status,
+            @ToolArg(description = "Resolution notes (optional)") String resolution,
+            @ToolArg(description = "Reassign to (optional)") String assignedTo,
+            @ToolArg(description = "New severity: low|medium|high|critical (optional)") String severity) {
+        try {
+            Optional<Defect> found = defectRepo.findByRefName(refName);
+            if (found.isEmpty()) {
+                return "{\"error\":\"DefectNotFound\",\"message\":\"No defect with refName '" + escapeJson(refName) + "'\"}";
+            }
+            Defect defect = found.get();
+            if (isPresent(status)) defect.setStatus(status.trim());
+            if (isPresent(resolution)) defect.setResolution(resolution);
+            if (isPresent(assignedTo)) defect.setAssignedTo(assignedTo.trim());
+            if (isPresent(severity)) defect.setSeverity(normalizeSeverity(severity));
+            Defect saved = defectRepo.save(defect);
+            return objectMapper.writeValueAsString(toMap(saved));
+        } catch (Exception e) {
+            return errorJson("DefectUpdateFailed", e);
+        }
+    }
+
+    private Map<String, Object> toMap(Defect d) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("refName", d.getRefName());
+        m.put("title", d.getTitle());
+        m.put("description", d.getDescription());
+        m.put("severity", d.getSeverity());
+        m.put("status", d.getStatus());
+        m.put("area", d.getArea());
+        m.put("component", d.getComponent());
+        m.put("reporter", d.getReporter());
+        m.put("assignedTo", d.getAssignedTo());
+        m.put("resolution", d.getResolution());
+        m.put("relatedRefs", d.getRelatedRefs());
+        m.put("tags", d.getTags());
+        return m;
+    }
+
+    private static final List<String> SEVERITIES = Arrays.asList("low", "medium", "high", "critical");
+
+    private String normalizeSeverity(String severity) {
+        if (severity == null || severity.isBlank()) return "medium";
+        String s = severity.trim().toLowerCase();
+        return SEVERITIES.contains(s) ? s : "medium";
+    }
+
+    private boolean blankOrEquals(String filter, String value) {
+        if (filter == null || filter.isBlank()) return true;
+        return filter.trim().equalsIgnoreCase(value);
+    }
+
+    private boolean isPresent(String v) {
+        return v != null && !v.isBlank();
+    }
+
+    private String errorJson(String code, Exception e) {
+        return "{\"error\":\"" + code + "\",\"message\":\"" + escapeJson(e.getMessage()) + "\"}";
+    }
+
+    private static String escapeJson(String s) {
+        if (s == null) return "null";
+        return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+    }
+}

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/defect/Defect.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/defect/Defect.java
@@ -1,0 +1,75 @@
+package com.e2eq.framework.mcp.defect;
+
+import com.e2eq.framework.model.persistent.base.FullBaseModel;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Indexed;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A tracked defect / issue. Persisted like any Quantum entity (realm-scoped, audited)
+ * and exposed both as REST CRUD ({@code DefectResource}) and as MCP tools
+ * ({@code McpDefectTools}) so agents can file and triage defects over MCP.
+ *
+ * <p>NOTE: a service that hosts these must include this package in
+ * {@code quarkus.morphia.packages} so the entity is mapped:
+ * {@code com.e2eq.framework.mcp.defect}.</p>
+ */
+@Entity("defect")
+@RegisterForReflection
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class Defect extends FullBaseModel {
+
+   /** Short summary line. */
+   protected String title;
+
+   /** Full description / reproduction / context. */
+   protected String description;
+
+   /** low | medium | high | critical */
+   @Indexed
+   protected String severity;
+
+   /** open | in-progress | resolved | closed */
+   @Indexed
+   protected String status;
+
+   /** Subsystem/area the defect is in (e.g. "quantum-ontology-service"). */
+   @Indexed
+   protected String area;
+
+   /** Finer-grained component within the area. */
+   protected String component;
+
+   /** Who reported it. */
+   protected String reporter;
+
+   /** Who it is assigned to. */
+   protected String assignedTo;
+
+   /** Resolution notes once resolved/closed. */
+   protected String resolution;
+
+   /** Free-form references (code paths, PRs, related defect refNames, docs). */
+   protected List<String> relatedRefs = new ArrayList<>();
+   // NOTE: `tags` (String[]) is inherited from UnversionedBaseModel — do not redeclare.
+
+   @Override
+   public String bmFunctionalArea() {
+      return "DEFECT";
+   }
+
+   @Override
+   public String bmFunctionalDomain() {
+      return "DEFECT";
+   }
+}

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/defect/DefectRepo.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/defect/DefectRepo.java
@@ -1,0 +1,8 @@
+package com.e2eq.framework.mcp.defect;
+
+import com.e2eq.framework.model.persistent.morphia.MorphiaRepo;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DefectRepo extends MorphiaRepo<Defect> {
+}

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/defect/DefectResource.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/defect/DefectResource.java
@@ -1,0 +1,15 @@
+package com.e2eq.framework.mcp.defect;
+
+import com.e2eq.framework.rest.resources.BaseResource;
+import jakarta.ws.rs.Path;
+
+/**
+ * REST CRUD for {@link Defect} (also usable via the generated helixor-sdk-gen binding).
+ * The same repo is exposed over MCP by {@link McpDefectTools}.
+ */
+@Path("/mcp/defects")
+public class DefectResource extends BaseResource<Defect, DefectRepo> {
+   protected DefectResource(DefectRepo repo) {
+      super(repo);
+   }
+}


### PR DESCRIPTION
## Summary
There was **no defect API over MCP** — the framework MCP server (`quantum-mcp-server`) exposed only Query Gateway CRUDL, ontology discovery, and schema/query-hint resources. This adds a first-class defect tracker as native MCP tools so agents (Claude, Cursor, ChatGPT) can file and triage defects directly.

## What's added (all in `quantum-mcp-server`)
- **`Defect`** — `FullBaseModel` (realm-scoped, audited): `title`, `description`, `severity` (low|medium|high|critical), `status` (open|in-progress|resolved|closed), `area`, `component`, `reporter`, `assignedTo`, `resolution`, `relatedRefs`.
- **`DefectRepo`** (`MorphiaRepo`) + **`DefectResource`** (`BaseResource`) at `/mcp/defects` — REST CRUD, also reachable through the generated helixor-sdk-gen binding.
- **`McpDefectTools`** (`@Tool`, `@Authenticated`, mirrors `McpOntologyTools`): `defect_create`, `defect_list` (filter by status/severity/area), `defect_get`, `defect_update`. JSON results. MCP clients discover them via `tools/list` and invoke via `tools/call`.

## Integration note
`quarkus.morphia.packages` is an explicit per-service list, so a service that hosts this MCP endpoint must add the entity package for it to be mapped:

```
quarkus.morphia.packages=...,com.e2eq.framework.mcp.defect
```

## Verification
- `mvn -o -pl quantum-mcp-server clean compile` → BUILD SUCCESS (18 sources, GraalVM 23 / Maven 3.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)