### PR TITLE
feat(ontology): governed federated query (Tier 1) + ontology-federation Phase 3 metadata + publisher fixes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -917,6 +917,47 @@ Multiple fields can be separated by commas.
 so for example
  //localhost/location?sort=-name,+id would first sort by name decending and then by id ascending.
 
+==== Federated Source Translation (SQL)
+The same QuantumQuery grammar now drives *federated data sources*, not just MongoDB. When a
+governed query targets a virtual entity view backed by a SQL source, the gateway translates the
+grammar into a parameterized SQL `WHERE` clause (`QueryToSqlListener` in
+`com.e2eq.framework.grammar.sql`) and pushes it down to the source. See
+`applications/helixor-di/docs/FEDERATED_QUERY_ENGINE_BUILD_SPEC.md` for the full engine spec.
+
+**Governed and safe by construction**
+
+* The translated query is ```userQuery && <policy rule filter strings>``` — the same RuleContext
+filters that gate the Mongo path are composed into the SQL `WHERE`, so row-level security is
+identical across sources. No security logic is re-implemented per dialect.
+* All values are bound as SQL parameters (```?```); field names are validated as safe identifiers.
+* **Fail-closed**: any construct the SQL tier cannot translate exactly is REJECTED rather than
+partially rendered — a silently dropped predicate would be a governance leak.
+
+**Supported in SQL tier 1**
+
+* Comparisons ```field:value```, ```field:!value```, ```field:<```, ```field:>```, ```field:<=```,
+```field:>=``` over strings, numbers (```##```/```#```), quoted strings, dates, references, booleans.
+* Membership: ```field:^[...]``` (IN) and ```field:!^[...]``` (NIN).
+* Null / exists: ```field:null```, ```field:!null```, ```field:~```.
+* Logical ```&&``` / ```||``` with the SAME precedence as the Mongo path — **AND binds tighter than
+OR** (```a || b && c``` renders as ```a OR (b AND c)```).
+* Sorting (```+```/```-```) maps to ```ORDER BY```; pagination (skip/length) to ```OFFSET```/```LIMIT```.
+
+**Not yet translated to SQL (rejected in tier 1)**
+
+Explicit parenthesized grouping ```(...)```, ```!!``` (NOT), regex (```"*value*"```),
+```elemMatch```, ```text(...)```, and the ontology relation functions ```hasEdge``` /
+```hasIncomingEdge``` / ```expand``` (relation joins land in a later federation tier).
+
+**Examples**
+```
+status:ACTIVE && region:^[west,east]
+  -> WHERE (region IN (?, ?) AND status = ?)          params: [west, east, ACTIVE]
+
+age:>#30 || tier:GOLD && active:TRUE
+  -> WHERE (age > ? OR (tier = ? AND active = ?))      params: [30, GOLD, true]
+```
+
 ==== Projection
 A projection parameter can be provided to include or exclude specific fields in each result.
 Provide a comma-separated list of fields; prefix with + to include or - to exclude.

--- a/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
@@ -28,10 +28,12 @@ import java.util.regex.Pattern;
  * <p><b>Federation tier 1.</b> Handles scalar comparison predicates, {@code IN/NIN}, {@code null}
  * and {@code exists}, composed with {@code &&} (AND) and {@code ||} (OR) using the SAME
  * precedence as the reference {@code QueryToFilterListener} — <b>AND binds tighter than OR</b>
- * (e.g. {@code a || b && c} → {@code a OR (b AND c)}). It <b>fails closed</b> on anything it
- * cannot translate exactly: explicit grouping {@code (...)}, {@code !!} (NOT), regex, elemMatch,
- * text, and the ontology edge/expand functions all throw {@link UnsupportedQueryException} —
- * a silently dropped/mis-composed predicate would be a governance leak.</p>
+ * (e.g. {@code a || b && c} → {@code a OR (b AND c)}), with explicit {@code (...)} grouping
+ * honored (so the gateway can safely compose {@code (userQuery) && (policyFilter)}). It
+ * <b>fails closed</b> on anything it cannot translate exactly: {@code !!} (NOT), regex,
+ * elemMatch, text, and the ontology edge/expand functions all throw
+ * {@link UnsupportedQueryException} — a silently dropped/mis-composed predicate would be a
+ * governance leak.</p>
  *
  * <p><b>Order-safety:</b> composition pops predicates in reverse, which would misalign positional
  * {@code ?} parameters. So leaves emit named placeholders ({@code :pN}) into a map, and the final
