### PR TITLE
fix(ontology): publisher federated an empty TBox — close cross-module class refs

### DIFF
--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/OntologyReferenceCloser.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/OntologyReferenceCloser.java
@@ -1,0 +1,67 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.PropertyDef;
+import com.e2eq.ontology.core.OntologyRegistry.TBox;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Closes dangling <em>class</em> references in a TBox so a module can declare object properties
+ * whose domain/range is a class OWNED BY ANOTHER MODULE (a federated, cross-module reference)
+ * without the whole TBox being rejected.
+ *
+ * <p>In a federated ontology each service publishes only the classes it owns, yet its properties
+ * may legitimately point at classes another service declares — e.g.
+ * {@code ApplicationPackVersion.usesOntology -> Ontology}, where {@code Ontology} is owned by a
+ * different pack. {@link OntologyValidator} enforces LOCAL referential integrity and treats such a
+ * dangling domain/range as fatal. That is correct for a hand-authored, self-contained TBox (and for
+ * direct admission, which stays strict), but wrong for a <em>source build</em> assembled from
+ * annotations/Morphia/YAML: there a single external edge would otherwise abort the merge and discard
+ * every real class the module does own.</p>
+ *
+ * <p>This step materializes each referenced-but-undeclared domain/range class as an EMPTY stub
+ * (tagged {@code external=true} in metadata for local provenance). Stubs carry no structure, so when
+ * the OWNING module later federates its real definition, {@link OntologyMerger}'s union semantics fold
+ * the two together with no conflict. Property-to-property references (inverseOf, subPropertyOf, chain
+ * members) are intentionally NOT closed here — those are local integrity constraints that must still
+ * fail loudly rather than be papered over.</p>
+ */
+public final class OntologyReferenceCloser {
+
+    /** Metadata key marking a class that was materialized only to satisfy an external reference. */
+    public static final String EXTERNAL_METADATA_KEY = "external";
+
+    private OntologyReferenceCloser() {}
+
+    /**
+     * Return a TBox identical to {@code tbox} except that every class referenced by a property's
+     * domain or range — but not declared in {@code tbox} — is added as an empty external stub. If
+     * no references are dangling, {@code tbox} is returned unchanged.
+     */
+    public static TBox closeClassReferences(TBox tbox) {
+        if (tbox == null) {
+            return null;
+        }
+        Map<String, ClassDef> classes = new LinkedHashMap<>(tbox.classes());
+        int before = classes.size();
+        for (PropertyDef p : tbox.properties().values()) {
+            addStubIfMissing(classes, p.domain().orElse(null));
+            addStubIfMissing(classes, p.range().orElse(null));
+        }
+        if (classes.size() == before) {
+            return tbox;
+        }
+        return new TBox(classes, tbox.properties(), tbox.propertyChains());
+    }
+
+    private static void addStubIfMissing(Map<String, ClassDef> classes, String classId) {
+        if (classId == null || classId.isBlank() || classes.containsKey(classId)) {
+            return;
+        }
+        classes.put(classId, new ClassDef(classId, Set.of(), Set.of(), Set.of(),
+                classId, Set.of(), Map.of(EXTERNAL_METADATA_KEY, Boolean.TRUE)));
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/OntologyReferenceCloserTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/OntologyReferenceCloserTest.java
@@ -1,0 +1,95 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.core.OntologyRegistry.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OntologyReferenceCloserTest {
+
+    private static PropertyDef prop(String name, String domain, String range) {
+        return new PropertyDef(name, Optional.ofNullable(domain), Optional.ofNullable(range),
+                false, Optional.empty(), false, false, false, Set.of(), false);
+    }
+
+    @Test
+    void materializesStubForCrossModuleRange() {
+        // ApplicationPackVersion.usesOntology -> Ontology, where Ontology is owned by another pack
+        // and is therefore not declared in this (annotation-scanned) TBox.
+        Map<String, ClassDef> classes = Map.of(
+                "ApplicationPackVersion", new ClassDef("ApplicationPackVersion", Set.of(), Set.of(), Set.of()));
+        Map<String, PropertyDef> props = Map.of(
+                "usesOntology", prop("usesOntology", "ApplicationPackVersion", "Ontology"));
+        TBox in = new TBox(classes, props, List.of());
+
+        TBox out = OntologyReferenceCloser.closeClassReferences(in);
+
+        assertTrue(out.classes().containsKey("Ontology"), "external range class should be stubbed");
+        assertTrue(out.classes().containsKey("ApplicationPackVersion"), "real class must survive");
+        assertEquals(Boolean.TRUE,
+                out.classes().get("Ontology").metadata().get(OntologyReferenceCloser.EXTERNAL_METADATA_KEY),
+                "stub must be tagged external for provenance");
+    }
+
+    @Test
+    void closesDanglingDomainToo() {
+        TBox in = new TBox(Map.of(), Map.of("p", prop("p", "MissingDomain", null)), List.of());
+        TBox out = OntologyReferenceCloser.closeClassReferences(in);
+        assertTrue(out.classes().containsKey("MissingDomain"));
+    }
+
+    @Test
+    void returnsSameInstanceWhenNothingDangling() {
+        Map<String, ClassDef> classes = Map.of(
+                "Person", new ClassDef("Person", Set.of(), Set.of(), Set.of()));
+        Map<String, PropertyDef> props = Map.of("knows", prop("knows", "Person", "Person"));
+        TBox in = new TBox(classes, props, List.of());
+
+        assertSame(in, OntologyReferenceCloser.closeClassReferences(in),
+                "no dangling refs -> unchanged, no needless copy");
+    }
+
+    @Test
+    void closedTBoxPassesMergeValidationThatWouldOtherwiseThrow() {
+        Map<String, ClassDef> classes = Map.of(
+                "ApplicationPackVersion", new ClassDef("ApplicationPackVersion", Set.of(), Set.of(), Set.of()));
+        Map<String, PropertyDef> props = Map.of(
+                "usesOntology", prop("usesOntology", "ApplicationPackVersion", "Ontology"),
+                "usesSeedPack", prop("usesSeedPack", "ApplicationPackVersion", "SeedPack"));
+        TBox raw = new TBox(classes, props, List.of());
+
+        // Reproduces the defect: merging the raw (dangling) TBox invokes OntologyValidator and throws.
+        TBox empty = new TBox(Map.of(), Map.of(), List.of());
+        assertThrows(IllegalArgumentException.class, () -> OntologyMerger.merge(empty, raw));
+
+        // Closing references first makes the merge validate cleanly and keep the real class.
+        TBox closed = OntologyReferenceCloser.closeClassReferences(raw);
+        TBox merged = assertDoesNotThrow(() -> OntologyMerger.merge(empty, closed));
+        assertTrue(merged.classes().containsKey("ApplicationPackVersion"));
+        assertTrue(merged.classes().containsKey("Ontology"));
+        assertTrue(merged.classes().containsKey("SeedPack"));
+    }
+
+    @Test
+    void doesNotClosePropertyToPropertyReferences() {
+        // inverseOf targets a PROPERTY, not a class: this is a local integrity constraint that must
+        // stay strict. The closer must not silence it.
+        Map<String, ClassDef> classes = Map.of(
+                "Person", new ClassDef("Person", Set.of(), Set.of(), Set.of()));
+        PropertyDef withBadInverse = new PropertyDef("knows", Optional.of("Person"), Optional.of("Person"),
+                true, Optional.of("missingInverseProp"), false, false, false, Set.of(), false);
+        TBox in = new TBox(classes, Map.of("knows", withBadInverse), List.of());
+
+        TBox out = OntologyReferenceCloser.closeClassReferences(in);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OntologyValidator.validate(out));
+        assertTrue(ex.getMessage().contains("Unknown property 'missingInverseProp'"));
+    }
+
+    @Test
+    void nullInputReturnsNull() {
+        assertNull(OntologyReferenceCloser.closeClassReferences(null));
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/OntologyTBoxPublisher.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/OntologyTBoxPublisher.java
@@ -96,7 +96,11 @@ public class OntologyTBoxPublisher {
             return;
         }
         try {
-            OntologyRegistry registry = registryProvider.getRegistryForRealm(realm);
+            // Build purely from sources (annotations + Morphia + YAML), bypassing the
+            // activation-preferring read path: once we activate a published TBox, a plain
+            // getRegistryForRealm would re-read THAT (possibly empty) active copy instead of
+            // the module's source annotations, so the federated TBox would never carry content.
+            OntologyRegistry registry = registryProvider.buildSourceRegistry(realm);
             publish(realm, registry, serviceBaseUrl.get());
         }
         catch (Exception e) {
@@ -109,6 +113,12 @@ public class OntologyTBoxPublisher {
      * Package-visible for testing.
      */
     void publish(String realm, OntologyRegistry registry, String baseUrl) throws Exception {
+        if (registry.classes().isEmpty() && registry.properties().isEmpty()) {
+            // Never clobber the central realm's TBox with an empty one — an empty source
+            // registry means there is nothing to federate (mis-scan or no annotations).
+            Log.warnf("Realm %s: source TBox is empty (0 classes, 0 properties); skipping publish.", realm);
+            return;
+        }
         String base = baseUrl.replaceAll("/+$", "") + "/v1/ontology/" + realm;
         String payload = objectMapper.writeValueAsString(buildSubmitBody(registry));
 

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
@@ -569,6 +569,11 @@ public class TenantOntologyRegistryProvider {
                 if (!pkgs.isEmpty()) {
                     AnnotationOntologyLoader annoLoader = new AnnotationOntologyLoader();
                     TBox annoTBox = annoLoader.loadFromPackages(pkgs);
+                    // Close cross-module class references (e.g. a property whose range is a class
+                    // OWNED BY ANOTHER pack) to empty external stubs, so a single federated edge does
+                    // not make the strict validator reject — and thereby discard — every real class
+                    // this module declares. See OntologyReferenceCloser.
+                    annoTBox = OntologyReferenceCloser.closeClassReferences(annoTBox);
                     accumulated = OntologyMerger.merge(accumulated, annoTBox);
                     Log.debugf("Realm %s: Loaded %d classes from annotations", realm, annoTBox.classes().size());
                 }
@@ -583,6 +588,7 @@ public class TenantOntologyRegistryProvider {
             if (ds != null && ds.getMapper() != null) {
                 MorphiaOntologyLoader loader = new MorphiaOntologyLoader(ds);
                 TBox base = loader.loadTBox();
+                base = OntologyReferenceCloser.closeClassReferences(base);
                 accumulated = OntologyMerger.merge(accumulated, base);
                 Log.debugf("Realm %s: Loaded %d classes from Morphia", realm, base.classes().size());
             }
@@ -604,6 +610,7 @@ public class TenantOntologyRegistryProvider {
                 try { overlay = yaml.loadFromClasspath("/ontology.yaml"); } catch (Exception ignored) { }
             }
             if (overlay != null) {
+                overlay = OntologyReferenceCloser.closeClassReferences(overlay);
                 accumulated = OntologyMerger.merge(accumulated, overlay);
             }
             var result = metaService.observeYaml(yamlPath, "/ontology.yaml");


### PR DESCRIPTION
## Problem

The opt-in ontology federation publisher (`OntologyTBoxPublisher`, shipped in #61) federated an **empty** TBox for realm `quantum-system` — `Published TBox for realm quantum-system ... (classes=0, properties=0)`, and `GET /v1/ontology/quantum-system/tbox` on the central ontology-service returned 0 classes — even though `quantum-system-service` declares `@OntologyClass` models (`ApplicationDefinition`, `ApplicationPackVersion`, `TenantApplicationInstance`).

## Root cause

Neither originally-suspected cache. Live logs showed the annotation scan **did** find all three models, but then `OntologyMerger.merge` → `OntologyValidator.validate` **threw** `Unknown class 'Ontology' in range of usesOntology`, and `buildRegistryForRealm`'s per-step `catch` **discarded every real class** over that single edge → 0 classes → empty publish.

`ApplicationPackVersion` declares object properties whose range is a class **owned by another module** and therefore not present in the scanned package:
- `usesOntology → Ontology`, `usesSeedPack → SeedPack`, `usesRuleBase → RuleBase`, `usesKnowledgeBase → KnowledgeBase`, `declaresFunctionalDomain → FunctionalDomain`

The strict validator treats these federated cross-module references as fatal — correct for a hand-authored, self-contained TBox, wrong for a source build assembled from annotations/Morphia/YAML.

## Fix

Two commits:

1. **`buildSourceRegistry` + empty-guard** — the publisher builds purely from sources (bypassing the activation-preferring read path and the persisted-TBox short-circuit) and never publishes/activates an empty TBox (so it can't clobber a real central TBox with an empty one).
2. **`OntologyReferenceCloser`** (new, `quantum-ontology-core`) — materializes each referenced-but-undeclared domain/range class as an empty `external=true` stub, applied to each loader output in `buildRegistryForRealm` before merge. Stubs union cleanly when the owning module later federates its real definition. `OntologyValidator` stays strict for direct admission; property-to-property refs (inverseOf/subPropertyOf/chains) are intentionally **not** closed.

This is the open-world/federation pattern, not a per-name special case.

## Tests

- `OntologyReferenceCloserTest` (6 cases) — reproduces the validator throw and proves closure fixes it; asserts the strictness boundary (property refs still fail).
- Existing `OntologyValidatorTest` still green (direct-admission strictness preserved).

## Verified live

Against `quantum-ontology-service :8181` for realm `quantum-system`: publish went from **0 → 59 classes / 13 properties** (3 declared models + 5 external stubs + the realm's Morphia entity set), and the central realm now serves the activated non-empty TBox.

## Out of scope (follow-up)

The publisher runs on a plain background thread with no CDI request scope, so the local persist step fails `RequestScoped context was not active ... SecurityIdentityProxy` (caught, non-fatal — central publish still works). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
