### PR TITLE
fix(quantum-models): tests silently skipped by compiler outputDirectory override

### DIFF
--- a/quantum-framework/src/test/java/com/e2eq/framework/validation/ValidQueryFilterTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/validation/ValidQueryFilterTest.java
@@ -1,4 +1,4 @@
-package annotations;
+package com.e2eq.framework.validation;
 
 import com.e2eq.framework.annotations.ValidQueryFilter;
 import com.e2eq.framework.model.persistent.base.BaseModel;

--- a/quantum-models/pom.xml
+++ b/quantum-models/pom.xml
@@ -98,9 +98,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <basedir>${project.basedir}</basedir>
-                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                    <projectArtifact>${project.artifact}</projectArtifact>
                     <source>17</source>
                     <target>17</target>
                     <release>17</release>


### PR DESCRIPTION
## Problem
`quantum-models/pom.xml` configured maven-compiler-plugin with plugin-level `<basedir>`, `<outputDirectory>${project.build.outputDirectory}</outputDirectory>`, and `<projectArtifact>` — parameters that are plugin internals, not user configuration. The `outputDirectory` applied to `default-testCompile` as well, so:

- test classes compiled into `target/classes` instead of `target/test-classes`
- surefire scanned an empty `target/test-classes`, found **0 tests**, and reported `BUILD SUCCESS` with no "Tests run:" line — `mvn test` has been running nothing in this module
- 7 test classes (e.g. `QueryToSqlListenerTest.class`) leaked into the installed `quantum-models` jar

## Fix
- Removed the three plugin-internal parameters (source/target/release + annotation processors kept). `mvn clean test` now runs **48 tests, all passing**, and the packaged jar contains no test classes (`TestUtils` is intentional main-source).
- Unearthing the dead tests exposed `ValidQueryFilterTest` failing with HV000030: the `@ValidQueryFilter` ConstraintValidator implementation and its `META-INF/services/jakarta.validation.ConstraintValidator` registration live in **quantum-framework**, so the test could never pass in quantum-models. Moved it to `com.e2eq.framework.validation` in quantum-framework — all 4 cases pass there (verified with `-Dtest=ValidQueryFilterTest -Dsurefire.failIfNoSpecifiedTests=true`).

## Verification
- `mvn clean install` in quantum-models: `Tests run: 48, Failures: 0, Errors: 0`, BUILD SUCCESS
- `find target/test-classes -name '*Test.class'` → 6 (previously 0)
- `unzip -l target/quantum-models-1.4.0-SNAPSHOT.jar | grep Test` → only `TestUtils` (main-source utility)
- Swept framework + enterprise reactors: no other pom has the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)