@@ -174,6 +176,10 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
     private void buildComposite() {
         List<String> andParts = new ArrayList<>();
         List<String> orParts = new ArrayList<>();
+
+        // Unwind operators (mirrors QueryToFilterListener.buildCompositeSince, start=0). An
+        // LPAREN marker closes a group using ONLY inner-scope predicates; walk order guarantees
+        // outer operators sit below the marker and are processed in later iterations.
         while (!opTypeStack.isEmpty()) {
             int op = opTypeStack.pop();
             if (op == BIAPIQueryParser.AND) {
@@ -188,6 +194,23 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
                 } else {
                     orParts.add(sqlStack.pop());
                 }
+            } else if (op == BIAPIQueryParser.LPAREN) {
+                if (sqlStack.isEmpty()) throw new UnsupportedQueryException("Group close found no inner predicate");
+                if (andParts.isEmpty()) {
+                    orParts.add(sqlStack.pop());
+                } else {
+                    andParts.add(sqlStack.pop());
+                    orParts.add(combine(andParts, " AND "));
+                    andParts = new ArrayList<>();
+                }
+                if (orParts.size() == 1) {
+                    sqlStack.push(orParts.get(0));
+                } else if (orParts.size() > 1) {
+                    sqlStack.push(combine(orParts, " OR "));
+                } else {
+                    throw new UnsupportedQueryException("Empty parenthesized group");
+                }
+                orParts = new ArrayList<>();
             } else {
                 throw new UnsupportedQueryException("Unsupported composition operator");
             }
@@ -296,9 +319,18 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
 
     // --- fail closed: not translated in tier 1 ------------------------------------------
 
+    // --- explicit grouping: preserves precedence for governed composition -----------------
+    // Required so the gateway can compose `(userQuery) && (policyFilter)` without a top-level
+    // OR in userQuery escaping the policy AND (which would be a governance leak).
+
     @Override public void enterExprGroup(BIAPIQueryParser.ExprGroupContext ctx) {
-        throw new UnsupportedQueryException("Parenthesized grouping is not supported yet (tier 1)");
+        opTypeStack.push(ctx.lp.getType()); // LPAREN marker; closed in buildComposite
     }
+
+    @Override public void exitExprGroup(BIAPIQueryParser.ExprGroupContext ctx) {
+        buildComposite();
+    }
+
     @Override public void enterNotExpr(BIAPIQueryParser.NotExprContext ctx) {
         throw new UnsupportedQueryException("NOT (!!) is not supported yet (tier 1)");
     }

--- a/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
@@ -8,75 +8,101 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * Translates a BIAPIQuery grammar string into a parameterized SQL {@code WHERE} clause.
  *
- * <p><b>Tier 1 — scalar-filter pushdown (fail-closed).</b> This translator is deliberately
- * conservative: it handles scalar comparison predicates joined by {@code &&} (AND) and REFUSES
- * anything it cannot translate exactly — {@code ||} (OR), parenthesized grouping, {@code !!}
- * (NOT), {@code :^}/{@code :!^} (IN/NIN), regex, elemMatch, text, and the ontology edge/expand
- * functions all throw {@link UnsupportedQueryException}. Because the base listener's default
- * methods are no-ops, EVERY leaf expression is overridden here — a silently-dropped predicate
- * would be a governance leak, so an unhandled construct fails the whole translation.</p>
+ * <p><b>Federation tier 1.</b> Handles scalar comparison predicates, {@code IN/NIN}, {@code null}
+ * and {@code exists}, composed with {@code &&} (AND) and {@code ||} (OR) using the SAME
+ * precedence as the reference {@code QueryToFilterListener} — <b>AND binds tighter than OR</b>
+ * (e.g. {@code a || b && c} → {@code a OR (b AND c)}). It <b>fails closed</b> on anything it
+ * cannot translate exactly: explicit grouping {@code (...)}, {@code !!} (NOT), regex, elemMatch,
+ * text, and the ontology edge/expand functions all throw {@link UnsupportedQueryException} —
+ * a silently dropped/mis-composed predicate would be a governance leak.</p>
  *
- * <p>The governed input is {@code userQuery && <policy rule filter strings>} composed upstream by
- * the gateway (RuleContext); the policy constraints are already in the filter before translation,
- * so the emitted SQL is governed with no security logic re-implemented here. Field names are
- * validated as safe identifiers; all values are parameterized ({@code ?}).</p>
+ * <p><b>Order-safety:</b> composition pops predicates in reverse, which would misalign positional
+ * {@code ?} parameters. So leaves emit named placeholders ({@code :pN}) into a map, and the final
+ * clause is scanned left-to-right, replacing each {@code :pN} with {@code ?} and emitting params in
+ * string-appearance order — guaranteeing {@code ?}↔param alignment regardless of composition order.</p>
+ *
+ * <p>The governed input is composed upstream by the gateway
+ * ({@code userQuery && <RuleContext policy filter strings>}); policy is already in the filter, so
+ * the emitted SQL is governed with no security logic re-implemented here. Variables ({@code ${x}})
+ * are expected to be substituted upstream before translation.</p>
  */
 public class QueryToSqlListener extends BIAPIQueryBaseListener {
 
-    /** Thrown when the query contains a construct this tier does not translate. Fail closed. */
     public static class UnsupportedQueryException extends RuntimeException {
-        public UnsupportedQueryException(String message) {
-            super(message);
-        }
+        public UnsupportedQueryException(String message) { super(message); }
     }
 
-    /** The rendered clause + its ordered parameters. */
+    /** The rendered clause (positional {@code ?}) + its ordered parameters. */
     public static final class SqlWhere {
         public final String whereClause;
         public final List<Object> params;
-
-        SqlWhere(String whereClause, List<Object> params) {
-            this.whereClause = whereClause;
-            this.params = params;
-        }
+        SqlWhere(String whereClause, List<Object> params) { this.whereClause = whereClause; this.params = params; }
     }
 
     private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_.]*");
+    private static final Pattern NAMED_PARAM = Pattern.compile(":p\\d+");
 
-    private final List<String> predicates = new ArrayList<>();
-    private final List<Object> params = new ArrayList<>();
+    private final Deque<String> sqlStack = new ArrayDeque<>();
+    private final Deque<Integer> opTypeStack = new ArrayDeque<>();
+    private final Map<String, Object> named = new LinkedHashMap<>();
+    private int paramCounter = 0;
+    private int queryDepth = 0;
 
-    /**
-     * Parse a BIAPIQuery string and render a governed SQL WHERE clause. Parse errors and
-     * unsupported constructs both fail closed (throw), never produce partial SQL.
-     */
     public static SqlWhere translate(String query) {
         BIAPIQueryLexer lexer = new BIAPIQueryLexer(CharStreams.fromString(query == null ? "" : query));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         BIAPIQueryParser parser = new BIAPIQueryParser(tokens);
         parser.removeErrorListeners();
         parser.addErrorListener(new BaseErrorListener() {
-            @Override
-            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line,
-                                    int charPositionInLine, String msg, RecognitionException e) {
-                throw new UnsupportedQueryException("Query parse error at " + line + ":" + charPositionInLine + " — " + msg);
+            @Override public void syntaxError(Recognizer<?, ?> r, Object sym, int line, int pos, String msg, RecognitionException e) {
+                throw new UnsupportedQueryException("Query parse error at " + line + ":" + pos + " — " + msg);
             }
         });
         QueryToSqlListener listener = new QueryToSqlListener();
         ParseTreeWalker.DEFAULT.walk(listener, parser.query());
-        return new SqlWhere(String.join(" AND ", listener.predicates), listener.params);
+        return listener.render();
     }
 
-    private String col(org.antlr.v4.runtime.Token field) {
+    private SqlWhere render() {
+        String body = sqlStack.isEmpty() ? "" : sqlStack.peek();
+        List<Object> positional = new ArrayList<>();
+        Matcher m = NAMED_PARAM.matcher(body);
+        StringBuilder out = new StringBuilder();
+        while (m.find()) {
+            String name = m.group();
+            if (!named.containsKey(name)) {
+                throw new UnsupportedQueryException("Internal: unknown named parameter " + name);
+            }
+            positional.add(named.get(name));
+            m.appendReplacement(out, "?");
+        }
+        m.appendTail(out);
+        return new SqlWhere(out.toString(), positional);
+    }
+
+    private String newParam(Object value) {
+        String name = ":p" + (paramCounter++);
+        named.put(name, value);
+        return name;
+    }
+
+    private String col(Token field) {
         String name = field.getText();
         if (name == null || !SAFE_IDENTIFIER.matcher(name).matches()) {
             throw new UnsupportedQueryException("Unsafe or empty field identifier: " + name);
@@ -84,7 +110,7 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
         return name;
     }
 
-    private String comparator(org.antlr.v4.runtime.Token op) {
+    private String comparator(Token op) {
         switch (op.getType()) {
             case BIAPIQueryParser.EQ: return "=";
             case BIAPIQueryParser.NEQ: return "<>";
@@ -92,64 +118,115 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
             case BIAPIQueryParser.GT: return ">";
             case BIAPIQueryParser.LTE: return "<=";
             case BIAPIQueryParser.GTE: return ">=";
-            default:
-                throw new UnsupportedQueryException("Operator not supported in SQL tier 1: " + op.getText());
+            default: throw new UnsupportedQueryException("Operator not supported in SQL tier 1: " + op.getText());
         }
     }
 
-    private void addComparison(org.antlr.v4.runtime.Token field, org.antlr.v4.runtime.Token op, Object value) {
-        predicates.add(col(field) + " " + comparator(op) + " ?");
-        params.add(value);
+    private void pushComparison(Token field, Token op, Object value) {
+        sqlStack.push(col(field) + " " + comparator(op) + " " + newParam(value));
     }
 
-    // --- Supported scalar comparisons -------------------------------------------------
-
-    @Override
-    public void enterStringExpr(BIAPIQueryParser.StringExprContext ctx) {
-        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    private static String combine(List<String> parts, String connector) {
+        if (parts.size() == 1) return parts.get(0);
+        return "(" + String.join(connector, parts) + ")";
     }
 
-    @Override
-    public void enterQuotedExpr(BIAPIQueryParser.QuotedExprContext ctx) {
-        addComparison(ctx.field, ctx.op, ctx.value.getText());
-    }
+    // --- composition (mirrors QueryToFilterListener; AND binds tighter than OR) ---------
+
+    @Override public void enterQuery(BIAPIQueryParser.QueryContext ctx) { queryDepth++; }
 
     @Override
-    public void enterReferenceExpr(BIAPIQueryParser.ReferenceExprContext ctx) {
-        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    public void exitQuery(BIAPIQueryParser.QueryContext ctx) {
+        queryDepth--;
+        if (queryDepth == 0 && (!opTypeStack.isEmpty() || sqlStack.size() > 1)) {
+            buildComposite();
+        }
+    }
+
+    private void buildComposite() {
+        List<String> andParts = new ArrayList<>();
+        List<String> orParts = new ArrayList<>();
+        while (!opTypeStack.isEmpty()) {
+            int op = opTypeStack.pop();
+            if (op == BIAPIQueryParser.AND) {
+                if (sqlStack.isEmpty()) throw new UnsupportedQueryException("AND without right-hand predicate");
+                andParts.add(sqlStack.pop());
+            } else if (op == BIAPIQueryParser.OR) {
+                if (sqlStack.isEmpty()) throw new UnsupportedQueryException("OR without predicate");
+                if (!andParts.isEmpty()) {
+                    andParts.add(sqlStack.pop());
+                    orParts.add(combine(andParts, " AND "));
+                    andParts = new ArrayList<>();
+                } else {
+                    orParts.add(sqlStack.pop());
+                }
+            } else {
+                throw new UnsupportedQueryException("Unsupported composition operator");
+            }
+        }
+        int inner = sqlStack.size();
+        if (!andParts.isEmpty()) {
+            if (inner <= 0) throw new UnsupportedQueryException("AND composition missing left-hand predicate");
+            andParts.add(sqlStack.pop());
+            String andCombined = combine(andParts, " AND ");
+            if (!orParts.isEmpty()) {
+                orParts.add(andCombined);
+                sqlStack.push(combine(orParts, " OR "));
+            } else {
+                sqlStack.push(andCombined);
+            }
+            return;
+        }
+        if (!orParts.isEmpty()) {
+            String left = null;
+            if (inner > 1) {
+                List<String> leftList = new ArrayList<>();
+                for (int i = 0; i < inner; i++) leftList.add(0, sqlStack.pop());
+                left = combine(leftList, " AND ");
+            } else if (inner == 1) {
+                left = sqlStack.pop();
+            }
+            if (left != null) orParts.add(left);
+            sqlStack.push(combine(orParts, " OR "));
+            return;
+        }
+        if (inner > 1) {
+            List<String> tmp = new ArrayList<>();
+            for (int i = 0; i < inner; i++) tmp.add(0, sqlStack.pop());
+            sqlStack.push(combine(tmp, " AND "));
+        }
     }
 
     @Override
-    public void enterDateExpr(BIAPIQueryParser.DateExprContext ctx) {
-        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    public void enterExprOp(BIAPIQueryParser.ExprOpContext ctx) {
+        int t = ctx.op.getType();
+        if (t != BIAPIQueryParser.AND && t != BIAPIQueryParser.OR) {
+            throw new UnsupportedQueryException("Unsupported combiner: " + ctx.op.getText());
+        }
+        opTypeStack.push(t);
     }
 
-    @Override
-    public void enterDateTimeExpr(BIAPIQueryParser.DateTimeExprContext ctx) {
-        addComparison(ctx.field, ctx.op, ctx.value.getText());
-    }
+    // --- leaves: scalar comparisons ------------------------------------------------------
 
-    @Override
-    public void enterNumberExpr(BIAPIQueryParser.NumberExprContext ctx) {
-        addComparison(ctx.field, ctx.op, Double.valueOf(ctx.value.getText()));
-    }
-
-    @Override
-    public void enterWholenumberExpr(BIAPIQueryParser.WholenumberExprContext ctx) {
-        addComparison(ctx.field, ctx.op, Long.valueOf(ctx.value.getText()));
-    }
+    @Override public void enterStringExpr(BIAPIQueryParser.StringExprContext ctx) { pushComparison(ctx.field, ctx.op, ctx.value.getText()); }
+    @Override public void enterQuotedExpr(BIAPIQueryParser.QuotedExprContext ctx) { pushComparison(ctx.field, ctx.op, ctx.value.getText()); }
+    @Override public void enterReferenceExpr(BIAPIQueryParser.ReferenceExprContext ctx) { pushComparison(ctx.field, ctx.op, ctx.value.getText()); }
+    @Override public void enterDateExpr(BIAPIQueryParser.DateExprContext ctx) { pushComparison(ctx.field, ctx.op, ctx.value.getText()); }
+    @Override public void enterDateTimeExpr(BIAPIQueryParser.DateTimeExprContext ctx) { pushComparison(ctx.field, ctx.op, ctx.value.getText()); }
+    @Override public void enterNumberExpr(BIAPIQueryParser.NumberExprContext ctx) { pushComparison(ctx.field, ctx.op, Double.valueOf(ctx.value.getText())); }
+    @Override public void enterWholenumberExpr(BIAPIQueryParser.WholenumberExprContext ctx) { pushComparison(ctx.field, ctx.op, Long.valueOf(ctx.value.getText())); }
 
     @Override
     public void enterBooleanExpr(BIAPIQueryParser.BooleanExprContext ctx) {
-        addComparison(ctx.field, ctx.op, Boolean.valueOf("true".equalsIgnoreCase(ctx.value.getText())));
+        pushComparison(ctx.field, ctx.op, Boolean.valueOf("true".equalsIgnoreCase(ctx.value.getText())));
     }
 
     @Override
     public void enterNullExpr(BIAPIQueryParser.NullExprContext ctx) {
         if (ctx.op.getType() == BIAPIQueryParser.EQ) {
-            predicates.add(col(ctx.field) + " IS NULL");
+            sqlStack.push(col(ctx.field) + " IS NULL");
         } else if (ctx.op.getType() == BIAPIQueryParser.NEQ) {
-            predicates.add(col(ctx.field) + " IS NOT NULL");
+            sqlStack.push(col(ctx.field) + " IS NOT NULL");
         } else {
             throw new UnsupportedQueryException("Null comparison operator not supported: " + ctx.op.getText());
         }
@@ -157,66 +234,65 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
 
     @Override
     public void enterExistsExpr(BIAPIQueryParser.ExistsExprContext ctx) {
-        predicates.add(col(ctx.field) + " IS NOT NULL");
-    }
-
-    // --- Fail closed: everything not translated above -------------------------------------
-
-    @Override
-    public void enterExprOp(BIAPIQueryParser.ExprOpContext ctx) {
-        // AND is the only supported combiner in tier 1; OR needs the full composition tier.
-        if (ctx.op.getType() != BIAPIQueryParser.AND) {
-            throw new UnsupportedQueryException("Only '&&' (AND) is supported in SQL tier 1; got '" + ctx.op.getText() + "'");
-        }
-    }
-
-    @Override
-    public void enterExprGroup(BIAPIQueryParser.ExprGroupContext ctx) {
-        throw new UnsupportedQueryException("Parenthesized grouping is not supported in SQL tier 1");
+        sqlStack.push(col(ctx.field) + " IS NOT NULL");
     }
 
     @Override
     public void enterInExpr(BIAPIQueryParser.InExprContext ctx) {
-        throw new UnsupportedQueryException("IN/NIN is not supported in SQL tier 1");
+        String column = col(ctx.field);
+        boolean negated = ctx.op.getType() == BIAPIQueryParser.NIN;
+        List<String> placeholders = new ArrayList<>();
+        BIAPIQueryParser.ValueListExprContext list = ctx.value;
+        if (list != null && list.children != null) {
+            for (Object child : list.children) {
+                if (child instanceof TerminalNode tn) {
+                    int t = tn.getSymbol().getType();
+                    switch (t) {
+                        case BIAPIQueryParser.STRING:
+                        case BIAPIQueryParser.QUOTED_STRING:
+                        case BIAPIQueryParser.OID:
+                        case BIAPIQueryParser.REFERENCE:
+                            placeholders.add(newParam(tn.getText()));
+                            break;
+                        case BIAPIQueryParser.VARIABLE:
+                            throw new UnsupportedQueryException("Unresolved variable in IN list — substitute upstream");
+                        default:
+                            // COMMA / brackets — skip
+                    }
+                }
+            }
+        }
+        if (placeholders.isEmpty()) throw new UnsupportedQueryException("Empty IN list");
+        sqlStack.push(column + (negated ? " NOT IN (" : " IN (") + String.join(", ", placeholders) + ")");
     }
 
-    @Override
-    public void enterNotExpr(BIAPIQueryParser.NotExprContext ctx) {
-        throw new UnsupportedQueryException("NOT (!!) is not supported in SQL tier 1");
-    }
+    // --- fail closed: not translated in tier 1 ------------------------------------------
 
-    @Override
-    public void enterRegexExpr(BIAPIQueryParser.RegexExprContext ctx) {
+    @Override public void enterExprGroup(BIAPIQueryParser.ExprGroupContext ctx) {
+        throw new UnsupportedQueryException("Parenthesized grouping is not supported yet (tier 1)");
+    }
+    @Override public void enterNotExpr(BIAPIQueryParser.NotExprContext ctx) {
+        throw new UnsupportedQueryException("NOT (!!) is not supported yet (tier 1)");
+    }
+    @Override public void enterRegexExpr(BIAPIQueryParser.RegexExprContext ctx) {
         throw new UnsupportedQueryException("Regex is not supported in SQL tier 1");
     }
-
-    @Override
-    public void enterElemMatchExpr(BIAPIQueryParser.ElemMatchExprContext ctx) {
+    @Override public void enterElemMatchExpr(BIAPIQueryParser.ElemMatchExprContext ctx) {
         throw new UnsupportedQueryException("elemMatch is not supported in SQL tier 1");
     }
-
-    @Override
-    public void enterTextExpr(BIAPIQueryParser.TextExprContext ctx) {
+    @Override public void enterTextExpr(BIAPIQueryParser.TextExprContext ctx) {
         throw new UnsupportedQueryException("text() is not supported in SQL tier 1");
     }
-
-    @Override
-    public void enterHasEdgeExpr(BIAPIQueryParser.HasEdgeExprContext ctx) {
-        throw new UnsupportedQueryException("hasEdge is a relation join (tier 2), not supported in SQL tier 1");
+    @Override public void enterHasEdgeExpr(BIAPIQueryParser.HasEdgeExprContext ctx) {
+        throw new UnsupportedQueryException("hasEdge is a relation join (tier 2)");
     }
-
-    @Override
-    public void enterHasOutgoingEdgeExpr(BIAPIQueryParser.HasOutgoingEdgeExprContext ctx) {
-        throw new UnsupportedQueryException("hasOutgoingEdge is a relation join (tier 2), not supported in SQL tier 1");
+    @Override public void enterHasOutgoingEdgeExpr(BIAPIQueryParser.HasOutgoingEdgeExprContext ctx) {
+        throw new UnsupportedQueryException("hasOutgoingEdge is a relation join (tier 2)");
     }
-
-    @Override
-    public void enterHasIncomingEdgeExpr(BIAPIQueryParser.HasIncomingEdgeExprContext ctx) {
-        throw new UnsupportedQueryException("hasIncomingEdge is a relation join (tier 2), not supported in SQL tier 1");
+    @Override public void enterHasIncomingEdgeExpr(BIAPIQueryParser.HasIncomingEdgeExprContext ctx) {
+        throw new UnsupportedQueryException("hasIncomingEdge is a relation join (tier 2)");
     }
-
-    @Override
-    public void enterExpandExpr(BIAPIQueryParser.ExpandExprContext ctx) {
-        throw new UnsupportedQueryException("expand is a relation join (tier 2), not supported in SQL tier 1");
+    @Override public void enterExpandExpr(BIAPIQueryParser.ExpandExprContext ctx) {
+        throw new UnsupportedQueryException("expand is a relation join (tier 2)");
     }
 }

--- a/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
@@ -1,0 +1,222 @@
+package com.e2eq.framework.grammar.sql;
+
+import com.e2eq.framework.grammar.BIAPIQueryBaseListener;
+import com.e2eq.framework.grammar.BIAPIQueryLexer;
+import com.e2eq.framework.grammar.BIAPIQueryParser;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Translates a BIAPIQuery grammar string into a parameterized SQL {@code WHERE} clause.
+ *
+ * <p><b>Tier 1 — scalar-filter pushdown (fail-closed).</b> This translator is deliberately
+ * conservative: it handles scalar comparison predicates joined by {@code &&} (AND) and REFUSES
+ * anything it cannot translate exactly — {@code ||} (OR), parenthesized grouping, {@code !!}
+ * (NOT), {@code :^}/{@code :!^} (IN/NIN), regex, elemMatch, text, and the ontology edge/expand
+ * functions all throw {@link UnsupportedQueryException}. Because the base listener's default
+ * methods are no-ops, EVERY leaf expression is overridden here — a silently-dropped predicate
+ * would be a governance leak, so an unhandled construct fails the whole translation.</p>
+ *
+ * <p>The governed input is {@code userQuery && <policy rule filter strings>} composed upstream by
+ * the gateway (RuleContext); the policy constraints are already in the filter before translation,
+ * so the emitted SQL is governed with no security logic re-implemented here. Field names are
+ * validated as safe identifiers; all values are parameterized ({@code ?}).</p>
+ */
+public class QueryToSqlListener extends BIAPIQueryBaseListener {
+
+    /** Thrown when the query contains a construct this tier does not translate. Fail closed. */
+    public static class UnsupportedQueryException extends RuntimeException {
+        public UnsupportedQueryException(String message) {
+            super(message);
+        }
+    }
+
+    /** The rendered clause + its ordered parameters. */
+    public static final class SqlWhere {
+        public final String whereClause;
+        public final List<Object> params;
+
+        SqlWhere(String whereClause, List<Object> params) {
+            this.whereClause = whereClause;
+            this.params = params;
+        }
+    }
+
+    private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_.]*");
+
+    private final List<String> predicates = new ArrayList<>();
+    private final List<Object> params = new ArrayList<>();
+
+    /**
+     * Parse a BIAPIQuery string and render a governed SQL WHERE clause. Parse errors and
+     * unsupported constructs both fail closed (throw), never produce partial SQL.
+     */
+    public static SqlWhere translate(String query) {
+        BIAPIQueryLexer lexer = new BIAPIQueryLexer(CharStreams.fromString(query == null ? "" : query));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        BIAPIQueryParser parser = new BIAPIQueryParser(tokens);
+        parser.removeErrorListeners();
+        parser.addErrorListener(new BaseErrorListener() {
+            @Override
+            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line,
+                                    int charPositionInLine, String msg, RecognitionException e) {
+                throw new UnsupportedQueryException("Query parse error at " + line + ":" + charPositionInLine + " — " + msg);
+            }
+        });
+        QueryToSqlListener listener = new QueryToSqlListener();
+        ParseTreeWalker.DEFAULT.walk(listener, parser.query());
+        return new SqlWhere(String.join(" AND ", listener.predicates), listener.params);
+    }
+
+    private String col(org.antlr.v4.runtime.Token field) {
+        String name = field.getText();
+        if (name == null || !SAFE_IDENTIFIER.matcher(name).matches()) {
+            throw new UnsupportedQueryException("Unsafe or empty field identifier: " + name);
+        }
+        return name;
+    }
+
+    private String comparator(org.antlr.v4.runtime.Token op) {
+        switch (op.getType()) {
+            case BIAPIQueryParser.EQ: return "=";
+            case BIAPIQueryParser.NEQ: return "<>";
+            case BIAPIQueryParser.LT: return "<";
+            case BIAPIQueryParser.GT: return ">";
+            case BIAPIQueryParser.LTE: return "<=";
+            case BIAPIQueryParser.GTE: return ">=";
+            default:
+                throw new UnsupportedQueryException("Operator not supported in SQL tier 1: " + op.getText());
+        }
+    }
+
+    private void addComparison(org.antlr.v4.runtime.Token field, org.antlr.v4.runtime.Token op, Object value) {
+        predicates.add(col(field) + " " + comparator(op) + " ?");
+        params.add(value);
+    }
+
+    // --- Supported scalar comparisons -------------------------------------------------
+
+    @Override
+    public void enterStringExpr(BIAPIQueryParser.StringExprContext ctx) {
+        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    }
+
+    @Override
+    public void enterQuotedExpr(BIAPIQueryParser.QuotedExprContext ctx) {
+        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    }
+
+    @Override
+    public void enterReferenceExpr(BIAPIQueryParser.ReferenceExprContext ctx) {
+        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    }
+
+    @Override
+    public void enterDateExpr(BIAPIQueryParser.DateExprContext ctx) {
+        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    }
+
+    @Override
+    public void enterDateTimeExpr(BIAPIQueryParser.DateTimeExprContext ctx) {
+        addComparison(ctx.field, ctx.op, ctx.value.getText());
+    }
+
+    @Override
+    public void enterNumberExpr(BIAPIQueryParser.NumberExprContext ctx) {
+        addComparison(ctx.field, ctx.op, Double.valueOf(ctx.value.getText()));
+    }
+
+    @Override
+    public void enterWholenumberExpr(BIAPIQueryParser.WholenumberExprContext ctx) {
+        addComparison(ctx.field, ctx.op, Long.valueOf(ctx.value.getText()));
+    }
+
+    @Override
+    public void enterBooleanExpr(BIAPIQueryParser.BooleanExprContext ctx) {
+        addComparison(ctx.field, ctx.op, Boolean.valueOf("true".equalsIgnoreCase(ctx.value.getText())));
+    }
+
+    @Override
+    public void enterNullExpr(BIAPIQueryParser.NullExprContext ctx) {
+        if (ctx.op.getType() == BIAPIQueryParser.EQ) {
+            predicates.add(col(ctx.field) + " IS NULL");
+        } else if (ctx.op.getType() == BIAPIQueryParser.NEQ) {
+            predicates.add(col(ctx.field) + " IS NOT NULL");
+        } else {
+            throw new UnsupportedQueryException("Null comparison operator not supported: " + ctx.op.getText());
+        }
+    }
+
+    @Override
+    public void enterExistsExpr(BIAPIQueryParser.ExistsExprContext ctx) {
+        predicates.add(col(ctx.field) + " IS NOT NULL");
+    }
+
+    // --- Fail closed: everything not translated above -------------------------------------
+
+    @Override
+    public void enterExprOp(BIAPIQueryParser.ExprOpContext ctx) {
+        // AND is the only supported combiner in tier 1; OR needs the full composition tier.
+        if (ctx.op.getType() != BIAPIQueryParser.AND) {
+            throw new UnsupportedQueryException("Only '&&' (AND) is supported in SQL tier 1; got '" + ctx.op.getText() + "'");
+        }
+    }
+
+    @Override
+    public void enterExprGroup(BIAPIQueryParser.ExprGroupContext ctx) {
+        throw new UnsupportedQueryException("Parenthesized grouping is not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterInExpr(BIAPIQueryParser.InExprContext ctx) {
+        throw new UnsupportedQueryException("IN/NIN is not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterNotExpr(BIAPIQueryParser.NotExprContext ctx) {
+        throw new UnsupportedQueryException("NOT (!!) is not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterRegexExpr(BIAPIQueryParser.RegexExprContext ctx) {
+        throw new UnsupportedQueryException("Regex is not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterElemMatchExpr(BIAPIQueryParser.ElemMatchExprContext ctx) {
+        throw new UnsupportedQueryException("elemMatch is not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterTextExpr(BIAPIQueryParser.TextExprContext ctx) {
+        throw new UnsupportedQueryException("text() is not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterHasEdgeExpr(BIAPIQueryParser.HasEdgeExprContext ctx) {
+        throw new UnsupportedQueryException("hasEdge is a relation join (tier 2), not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterHasOutgoingEdgeExpr(BIAPIQueryParser.HasOutgoingEdgeExprContext ctx) {
+        throw new UnsupportedQueryException("hasOutgoingEdge is a relation join (tier 2), not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterHasIncomingEdgeExpr(BIAPIQueryParser.HasIncomingEdgeExprContext ctx) {
+        throw new UnsupportedQueryException("hasIncomingEdge is a relation join (tier 2), not supported in SQL tier 1");
+    }
+
+    @Override
+    public void enterExpandExpr(BIAPIQueryParser.ExpandExprContext ctx) {
+        throw new UnsupportedQueryException("expand is a relation join (tier 2), not supported in SQL tier 1");
+    }
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
@@ -18,6 +18,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -61,10 +62,33 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
     private final Deque<String> sqlStack = new ArrayDeque<>();
     private final Deque<Integer> opTypeStack = new ArrayDeque<>();
     private final Map<String, Object> named = new LinkedHashMap<>();
+    /** Maps an ontology field reference to its physical source column. Identity by default. */
+    private final Function<String, String> columnResolver;
     private int paramCounter = 0;
     private int queryDepth = 0;
 
+    private QueryToSqlListener(Function<String, String> columnResolver) {
+        this.columnResolver = columnResolver == null ? Function.identity() : columnResolver;
+    }
+
+    /** Translate with the field name used verbatim as the column (identity mapping). */
     public static SqlWhere translate(String query) {
+        return translate(query, Function.<String>identity());
+    }
+
+    /**
+     * Translate, mapping each ontology field reference to its physical source column via
+     * {@code fieldToColumn} (the reverse of the source→ontology mapping). Unmapped fields pass
+     * through unchanged. Both the field and the resolved column are validated as safe identifiers.
+     */
+    public static SqlWhere translate(String query, Map<String, String> fieldToColumn) {
+        Function<String, String> resolver = (fieldToColumn == null)
+                ? Function.identity()
+                : field -> fieldToColumn.getOrDefault(field, field);
+        return translate(query, resolver);
+    }
+
+    public static SqlWhere translate(String query, Function<String, String> columnResolver) {
         BIAPIQueryLexer lexer = new BIAPIQueryLexer(CharStreams.fromString(query == null ? "" : query));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         BIAPIQueryParser parser = new BIAPIQueryParser(tokens);
@@ -74,7 +98,7 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
                 throw new UnsupportedQueryException("Query parse error at " + line + ":" + pos + " — " + msg);
             }
         });
-        QueryToSqlListener listener = new QueryToSqlListener();
+        QueryToSqlListener listener = new QueryToSqlListener(columnResolver);
         ParseTreeWalker.DEFAULT.walk(listener, parser.query());
         return listener.render();
     }
@@ -107,7 +131,11 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
         if (name == null || !SAFE_IDENTIFIER.matcher(name).matches()) {
             throw new UnsupportedQueryException("Unsafe or empty field identifier: " + name);
         }
-        return name;
+        String column = columnResolver.apply(name);
+        if (column == null || !SAFE_IDENTIFIER.matcher(column).matches()) {
+            throw new UnsupportedQueryException("Unsafe or empty resolved column for field: " + name);
+        }
+        return column;
     }
 
     private String comparator(Token op) {

--- a/quantum-models/src/test/java/com/e2eq/framework/grammar/sql/QueryToSqlListenerTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/grammar/sql/QueryToSqlListenerTest.java
@@ -105,12 +105,38 @@ class QueryToSqlListenerTest {
                 () -> QueryToSqlListener.translate("region:west", Map.of("region", "region; DROP TABLE x")));
     }
 
-    // --- fail closed -------------------------------------------------------------
+    // --- explicit grouping (governed composition) --------------------------------
 
     @Test
-    void parenthesizedGroupingRejected() {
-        assertThrows(UnsupportedQueryException.class, () -> QueryToSqlListener.translate("(a:1 || b:2) && c:3"));
+    void parenthesizedGroup_overridesPrecedence() {
+        // Without parens this is a:1 OR (b:2 AND c:3); the parens force the OR to be grouped
+        // and ANDed with c — the exact shape a governed `(userQuery) && (policyFilter)` needs.
+        // (Reference AND-ordering emits the right-hand operand first; params stay aligned.)
+        assertWhere("(a:1 || b:2) && c:3",
+                "(c = ? AND (b = ? OR a = ?))", List.of("3", "2", "1"));
     }
+
+    @Test
+    void singleElementGroup_unwraps() {
+        assertWhere("(name:Acme)", "name = ?", List.of("Acme"));
+    }
+
+    @Test
+    void governedComposition_userOrCannotEscapePolicyAnd() {
+        // The governance-critical case: a user query with a top-level OR, ANDed with a tenant
+        // policy filter. The tenant predicate MUST gate BOTH branches of the OR — and it does:
+        // it ANDs with the entire (b OR a) group, not just one branch.
+        assertWhere("(a:1 || b:2) && tenantId:t1",
+                "(tenantId = ? AND (b = ? OR a = ?))", List.of("t1", "2", "1"));
+    }
+
+    @Test
+    void nestedGroups() {
+        assertWhere("(a:1 || b:2) && (c:3 || d:4)",
+                "((d = ? OR c = ?) AND (b = ? OR a = ?))", List.of("4", "3", "2", "1"));
+    }
+
+    // --- fail closed -------------------------------------------------------------
 
     @Test
     void notRejected() {

--- a/quantum-models/src/test/java/com/e2eq/framework/grammar/sql/QueryToSqlListenerTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/grammar/sql/QueryToSqlListenerTest.java
@@ -1,0 +1,135 @@
+package com.e2eq.framework.grammar.sql;
+
+import com.e2eq.framework.grammar.sql.QueryToSqlListener.SqlWhere;
+import com.e2eq.framework.grammar.sql.QueryToSqlListener.UnsupportedQueryException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression suite for the BIAPIQuery → SQL WHERE translator (federation tier 1). Locks in the
+ * security-critical behavior: precedence (AND binds tighter than OR), positional-param alignment
+ * across composition reordering, IN/NIN, ontology-field → source-column mapping, and fail-closed
+ * rejection of anything not yet translatable.
+ */
+class QueryToSqlListenerTest {
+
+    private static void assertWhere(String query, String expectedWhere, List<Object> expectedParams) {
+        SqlWhere w = QueryToSqlListener.translate(query);
+        assertEquals(expectedWhere, w.whereClause, "WHERE for: " + query);
+        assertEquals(expectedParams, w.params, "params for: " + query);
+    }
+
+    // --- scalars -----------------------------------------------------------------
+
+    @Test
+    void singlePredicate_noParens() {
+        assertWhere("name:Acme", "name = ?", List.of("Acme"));
+    }
+
+    @Test
+    void comparisonOperators() {
+        assertWhere("age:>#30", "age > ?", List.of(30L));
+        assertWhere("total:>=##100.50", "total >= ?", List.of(100.50d));
+        assertWhere("status:!X", "status <> ?", List.of("X"));
+    }
+
+    @Test
+    void booleanAndNullAndExists() {
+        assertWhere("active:TRUE", "active = ?", List.of(true));
+        assertWhere("deletedAt:null", "deletedAt IS NULL", List.of());
+        assertWhere("deletedAt:!null", "deletedAt IS NOT NULL", List.of());
+        assertWhere("email:~", "email IS NOT NULL", List.of());
+    }
+
+    // --- composition + precedence ------------------------------------------------
+
+    @Test
+    void conjunction() {
+        // popped in reverse; params stay aligned via the named->positional pass
+        assertWhere("name:Acme && active:TRUE", "(active = ? AND name = ?)", List.of(true, "Acme"));
+    }
+
+    @Test
+    void disjunction() {
+        assertWhere("a:1 || b:2", "(b = ? OR a = ?)", List.of("2", "1"));
+    }
+
+    @Test
+    void andBindsTighterThanOr() {
+        assertWhere("a:AAA || b:BBB && c:CCC",
+                "((c = ? AND b = ?) OR a = ?)", List.of("CCC", "BBB", "AAA"));
+        assertWhere("a:AAA && b:BBB || c:CCC",
+                "(c = ? OR (b = ? AND a = ?))", List.of("CCC", "BBB", "AAA"));
+    }
+
+    // --- IN / NIN ---------------------------------------------------------------
+
+    @Test
+    void inAndNotIn() {
+        assertWhere("region:^[west,east,south]", "region IN (?, ?, ?)", List.of("west", "east", "south"));
+        assertWhere("region:!^[west]", "region NOT IN (?)", List.of("west"));
+    }
+
+    @Test
+    void inComposesWithScalar_paramsStayAligned() {
+        assertWhere("status:ACTIVE && region:^[west,east]",
+                "(region IN (?, ?) AND status = ?)", List.of("west", "east", "ACTIVE"));
+    }
+
+    // --- ontology-field -> source-column mapping --------------------------------
+
+    @Test
+    void fieldToColumnMapping() {
+        Map<String, String> m = Map.of("region", "region_code", "tenantId", "tenant_id");
+        SqlWhere w = QueryToSqlListener.translate("region:west && tenantId:t1", m);
+        assertEquals("(tenant_id = ? AND region_code = ?)", w.whereClause);
+        assertEquals(List.of("t1", "west"), w.params);
+    }
+
+    @Test
+    void unmappedFieldPassesThrough() {
+        Map<String, String> m = Map.of("region", "region_code");
+        SqlWhere w = QueryToSqlListener.translate("region:west && status:ACTIVE", m);
+        assertEquals("(status = ? AND region_code = ?)", w.whereClause);
+        assertEquals(List.of("ACTIVE", "west"), w.params);
+    }
+
+    @Test
+    void unsafeResolvedColumnRejected() {
+        assertThrows(UnsupportedQueryException.class,
+                () -> QueryToSqlListener.translate("region:west", Map.of("region", "region; DROP TABLE x")));
+    }
+
+    // --- fail closed -------------------------------------------------------------
+
+    @Test
+    void parenthesizedGroupingRejected() {
+        assertThrows(UnsupportedQueryException.class, () -> QueryToSqlListener.translate("(a:1 || b:2) && c:3"));
+    }
+
+    @Test
+    void notRejected() {
+        assertThrows(UnsupportedQueryException.class, () -> QueryToSqlListener.translate("!!a:1"));
+    }
+
+    @Test
+    void regexRejected() {
+        assertThrows(UnsupportedQueryException.class, () -> QueryToSqlListener.translate("name:*acme*"));
+    }
+
+    @Test
+    void ontologyEdgeFunctionsRejected() {
+        assertThrows(UnsupportedQueryException.class, () -> QueryToSqlListener.translate("hasEdge(assignedTo, t1)"));
+        assertThrows(UnsupportedQueryException.class, () -> QueryToSqlListener.translate("expand(orders)"));
+    }
+
+    @Test
+    void parseErrorFailsClosed() {
+        assertThrows(UnsupportedQueryException.class, () -> QueryToSqlListener.translate("this is not && a valid ::: query"));
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
@@ -1907,6 +1907,118 @@ public class RuleContext {
     }
 
     /**
+     * Store-agnostic governance seam for the federated query gateway (data-virtualization).
+     *
+     * <p>{@link #getFilters} returns Morphia {@link Filter}s keyed on a Java model class — a
+     * federated SQL/REST source has no Java model. This method instead composes the governed
+     * predicate as a <b>BIAPIQuery grammar STRING</b> ({@code (userQuery) && (matched rule
+     * filters)}) that a non-Mongo executor can translate into its own dialect (e.g. via
+     * {@code QueryToSqlListener}). It mirrors {@code getFilters}' rule matching and AND/OR
+     * composition, with variables ({@code ${pTenantId}} …) substituted to concrete values.</p>
+     *
+     * <p><b>Deliberate governance difference — this FAILS CLOSED.</b> {@code getFilters} SKIPS a
+     * matched allow-filter rule whose variables cannot be resolved (correct for typed queries,
+     * where the rule genuinely doesn't apply to that model class). A federated query has no model
+     * class, so silently dropping a security filter would leak rows. Here, an unresolved variable
+     * in a matched filter rule — or a non-ALLOW effect, or a composed string that fails to parse —
+     * throws instead. Only scalar variables from the standard/custom bundle are substitutable;
+     * collection-typed resolver variables (which {@code QueryToFilterListener} expands internally)
+     * are not, and correctly trip the fail-closed guard.</p>
+     *
+     * <p>Every clause is parenthesized so a top-level {@code ||} in {@code userQuery} cannot escape
+     * the policy {@code &&} (which would be a governance leak). The empty result means ALLOW with no
+     * row filter and no user query — the caller may read the source unfiltered.</p>
+     *
+     * @param userQuery optional caller-supplied BIAPIQuery filter (null/blank = none)
+     * @param pcontext  principal context
+     * @param rcontext  resource context {@code (area, functionalDomain, action)} of the view
+     * @return the composed governed BIAPIQuery string, or empty if there is nothing to constrain
+     * @throws SecurityException if access is not ALLOW or a matched filter rule cannot be fully
+     *                           resolved to concrete values
+     */
+    public java.util.Optional<String> getGovernedFilterString(
+            String userQuery,
+            @Valid @NotNull(message = "Principal Context can not be null") PrincipalContext pcontext,
+            @Valid @NotNull(message = "Resource Context can not be null") ResourceContext rcontext) {
+
+        SecurityCheckResponse response = this.checkRules(pcontext, rcontext);
+        if (response.getFinalEffect() != RuleEffect.ALLOW) {
+            throw new SecurityException("Federated query denied by policy for resource "
+                    + rcontext.getArea() + "/" + rcontext.getFunctionalDomain() + "/" + rcontext.getAction()
+                    + " (effect=" + response.getFinalEffect() + ")");
+        }
+
+        // The same matched allow-filter rule set getFilters() composes from.
+        List<SecurityCheckResponse.RuleFilterInfo> filterInfos = collectMatchedAllowFilterRules(response);
+        if (response.getFilterConstraints() != null) {
+            for (SecurityCheckResponse.RuleFilterInfo info : response.getFilterConstraints()) {
+                if (info == null) {
+                    continue;
+                }
+                boolean alreadyPresent = filterInfos.stream().anyMatch(existing ->
+                        Objects.equals(existing.getRuleName(), info.getRuleName())
+                                && Objects.equals(existing.getAndFilterString(), info.getAndFilterString())
+                                && Objects.equals(existing.getOrFilterString(), info.getOrFilterString())
+                                && Objects.equals(existing.getJoinOp(), info.getJoinOp()));
+                if (!alreadyPresent) {
+                    filterInfos.add(info);
+                }
+            }
+        }
+
+        org.apache.commons.text.StringSubstitutor sub = new org.apache.commons.text.StringSubstitutor(
+                MorphiaUtils.buildVariableBundle(pcontext, rcontext, null).strings);
+
+        List<String> governedClauses = new ArrayList<>();
+        for (SecurityCheckResponse.RuleFilterInfo info : filterInfos) {
+            String andClause = resolveGovernedClause(info.getAndFilterString(), sub, info.getRuleName());
+            String orClause = resolveGovernedClause(info.getOrFilterString(), sub, info.getRuleName());
+            String clause;
+            if (andClause != null && orClause != null) {
+                String joinOp = (info.getJoinOp() != null && !info.getJoinOp().isBlank())
+                        ? info.getJoinOp() : "AND";
+                String glue = "OR".equalsIgnoreCase(joinOp) ? " || " : " && ";
+                clause = "(" + andClause + ")" + glue + "(" + orClause + ")";
+            } else if (andClause != null) {
+                clause = andClause;
+            } else if (orClause != null) {
+                clause = orClause;
+            } else {
+                continue;
+            }
+            governedClauses.add("(" + clause + ")");
+        }
+
+        List<String> all = new ArrayList<>();
+        if (userQuery != null && !userQuery.isBlank()) {
+            all.add("(" + userQuery.trim() + ")");
+        }
+        all.addAll(governedClauses);
+        if (all.isEmpty()) {
+            return java.util.Optional.empty();
+        }
+        String governed = String.join(" && ", all);
+
+        // Fail closed: the composed governed string must be a valid BIAPIQuery.
+        MorphiaUtils.validateQueryString(governed);
+        return java.util.Optional.of(governed);
+    }
+
+    private static String resolveGovernedClause(String filterString,
+            org.apache.commons.text.StringSubstitutor sub, String ruleName) {
+        if (filterString == null || filterString.isEmpty()) {
+            return null;
+        }
+        String resolved = sub.replace(filterString);
+        if (resolved.contains("${")) {
+            throw new SecurityException("Cannot lower security rule '" + ruleName
+                    + "' into a federated filter: unresolved variable(s) in \"" + filterString
+                    + "\". Federated queries fail closed rather than drop a security filter.");
+        }
+        return resolved;
+    }
+
+    /**
      * Get the list of filters that are applicable for the given principal and resource context.
      * @param ifilters
      * @param pcontext

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/security/GovernedFilterStringTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/security/GovernedFilterStringTest.java
@@ -1,0 +1,130 @@
+package com.e2eq.framework.security;
+
+import com.e2eq.framework.grammar.sql.QueryToSqlListener;
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import com.e2eq.framework.model.security.Rule;
+import com.e2eq.framework.model.securityrules.*;
+import com.e2eq.framework.security.runtime.RuleContext;
+import dev.morphia.query.filters.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests {@link RuleContext#getGovernedFilterString} — the store-agnostic governance seam that
+ * lowers matched policy rules into a BIAPIQuery grammar STRING for federated (SQL/REST) sources,
+ * end-to-end through {@link QueryToSqlListener}. Covers: user-query + policy composition, the
+ * fail-closed contract (unlike getFilters, an unresolvable variable throws), non-ALLOW denial,
+ * and parity with getFilters on the same matched rule set.
+ */
+public class GovernedFilterStringTest {
+
+    RuleContext ruleContext;
+    PrincipalContext principal;
+
+    /** Dummy model so the parity call to the Morphia-coupled getFilters() has a class to key on. */
+    static class LocationModel extends UnversionedBaseModel {
+        @Override public String bmFunctionalDomain() { return "locations"; }
+        @Override public String bmFunctionalArea() { return "location_hub"; }
+    }
+
+    private ResourceContext rc() {
+        return new ResourceContext.Builder()
+                .withArea("location_hub").withFunctionalDomain("locations").withAction("list")
+                .withResourceId("res-1").withOwnerId(principal.getUserId()).build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        ruleContext = new RuleContext();
+        ruleContext.clear();
+        // orgRefName="acme" so ${orgRefName} resolves to a clean string token.
+        DataDomain dd = new DataDomain("acme", "0000000001", "acmeTenant", 0, "user@test.com");
+        principal = new PrincipalContext.Builder()
+                .withDefaultRealm("test-realm").withDataDomain(dd)
+                .withUserId("user@test.com").withRoles(new String[]{"user"}).build();
+    }
+
+    @Test
+    void composesUserQueryWithTenantRule_andTranslatesToGovernedSql() {
+        ruleContext.addRule(header(), createRule("org-scope", "org:${orgRefName}", null, RuleEffect.ALLOW, 10));
+
+        Optional<String> governed = ruleContext.getGovernedFilterString("status:active", principal, rc());
+        assertTrue(governed.isPresent());
+        assertEquals("(status:active) && (org:acme)", governed.get());
+
+        // End-to-end: the governed grammar string translates to governed SQL with BOTH predicates.
+        QueryToSqlListener.SqlWhere w = QueryToSqlListener.translate(governed.get());
+        assertTrue(w.whereClause.contains("org = ?"), "governed SQL must carry the policy predicate: " + w.whereClause);
+        assertTrue(w.whereClause.contains("status = ?"), "governed SQL must carry the user predicate: " + w.whereClause);
+        assertTrue(w.params.contains("acme") && w.params.contains("active"), "params: " + w.params);
+    }
+
+    @Test
+    void policyOnly_whenNoUserQuery() {
+        ruleContext.addRule(header(), createRule("org-scope", "org:${orgRefName}", null, RuleEffect.ALLOW, 10));
+        Optional<String> governed = ruleContext.getGovernedFilterString(null, principal, rc());
+        assertEquals("(org:acme)", governed.orElseThrow());
+    }
+
+    @Test
+    void userOrCannotEscapePolicyAnd() {
+        // The governance-critical shape: a user OR must be gated by the policy AND across BOTH branches.
+        ruleContext.addRule(header(), createRule("org-scope", "org:${orgRefName}", null, RuleEffect.ALLOW, 10));
+        String governed = ruleContext.getGovernedFilterString("a:1 || b:2", principal, rc()).orElseThrow();
+        assertEquals("(a:1 || b:2) && (org:acme)", governed);
+
+        QueryToSqlListener.SqlWhere w = QueryToSqlListener.translate(governed);
+        // org must AND with the WHOLE (b OR a) group, never a single branch.
+        assertEquals("(org = ? AND (b = ? OR a = ?))", w.whereClause);
+    }
+
+    @Test
+    void failsClosed_onUnresolvableVariable() {
+        // getFilters() SKIPS this rule; the federated seam must NOT — dropping a policy filter leaks rows.
+        ruleContext.addRule(header(), createRule("bad-var", "id:^[${unknownVariable}]", null, RuleEffect.ALLOW, 10));
+        assertThrows(SecurityException.class,
+                () -> ruleContext.getGovernedFilterString("status:active", principal, rc()));
+    }
+
+    @Test
+    void failsClosed_whenNotAllowed() {
+        ruleContext.addRule(header(), createRule("deny", "org:${orgRefName}", null, RuleEffect.DENY, 10));
+        assertThrows(SecurityException.class,
+                () -> ruleContext.getGovernedFilterString("status:active", principal, rc()));
+    }
+
+    @Test
+    void parityWithGetFilters_sameMatchedRuleSet() {
+        ruleContext.addRule(header(), createRule("org-scope", "org:${orgRefName}", null, RuleEffect.ALLOW, 10));
+        // getFilters sees exactly one matched policy filter for this resource...
+        List<Filter> filters = ruleContext.getFilters(new ArrayList<>(), principal, rc(), LocationModel.class);
+        assertEquals(1, filters.size());
+        // ...and the governed string carries that same single policy predicate.
+        String governed = ruleContext.getGovernedFilterString(null, principal, rc()).orElseThrow();
+        assertEquals("(org:acme)", governed);
+    }
+
+    // --- helpers -----------------------------------------------------------------
+
+    private SecurityURIHeader header() {
+        return new SecurityURIHeader("user", "location_hub", "locations", "list");
+    }
+
+    private Rule createRule(String name, String andFilterString, String orFilterString,
+                            RuleEffect effect, int priority) {
+        SecurityURIBody body = new SecurityURIBody.Builder()
+                .withOrgRefName("*").withAccountNumber("*").withRealm("*").withTenantId("*")
+                .withOwnerId("*").withDataSegment("*").withResourceId("*").build();
+        SecurityURI uri = new SecurityURI(header(), body);
+        return new Rule.Builder()
+                .withName(name).withSecurityURI(uri).withEffect(effect).withPriority(priority)
+                .withAndFilterString(andFilterString).withOrFilterString(orFilterString).build();
+    }
+}

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/AnnotationOntologyLoader.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/AnnotationOntologyLoader.java
@@ -181,6 +181,24 @@ public final class AnnotationOntologyLoader {
         return clazz.getSimpleName();
     }
 
+    /**
+     * Build an ontology-class-id → Java class index over the given packages by scanning for
+     * {@link OntologyClass}-annotated types (same discovery used to build the TBox). Callers that
+     * need the concrete model class behind an ontology id — e.g. to read a type-level annotation
+     * such as {@code @FunctionalMapping} — use this instead of the resource-free {@code TBox}.
+     * The first class wins on id collision.
+     */
+    public Map<String, Class<?>> classIndex(Collection<String> packageNames) {
+        Map<String, Class<?>> index = new LinkedHashMap<>();
+        for (String pkg : packageNames) {
+            if (pkg == null || pkg.isBlank()) continue;
+            for (Class<?> c : findClassesWithAnnotation(pkg.trim(), OntologyClass.class)) {
+                index.putIfAbsent(classIdOf(c), c);
+            }
+        }
+        return index;
+    }
+
     private String derivedNameFromMethod(String methodName) {
         if (methodName.startsWith("get") && methodName.length() > 3) {
             String base = methodName.substring(3);

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/AnnotationOntologyLoader.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/AnnotationOntologyLoader.java
@@ -53,7 +53,11 @@ public final class AnnotationOntologyLoader {
                 if (annotatedClasses.contains(p)) parents.add(classIdOf(p));
                 p = p.getSuperclass();
             }
-            classes.put(id, new OntologyRegistry.ClassDef(id, parents, Set.of(), Set.of()));
+            // Carry row-governance (functionalArea/domain from @FunctionalMapping) into the TBox so a
+            // Java-backed class exposes the SAME governance metadata an admitted ontology-only class
+            // does — one governance vocabulary for OntologyResourceResolver (ontology-federation Phase 3).
+            Map<String, Object> metadata = functionalMetadataOf(c);
+            classes.put(id, new OntologyRegistry.ClassDef(id, parents, Set.of(), Set.of(), null, Set.of(), metadata));
         }
 
         // Build property defs from fields and methods on annotated classes
@@ -173,6 +177,33 @@ public final class AnnotationOntologyLoader {
 
     private boolean isCollectionOrArray(Class<?> t) {
         return t.isArray() || Collection.class.isAssignableFrom(t);
+    }
+
+    /**
+     * Reflectively read {@code @FunctionalMapping(area, domain)} (framework annotation, not a
+     * compile dependency of ontology-core) from the class or a superclass into TBox metadata keyed
+     * {@code functionalArea}/{@code functionalDomain}. Empty map when absent.
+     */
+    private Map<String, Object> functionalMetadataOf(Class<?> c) {
+        try {
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            Class<? extends java.lang.annotation.Annotation> fmType =
+                    (Class) Class.forName("com.e2eq.framework.annotations.FunctionalMapping");
+            for (Class<?> k = c; k != null && k != Object.class; k = k.getSuperclass()) {
+                java.lang.annotation.Annotation fm = k.getAnnotation(fmType);
+                if (fm != null) {
+                    String area = (String) fmType.getMethod("area").invoke(fm);
+                    String domain = (String) fmType.getMethod("domain").invoke(fm);
+                    Map<String, Object> md = new LinkedHashMap<>();
+                    if (area != null && !area.isBlank()) md.put("functionalArea", area);
+                    if (domain != null && !domain.isBlank()) md.put("functionalDomain", domain);
+                    return md.isEmpty() ? Map.of() : md;
+                }
+            }
+        } catch (Throwable ignore) {
+            // FunctionalMapping not on classpath, or reflection failed → no governance metadata.
+        }
+        return Map.of();
     }
 
     private String classIdOf(Class<?> clazz) {

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/OntologyReferenceCloser.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/OntologyReferenceCloser.java
@@ -1,0 +1,67 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.PropertyDef;
+import com.e2eq.ontology.core.OntologyRegistry.TBox;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Closes dangling <em>class</em> references in a TBox so a module can declare object properties
+ * whose domain/range is a class OWNED BY ANOTHER MODULE (a federated, cross-module reference)
+ * without the whole TBox being rejected.
+ *
+ * <p>In a federated ontology each service publishes only the classes it owns, yet its properties
+ * may legitimately point at classes another service declares — e.g.
+ * {@code ApplicationPackVersion.usesOntology -> Ontology}, where {@code Ontology} is owned by a
+ * different pack. {@link OntologyValidator} enforces LOCAL referential integrity and treats such a
+ * dangling domain/range as fatal. That is correct for a hand-authored, self-contained TBox (and for
+ * direct admission, which stays strict), but wrong for a <em>source build</em> assembled from
+ * annotations/Morphia/YAML: there a single external edge would otherwise abort the merge and discard
+ * every real class the module does own.</p>
+ *
+ * <p>This step materializes each referenced-but-undeclared domain/range class as an EMPTY stub
+ * (tagged {@code external=true} in metadata for local provenance). Stubs carry no structure, so when
+ * the OWNING module later federates its real definition, {@link OntologyMerger}'s union semantics fold
+ * the two together with no conflict. Property-to-property references (inverseOf, subPropertyOf, chain
+ * members) are intentionally NOT closed here — those are local integrity constraints that must still
+ * fail loudly rather than be papered over.</p>
+ */
+public final class OntologyReferenceCloser {
+
+    /** Metadata key marking a class that was materialized only to satisfy an external reference. */
+    public static final String EXTERNAL_METADATA_KEY = "external";
+
+    private OntologyReferenceCloser() {}
+
+    /**
+     * Return a TBox identical to {@code tbox} except that every class referenced by a property's
+     * domain or range — but not declared in {@code tbox} — is added as an empty external stub. If
+     * no references are dangling, {@code tbox} is returned unchanged.
+     */
+    public static TBox closeClassReferences(TBox tbox) {
+        if (tbox == null) {
+            return null;
+        }
+        Map<String, ClassDef> classes = new LinkedHashMap<>(tbox.classes());
+        int before = classes.size();
+        for (PropertyDef p : tbox.properties().values()) {
+            addStubIfMissing(classes, p.domain().orElse(null));
+            addStubIfMissing(classes, p.range().orElse(null));
+        }
+        if (classes.size() == before) {
+            return tbox;
+        }
+        return new TBox(classes, tbox.properties(), tbox.propertyChains());
+    }
+
+    private static void addStubIfMissing(Map<String, ClassDef> classes, String classId) {
+        if (classId == null || classId.isBlank() || classes.containsKey(classId)) {
+            return;
+        }
+        classes.put(classId, new ClassDef(classId, Set.of(), Set.of(), Set.of(),
+                classId, Set.of(), Map.of(EXTERNAL_METADATA_KEY, Boolean.TRUE)));
+    }
+}

--- a/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/OntologyReferenceCloserTest.java
+++ b/quantum-ontology-core/src/test/java/com/e2eq/ontology/core/OntologyReferenceCloserTest.java
@@ -1,0 +1,95 @@
+package com.e2eq.ontology.core;
+
+import com.e2eq.ontology.core.OntologyRegistry.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OntologyReferenceCloserTest {
+
+    private static PropertyDef prop(String name, String domain, String range) {
+        return new PropertyDef(name, Optional.ofNullable(domain), Optional.ofNullable(range),
+                false, Optional.empty(), false, false, false, Set.of(), false);
+    }
+
+    @Test
+    void materializesStubForCrossModuleRange() {
+        // ApplicationPackVersion.usesOntology -> Ontology, where Ontology is owned by another pack
+        // and is therefore not declared in this (annotation-scanned) TBox.
+        Map<String, ClassDef> classes = Map.of(
+                "ApplicationPackVersion", new ClassDef("ApplicationPackVersion", Set.of(), Set.of(), Set.of()));
+        Map<String, PropertyDef> props = Map.of(
+                "usesOntology", prop("usesOntology", "ApplicationPackVersion", "Ontology"));
+        TBox in = new TBox(classes, props, List.of());
+
+        TBox out = OntologyReferenceCloser.closeClassReferences(in);
+
+        assertTrue(out.classes().containsKey("Ontology"), "external range class should be stubbed");
+        assertTrue(out.classes().containsKey("ApplicationPackVersion"), "real class must survive");
+        assertEquals(Boolean.TRUE,
+                out.classes().get("Ontology").metadata().get(OntologyReferenceCloser.EXTERNAL_METADATA_KEY),
+                "stub must be tagged external for provenance");
+    }
+
+    @Test
+    void closesDanglingDomainToo() {
+        TBox in = new TBox(Map.of(), Map.of("p", prop("p", "MissingDomain", null)), List.of());
+        TBox out = OntologyReferenceCloser.closeClassReferences(in);
+        assertTrue(out.classes().containsKey("MissingDomain"));
+    }
+
+    @Test
+    void returnsSameInstanceWhenNothingDangling() {
+        Map<String, ClassDef> classes = Map.of(
+                "Person", new ClassDef("Person", Set.of(), Set.of(), Set.of()));
+        Map<String, PropertyDef> props = Map.of("knows", prop("knows", "Person", "Person"));
+        TBox in = new TBox(classes, props, List.of());
+
+        assertSame(in, OntologyReferenceCloser.closeClassReferences(in),
+                "no dangling refs -> unchanged, no needless copy");
+    }
+
+    @Test
+    void closedTBoxPassesMergeValidationThatWouldOtherwiseThrow() {
+        Map<String, ClassDef> classes = Map.of(
+                "ApplicationPackVersion", new ClassDef("ApplicationPackVersion", Set.of(), Set.of(), Set.of()));
+        Map<String, PropertyDef> props = Map.of(
+                "usesOntology", prop("usesOntology", "ApplicationPackVersion", "Ontology"),
+                "usesSeedPack", prop("usesSeedPack", "ApplicationPackVersion", "SeedPack"));
+        TBox raw = new TBox(classes, props, List.of());
+
+        // Reproduces the defect: merging the raw (dangling) TBox invokes OntologyValidator and throws.
+        TBox empty = new TBox(Map.of(), Map.of(), List.of());
+        assertThrows(IllegalArgumentException.class, () -> OntologyMerger.merge(empty, raw));
+
+        // Closing references first makes the merge validate cleanly and keep the real class.
+        TBox closed = OntologyReferenceCloser.closeClassReferences(raw);
+        TBox merged = assertDoesNotThrow(() -> OntologyMerger.merge(empty, closed));
+        assertTrue(merged.classes().containsKey("ApplicationPackVersion"));
+        assertTrue(merged.classes().containsKey("Ontology"));
+        assertTrue(merged.classes().containsKey("SeedPack"));
+    }
+
+    @Test
+    void doesNotClosePropertyToPropertyReferences() {
+        // inverseOf targets a PROPERTY, not a class: this is a local integrity constraint that must
+        // stay strict. The closer must not silence it.
+        Map<String, ClassDef> classes = Map.of(
+                "Person", new ClassDef("Person", Set.of(), Set.of(), Set.of()));
+        PropertyDef withBadInverse = new PropertyDef("knows", Optional.of("Person"), Optional.of("Person"),
+                true, Optional.of("missingInverseProp"), false, false, false, Set.of(), false);
+        TBox in = new TBox(classes, Map.of("knows", withBadInverse), List.of());
+
+        TBox out = OntologyReferenceCloser.closeClassReferences(in);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OntologyValidator.validate(out));
+        assertTrue(ex.getMessage().contains("Unknown property 'missingInverseProp'"));
+    }
+
+    @Test
+    void nullInputReturnsNull() {
+        assertNull(OntologyReferenceCloser.closeClassReferences(null));
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/OntologyTBox.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/OntologyTBox.java
@@ -55,12 +55,13 @@ public class OntologyTBox extends UnversionedBaseModel {
     }
     
     public TBox toTBox() {
-        Map<String, ClassDef> classDefs = classes != null ? 
+        Map<String, ClassDef> classDefs = classes != null ?
             classes.entrySet().stream()
                 .collect(java.util.stream.Collectors.toMap(
                     Map.Entry::getKey,
-                    e -> new ClassDef(e.getValue().name, e.getValue().parents, 
-                                     e.getValue().disjointWith, e.getValue().sameAs)
+                    e -> new ClassDef(e.getValue().name, e.getValue().parents,
+                                     e.getValue().disjointWith, e.getValue().sameAs,
+                                     e.getValue().label, e.getValue().aliases, e.getValue().metadata)
                 )) : Map.of();
         
         Map<String, PropertyDef> propDefs = properties != null ?
@@ -131,12 +132,20 @@ public class OntologyTBox extends UnversionedBaseModel {
         private Set<String> parents;
         private Set<String> disjointWith;
         private Set<String> sameAs;
-        
+        // Presentation + governance metadata — MUST round-trip so governance (functionalArea/
+        // domain/defaultReadAction) survives persistence and reaches OntologyResourceResolver.
+        private String label;
+        private Set<String> aliases;
+        private Map<String, Object> metadata;
+
         public ClassDefData(ClassDef def) {
             this.name = def.name();
             this.parents = def.parents();
             this.disjointWith = def.disjointWith();
             this.sameAs = def.sameAs();
+            this.label = def.label();
+            this.aliases = def.aliases();
+            this.metadata = def.metadata();
         }
     }
     

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/OntologyTBox.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/OntologyTBox.java
@@ -77,7 +77,11 @@ public class OntologyTBox extends UnversionedBaseModel {
                         e.getValue().transitive,
                         e.getValue().symmetric,
                         e.getValue().functional,
-                        e.getValue().subPropertyOf != null ? e.getValue().subPropertyOf : Set.of()
+                        e.getValue().subPropertyOf != null ? e.getValue().subPropertyOf : Set.of(),
+                        e.getValue().inferred,
+                        e.getValue().label,
+                        e.getValue().aliases,
+                        e.getValue().metadata
                     )
                 )) : Map.of();
         
@@ -161,7 +165,12 @@ public class OntologyTBox extends UnversionedBaseModel {
         private boolean symmetric;
         private boolean functional;
         private Set<String> subPropertyOf;
-        
+        // Round-trip inferred + presentation/governance metadata (e.g. a relation's join-key).
+        private boolean inferred;
+        private String label;
+        private Set<String> aliases;
+        private Map<String, Object> metadata;
+
         public PropertyDefData(PropertyDef def) {
             this.name = def.name();
             this.domain = def.domain().orElse(null);
@@ -172,6 +181,10 @@ public class OntologyTBox extends UnversionedBaseModel {
             this.symmetric = def.symmetric();
             this.functional = def.functional();
             this.subPropertyOf = def.subPropertyOf();
+            this.inferred = def.inferred();
+            this.label = def.label();
+            this.aliases = def.aliases();
+            this.metadata = def.metadata();
         }
     }
     

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
@@ -97,8 +97,9 @@ public class TenantOntologyTBox extends UnversionedBaseModel {
             classes.entrySet().stream()
                 .collect(java.util.stream.Collectors.toMap(
                     Map.Entry::getKey,
-                    e -> new ClassDef(e.getValue().name, e.getValue().parents, 
-                                     e.getValue().disjointWith, e.getValue().sameAs)
+                    e -> new ClassDef(e.getValue().name, e.getValue().parents,
+                                     e.getValue().disjointWith, e.getValue().sameAs,
+                                     e.getValue().label, e.getValue().aliases, e.getValue().metadata)
                 )) : Map.of();
         
         Map<String, PropertyDef> propDefs = properties != null ?
@@ -169,12 +170,20 @@ public class TenantOntologyTBox extends UnversionedBaseModel {
         private Set<String> parents;
         private Set<String> disjointWith;
         private Set<String> sameAs;
-        
+        // Presentation + governance metadata — MUST round-trip so an admitted class's governance
+        // (functionalArea/domain/defaultReadAction) survives activation and reaches the resolver.
+        private String label;
+        private Set<String> aliases;
+        private Map<String, Object> metadata;
+
         public ClassDefData(ClassDef def) {
             this.name = def.name();
             this.parents = def.parents();
             this.disjointWith = def.disjointWith();
             this.sameAs = def.sameAs();
+            this.label = def.label();
+            this.aliases = def.aliases();
+            this.metadata = def.metadata();
         }
     }
     

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/model/TenantOntologyTBox.java
@@ -115,7 +115,11 @@ public class TenantOntologyTBox extends UnversionedBaseModel {
                         e.getValue().transitive,
                         e.getValue().symmetric,
                         e.getValue().functional,
-                        e.getValue().subPropertyOf != null ? e.getValue().subPropertyOf : Set.of()
+                        e.getValue().subPropertyOf != null ? e.getValue().subPropertyOf : Set.of(),
+                        e.getValue().inferred,
+                        e.getValue().label,
+                        e.getValue().aliases,
+                        e.getValue().metadata
                     )
                 )) : Map.of();
         
@@ -199,7 +203,12 @@ public class TenantOntologyTBox extends UnversionedBaseModel {
         private boolean symmetric;
         private boolean functional;
         private Set<String> subPropertyOf;
-        
+        // Round-trip inferred + presentation/governance metadata (e.g. a relation's join-key).
+        private boolean inferred;
+        private String label;
+        private Set<String> aliases;
+        private Map<String, Object> metadata;
+
         public PropertyDefData(PropertyDef def) {
             this.name = def.name();
             this.domain = def.domain().orElse(null);
@@ -210,6 +219,10 @@ public class TenantOntologyTBox extends UnversionedBaseModel {
             this.symmetric = def.symmetric();
             this.functional = def.functional();
             this.subPropertyOf = def.subPropertyOf();
+            this.inferred = def.inferred();
+            this.label = def.label();
+            this.aliases = def.aliases();
+            this.metadata = def.metadata();
         }
     }
     

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/OntologyTBoxPublisher.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/OntologyTBoxPublisher.java
@@ -96,7 +96,11 @@ public class OntologyTBoxPublisher {
             return;
         }
         try {
-            OntologyRegistry registry = registryProvider.getRegistryForRealm(realm);
+            // Build purely from sources (annotations + Morphia + YAML), bypassing the
+            // activation-preferring read path: once we activate a published TBox, a plain
+            // getRegistryForRealm would re-read THAT (possibly empty) active copy instead of
+            // the module's source annotations, so the federated TBox would never carry content.
+            OntologyRegistry registry = registryProvider.buildSourceRegistry(realm);
             publish(realm, registry, serviceBaseUrl.get());
         }
         catch (Exception e) {
@@ -109,6 +113,12 @@ public class OntologyTBoxPublisher {
      * Package-visible for testing.
      */
     void publish(String realm, OntologyRegistry registry, String baseUrl) throws Exception {
+        if (registry.classes().isEmpty() && registry.properties().isEmpty()) {
+            // Never clobber the central realm's TBox with an empty one — an empty source
+            // registry means there is nothing to federate (mis-scan or no annotations).
+            Log.warnf("Realm %s: source TBox is empty (0 classes, 0 properties); skipping publish.", realm);
+            return;
+        }
         String base = baseUrl.replaceAll("/+$", "") + "/v1/ontology/" + realm;
         String payload = objectMapper.writeValueAsString(buildSubmitBody(registry));
 

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
@@ -569,6 +569,11 @@ public class TenantOntologyRegistryProvider {
                 if (!pkgs.isEmpty()) {
                     AnnotationOntologyLoader annoLoader = new AnnotationOntologyLoader();
                     TBox annoTBox = annoLoader.loadFromPackages(pkgs);
+                    // Close cross-module class references (e.g. a property whose range is a class
+                    // OWNED BY ANOTHER pack) to empty external stubs, so a single federated edge does
+                    // not make the strict validator reject — and thereby discard — every real class
+                    // this module declares. See OntologyReferenceCloser.
+                    annoTBox = OntologyReferenceCloser.closeClassReferences(annoTBox);
                     accumulated = OntologyMerger.merge(accumulated, annoTBox);
                     Log.debugf("Realm %s: Loaded %d classes from annotations", realm, annoTBox.classes().size());
                 }
@@ -583,6 +588,7 @@ public class TenantOntologyRegistryProvider {
             if (ds != null && ds.getMapper() != null) {
                 MorphiaOntologyLoader loader = new MorphiaOntologyLoader(ds);
                 TBox base = loader.loadTBox();
+                base = OntologyReferenceCloser.closeClassReferences(base);
                 accumulated = OntologyMerger.merge(accumulated, base);
                 Log.debugf("Realm %s: Loaded %d classes from Morphia", realm, base.classes().size());
             }
@@ -604,6 +610,7 @@ public class TenantOntologyRegistryProvider {
                 try { overlay = yaml.loadFromClasspath("/ontology.yaml"); } catch (Exception ignored) { }
             }
             if (overlay != null) {
+                overlay = OntologyReferenceCloser.closeClassReferences(overlay);
                 accumulated = OntologyMerger.merge(accumulated, overlay);
             }
             var result = metaService.observeYaml(yamlPath, "/ontology.yaml");

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/runtime/TenantOntologyRegistryProvider.java
@@ -3,6 +3,8 @@ package com.e2eq.ontology.runtime;
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.morphia.MorphiaDataStoreWrapper;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.security.runtime.RuleContext;
 import com.e2eq.ontology.core.*;
@@ -629,29 +631,88 @@ public class TenantOntologyRegistryProvider {
 
         // 5. Persist TBox if persistence is enabled
         if (persistTBox) {
-            try {
-                String tboxHash = TBoxHasher.computeHash(accumulated);
-                String source = yamlPath.map(Path::toString).orElse("/ontology.yaml");
-                
-                // Check if this TBox already exists
-                Optional<OntologyTBox> existing = tboxRepo.findByHash(tboxHash);
-                if (existing.isEmpty()) {
-                    OntologyTBox newTBox = new OntologyTBox(accumulated, tboxHash, currentHash, source);
-                    tboxRepo.save(newTBox);
-                    Log.infof("Persisted new TBox for realm %s (hash: %s, yamlHash: %s)", 
-                            realm, tboxHash, currentHash);
-                } else {
-                    Log.debugf("TBox already persisted for realm %s (hash: %s)", realm, tboxHash);
-                }
-            } catch (Throwable t) {
-                Log.warnf("Failed to persist TBox for realm %s: %s", realm, t.getMessage());
-            }
+            persistBuiltTBox(realm, accumulated, currentHash, yamlPath);
         }
 
-        Log.infof("Built ontology registry for realm %s: %d classes, %d properties", 
+        Log.infof("Built ontology registry for realm %s: %d classes, %d properties",
                 realm, accumulated.classes().size(), accumulated.properties().size());
 
         return new YamlBackedOntologyRegistry(accumulated, currentHash, needsReindex);
+    }
+
+    /**
+     * Persist the freshly built <em>source</em> TBox for {@code realm}, best-effort — so a
+     * later boot loads the persisted {@link OntologyTBox} instead of re-scanning annotations,
+     * Morphia, and YAML every time.
+     * <p>
+     * The Morphia save path resolves the target realm (and, via the audit interceptor, the
+     * acting identity) from the ambient {@link SecurityContext}, falling back to the
+     * request-scoped {@link io.quarkus.security.identity.SecurityIdentity} proxy when no
+     * context is set. That fallback is fatal when {@code buildRegistryForRealm} runs OUTSIDE a
+     * request/security context — e.g. the {@code OntologyStartupInitializer} daemon thread that
+     * publishes the TBox at boot ({@code "ontology-tbox-publisher"}), or a {@code @PostConstruct}
+     * startup path: dereferencing the proxy throws
+     * "RequestScoped context was not active …", the persist is skipped, and every subsequent
+     * rebuild re-scans. To make persistence work from any thread we run the save under a
+     * realm-scoped SYSTEM security context when — and only when — none is already active, so the
+     * realm resolves WITHOUT touching the request-scoped proxy. Request-scoped callers keep their
+     * existing context and behave exactly as before.
+     * <p>
+     * Best-effort by contract: any failure is caught and logged; startup is never broken.
+     */
+    private void persistBuiltTBox(String realm, TBox accumulated, String currentHash, Optional<Path> yamlPath) {
+        boolean contextActive = SecurityContext.getPrincipalContext().isPresent()
+                && SecurityContext.getResourceContext().isPresent();
+        if (contextActive) {
+            // Normal request path: an ambient security context already resolves the realm/identity.
+            doPersistBuiltTBox(realm, accumulated, currentHash, yamlPath);
+            return;
+        }
+        // Background/startup thread: no ambient context, so the repo would dereference the
+        // request-scoped SecurityIdentity proxy and fail. Establish a realm-scoped SYSTEM context
+        // (realmDataDomain is the SAME principal-independent key the read/admission paths use) so
+        // the persist resolves the realm without the proxy and lands in the correct realm database.
+        //
+        // Rules are bypassed for THIS branch only: there is no authenticated user to authorize the
+        // write — the system is persisting its OWN source-derived TBox as a bootstrap step — and a
+        // synthetic SYSTEM principal has no ONTOLOGY/TBOX write grant in every realm. The normal
+        // request path (contextActive above) keeps full permission enforcement, so a user-triggered
+        // rebuild still requires write permission; only genuine no-context system/startup threads
+        // (which never originate from an external caller) take this privileged path.
+        PrincipalContext principal = SecurityCallScope.service(
+                realm, realmDataDomain(realm), "ontology-tbox-publisher");
+        ResourceContext resource = SecurityCallScope.writeResource(principal, realm, "ONTOLOGY", "TBOX");
+        try (SecurityCallScope.Scope ctx = SecurityCallScope.open(principal, resource);
+             SecurityCallScope.Scope ignoreRules = SecurityCallScope.openIgnoringRules()) {
+            doPersistBuiltTBox(realm, accumulated, currentHash, yamlPath);
+        } catch (Throwable t) {
+            // Never break startup: a context-establishment failure is logged and swallowed.
+            Log.warnf("Failed to persist TBox for realm %s under system context: %s", realm, t.getMessage());
+        }
+    }
+
+    /**
+     * The actual persist: idempotent by canonical TBox hash. Assumes an active security context
+     * (see {@link #persistBuiltTBox}). Fully guarded so a persistence failure never propagates.
+     */
+    private void doPersistBuiltTBox(String realm, TBox accumulated, String currentHash, Optional<Path> yamlPath) {
+        try {
+            String tboxHash = TBoxHasher.computeHash(accumulated);
+            String source = yamlPath.map(Path::toString).orElse("/ontology.yaml");
+
+            // Check if this TBox already exists
+            Optional<OntologyTBox> existing = tboxRepo.findByHash(tboxHash);
+            if (existing.isEmpty()) {
+                OntologyTBox newTBox = new OntologyTBox(accumulated, tboxHash, currentHash, source);
+                tboxRepo.save(newTBox);
+                Log.infof("Persisted new TBox for realm %s (hash: %s, yamlHash: %s)",
+                        realm, tboxHash, currentHash);
+            } else {
+                Log.debugf("TBox already persisted for realm %s (hash: %s)", realm, tboxHash);
+            }
+        } catch (Throwable t) {
+            Log.warnf("Failed to persist TBox for realm %s: %s", realm, t.getMessage());
+        }
     }
 
     /**

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/model/TBoxMetadataRoundTripTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/model/TBoxMetadataRoundTripTest.java
@@ -1,0 +1,50 @@
+package com.e2eq.ontology.model;
+
+import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.TBox;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the persistence round-trip of class-level presentation + governance metadata through
+ * both persisted TBox entities. Without this, {@code toTBox()} rebuilt ClassDefs with the 4-arg
+ * constructor and silently dropped {@code label}/{@code aliases}/{@code metadata} — so an admitted
+ * class's {@code functionalArea}/{@code functionalDomain} never reached OntologyResourceResolver
+ * (Phase 3 of ontology federation).
+ */
+class TBoxMetadataRoundTripTest {
+
+    private static TBox oneClassWithGovernance() {
+        ClassDef cd = new ClassDef("Customer", Set.of(), Set.of(), Set.of(),
+                "Customer", Set.of("Client"),
+                Map.of("functionalArea", "crm", "functionalDomain", "customer", "defaultReadAction", "view"));
+        return new TBox(Map.of("Customer", cd), Map.of(), List.of());
+    }
+
+    private static void assertGovernanceSurvives(TBox rt) {
+        ClassDef out = rt.classes().get("Customer");
+        assertNotNull(out, "Customer class must survive round-trip");
+        assertEquals("crm", out.metadata().get("functionalArea"));
+        assertEquals("customer", out.metadata().get("functionalDomain"));
+        assertEquals("view", out.metadata().get("defaultReadAction"));
+        assertEquals("Customer", out.label());
+        assertTrue(out.aliases().contains("Client"));
+    }
+
+    @Test
+    void ontologyTBox_roundTripsClassMetadata() {
+        OntologyTBox doc = new OntologyTBox(oneClassWithGovernance(), "h1", "y1", "test");
+        assertGovernanceSurvives(doc.toTBox());
+    }
+
+    @Test
+    void tenantOntologyTBox_roundTripsClassMetadata() {
+        TenantOntologyTBox doc = new TenantOntologyTBox(oneClassWithGovernance(), "h1", "y1", "test", "1.0");
+        assertGovernanceSurvives(doc.toTBox());
+    }
+}

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/model/TBoxMetadataRoundTripTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/model/TBoxMetadataRoundTripTest.java
@@ -1,11 +1,13 @@
 package com.e2eq.ontology.model;
 
 import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
+import com.e2eq.ontology.core.OntologyRegistry.PropertyDef;
 import com.e2eq.ontology.core.OntologyRegistry.TBox;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,7 +25,12 @@ class TBoxMetadataRoundTripTest {
         ClassDef cd = new ClassDef("Customer", Set.of(), Set.of(), Set.of(),
                 "Customer", Set.of("Client"),
                 Map.of("functionalArea", "crm", "functionalDomain", "customer", "defaultReadAction", "view"));
-        return new TBox(Map.of("Customer", cd), Map.of(), List.of());
+        // A relation carrying a join-key in its metadata (what Tier 2/3 reads).
+        PropertyDef pd = new PropertyDef("placedBy", Optional.of("Order"), Optional.of("Customer"),
+                false, Optional.of("places"), false, false, true, Set.of(), false,
+                "placed by", Set.of(),
+                Map.of("joinFromField", "customerId", "joinToField", "id"));
+        return new TBox(Map.of("Customer", cd), Map.of("placedBy", pd), List.of());
     }
 
     private static void assertGovernanceSurvives(TBox rt) {
@@ -34,6 +41,12 @@ class TBoxMetadataRoundTripTest {
         assertEquals("view", out.metadata().get("defaultReadAction"));
         assertEquals("Customer", out.label());
         assertTrue(out.aliases().contains("Client"));
+
+        PropertyDef pOut = rt.properties().get("placedBy");
+        assertNotNull(pOut, "placedBy property must survive round-trip");
+        assertEquals("customerId", pOut.metadata().get("joinFromField"));
+        assertEquals("id", pOut.metadata().get("joinToField"));
+        assertEquals("placed by", pOut.label());
     }
 
     @Test

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/TenantOntologyRegistryProviderPersistScopeTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/TenantOntologyRegistryProviderPersistScopeTest.java
@@ -1,0 +1,109 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import com.e2eq.ontology.core.OntologyRegistry;
+import com.e2eq.ontology.model.OntologyTBox;
+import com.e2eq.ontology.repo.OntologyTBoxRepo;
+import com.e2eq.ontology.runtime.TenantOntologyRegistryProvider;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression guard for the TBox persist-scope fix.
+ *
+ * <p>{@code buildRegistryForRealm} must persist the freshly built <em>source</em> TBox even when
+ * it is invoked from a thread with NO active CDI request/security context — i.e. the
+ * {@code OntologyStartupInitializer} {@code "ontology-tbox-publisher"} daemon thread that runs at
+ * boot, or a {@code @PostConstruct} startup path. Before the fix, the persist step dereferenced the
+ * request-scoped {@link io.quarkus.security.identity.SecurityIdentity} proxy while resolving the
+ * realm, which threw <em>"RequestScoped context was not active"</em>; the exception was swallowed
+ * (only warned), so the source TBox was never persisted and every subsequent rebuild re-scanned
+ * annotations/Morphia/YAML instead of loading the persisted {@link OntologyTBox}.</p>
+ *
+ * <p>This test reproduces the exact failing shape: it runs {@link TenantOntologyRegistryProvider#buildSourceRegistry(String)}
+ * on a plain {@code new Thread} (no inherited request context) and asserts the realm's
+ * {@code ontology_tbox} collection is populated afterwards. It FAILS against the pre-fix code (the
+ * background persist throws and is swallowed, leaving the collection empty) and PASSES once the
+ * persist runs under a realm-scoped SYSTEM {@link SecurityCallScope}.</p>
+ */
+@QuarkusTest
+@TestProfile(TenantOntologyRegistryProviderPersistScopeTest.PersistEnabledProfile.class)
+public class TenantOntologyRegistryProviderPersistScopeTest {
+
+    /**
+     * The shared test profile disables TBox persistence ({@code quantum.ontology.tbox.persist=false});
+     * this fix is specifically about the persist step, so enable it for this class.
+     */
+    public static class PersistEnabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quantum.ontology.tbox.persist", "true");
+        }
+    }
+
+    @Inject
+    TenantOntologyRegistryProvider provider;
+
+    @Inject
+    OntologyTBoxRepo tboxRepo;
+
+    @ConfigProperty(name = "quantum.realmConfig.defaultRealm")
+    String defaultRealm;
+
+    @Test
+    void persistsSourceTBoxFromNoContextBackgroundThread() throws Exception {
+        // Deterministically clear + read the realm's ontology_tbox collection under a realm-scoped
+        // SYSTEM context. This uses the SAME realm-deterministic DataDomain the fix uses to resolve
+        // the realm without the request-scoped proxy, so write and read target the same collection.
+        PrincipalContext principal = SecurityCallScope.service(
+                defaultRealm, TenantOntologyRegistryProvider.realmDataDomain(defaultRealm), "test-fixture");
+        ResourceContext resource = SecurityCallScope.writeResource(principal, defaultRealm, "ONTOLOGY", "TBOX");
+
+        SecurityCallScope.runWithContexts(principal, resource, () -> tboxRepo.deleteAll());
+
+        Optional<OntologyTBox> before =
+                SecurityCallScope.runWithContexts(principal, resource, () -> tboxRepo.findLatest());
+        assertTrue(before.isEmpty(), "precondition: no persisted TBox before the background build");
+
+        // Reproduce the startup publisher: build the source registry on a PLAIN thread that has no
+        // inherited CDI request/security context (SecurityContext thread-locals do not propagate to
+        // child threads, and no request scope is active on a bare new Thread).
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<OntologyRegistry> built = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                SecurityContext.clear(); // belt-and-suspenders: guarantee no ambient context here
+                built.set(provider.buildSourceRegistry(defaultRealm));
+            } catch (Throwable e) {
+                error.set(e);
+            }
+        }, "test-ontology-tbox-publisher");
+        t.start();
+        t.join(60_000);
+
+        assertFalse(t.isAlive(), "background build thread did not finish in time");
+        assertNull(error.get(), "build/persist from a no-context background thread must not throw");
+        assertNotNull(built.get(), "build must return a registry");
+
+        // The source TBox must now be persisted in the realm's ontology_tbox collection so a later
+        // boot loads it instead of re-scanning. This is the assertion that fails pre-fix.
+        Optional<OntologyTBox> after =
+                SecurityCallScope.runWithContexts(principal, resource, () -> tboxRepo.findLatest());
+        assertTrue(after.isPresent(),
+                "source TBox must be persisted after a background-thread build "
+                        + "(regression: RequestScoped context was not active while resolving the realm)");
+    }
+}


### PR DESCRIPTION
Consolidates the governed data-virtualization / ontology-federation work onto `1.4.0-SNAPSHOT`.

## Federated query — Tier 1 (governed BIAPIQuery → SQL)
- `QueryToSqlListener` (quantum-models): grammar → parameterized SQL `WHERE`, AND-binds-tighter-than-OR precedence, `IN/NIN`, null/exists, order-safe positional params, ontology-field → source-column remap, and explicit `(...)` grouping (prerequisite for safe governed composition). Fail-closed on untranslatable constructs. Regression suite included.
- `RuleContext.getGovernedFilterString(...)` (quantum-morphia-repos): store-agnostic governance seam — composes `(userQuery && policy filters)` as a grammar string, **fails closed** (unlike `getFilters`, which skips unresolvable rules).

## Ontology federation — Phase 3 (governance metadata travels with the class)
- `AnnotationOntologyLoader` stashes `@FunctionalMapping(area,domain)` into `ClassDef.metadata`.
- **Fix**: `OntologyTBox`/`TenantOntologyTBox.toTBox()` dropped `label`/`aliases`/`metadata` on the 4-arg `ClassDef` ctor — governance never survived persistence. Now round-trips (tested).
- `AnnotationOntologyLoader.classIndex(packages)` → id→Class map.

## Ontology federation — Phase 1 support (publisher enablement)
- Empty-TBox fix (`OntologyReferenceCloser`): the publisher builds from sources and never federates an empty TBox.
- **Persist-scope fix**: `buildRegistryForRealm` now persists the source TBox from non-request threads (the publisher's `ontology-tbox-publisher` boot daemon), instead of swallowing a "RequestScoped context not active" error and re-scanning every boot. Regression test included.

Full framework reactor builds green (`mvn -o install -DskipTests`). Note: framework module unit tests do not execute under surefire (`default-testCompile` writes to `target/classes`); the added tests were verified via the JUnit Platform launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
