### PR TITLE
Add application auth and governed participant work items

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/ContentLengthFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/ContentLengthFilter.java
@@ -29,11 +29,25 @@ public class ContentLengthFilter implements ContainerRequestFilter, ContainerRes
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws JsonProcessingException {
-        // Add content length header to responses
-        if (responseContext.getEntity() != null && responseContext.getMediaType()!= null && responseContext.getMediaType().toString().equals("application/json;charset=UTF-8")) {
+        // Ensure JSON responses are sent with an explicit, correct Content-Length (some
+        // serverless / API-gateway fronts — e.g. AWS API Gateway / Lambda / ALB — require
+        // a fixed Content-Length and do not tolerate chunked Transfer-Encoding). We do this
+        // by buffering the serialized JSON into a String so the body length is known up
+        // front: the server then emits a correct fixed-length Content-Length itself and
+        // does NOT fall back to chunked encoding.
+        //
+        // We deliberately do NOT hand-add a Content-Length header. The previous code did
+        // (headers.add(CONTENT_LENGTH, entity.getBytes().length)) while the entity was still
+        // a streamed POJO — so on responses past the write-buffer threshold (~8KB) the server
+        // chunked the body AND a manual Content-Length was appended. A response carrying both
+        // Transfer-Encoding: chunked and Content-Length is illegal HTTP; upstream proxies
+        // (Cloud Run / Envoy) reset the stream with "protocol error, reset before headers",
+        // which surfaces to clients as a 502. Buffering to a String + letting the server own
+        // the header satisfies the serverless constraint without the conflict.
+        if (responseContext.getEntity() != null && responseContext.getMediaType() != null
+                && responseContext.getMediaType().toString().equals("application/json;charset=UTF-8")) {
             String entity = mapper.writeValueAsString(responseContext.getEntity());
             responseContext.setEntity(entity);
-            responseContext.getHeaders().add(HttpHeaders.CONTENT_LENGTH, entity.getBytes().length);
         }
         else if (responseContext.getMediaType()!= null && "text/event-stream".equals(responseContext.getMediaType().toString())){
            responseContext.getHeaders().putSingle("Cache-Control", "no-cache, no-transform");

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/RolesAugmentor.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/RolesAugmentor.java
@@ -57,6 +57,21 @@ public class RolesAugmentor implements SecurityIdentityAugmentor {
             contextRealm = envConfigUtils.getSystemRealm();
         }
 
+        // Derive roles from the validated token's groups claim. A DELEGATED identity (a trusted
+        // central-issuer token whose subject has no local credential in this realm — the standard
+        // multi-app case) carries its credential's roles in the JWT `groups`, not in a local
+        // record. Without this, the coarse @RolesAllowed gate can't see the roles the token grants
+        // (only the RuleContext policy engine, which reads the token directly, does), so it 403s.
+        // Adding them here keeps both authz layers agreeing on the same role set.
+        if (identity.getPrincipal() instanceof org.eclipse.microprofile.jwt.JsonWebToken token) {
+            java.util.Set<String> groups = token.getGroups();
+            if (groups != null && !groups.isEmpty()) {
+                builder.addRoles(new HashSet<>(groups));
+                Log.debugf("RolesAugmentor: added %d role(s) from token groups for %s: %s",
+                        groups.size(), originalPrincipal, groups);
+            }
+        }
+
         Optional<CredentialUserIdPassword> ocred = credentialRepo.findBySubject(originalPrincipal, contextRealm, true);
         if (ocred.isPresent()) {
             CredentialUserIdPassword cred = ocred.get();

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -112,6 +112,15 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     @ConfigProperty(name = "quantum.auth.trust-token-claims", defaultValue = "false")
     boolean trustTokenClaims;
 
+    // Delegated-identity data-domain scoping: when true, a delegated principal (trusted-issuer
+    // token, no local credential) adopts the DATA DOMAIN of the tenant realm it operates in —
+    // resolved from that realm's registered Realm.DomainContext — instead of the cross-tenant
+    // system data domain. If the realm is NOT a registered tenant, the request FAILS CLOSED
+    // (403) rather than silently granting the system domain. Default false preserves the prior
+    // behavior (system data domain) for services that have not opted in.
+    @ConfigProperty(name = "quantum.auth.delegated.realm-scoped-domain", defaultValue = "false")
+    boolean delegatedRealmScopedDomain;
+
     @Inject
     com.e2eq.framework.security.runtime.RuleContext ruleContext;
 
@@ -726,17 +735,41 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         if (userId == null) userId = claimString("username");
         if (userId == null) userId = sub;
 
+        String systemRealm = envConfigUtils.getSystemRealm();
         String contextRealm = (realmOverride != null && !realmOverride.isBlank())
                 ? realmOverride
-                : envConfigUtils.getSystemRealm();
+                : systemRealm;
         String[] roles = resolveEffectiveRoles(securityIdentity, null, contextRealm);
 
         Log.infof("Delegated identity: principal from trusted-issuer token claims (iss=%s, sub=%s, userId=%s, realm=%s, roles=%s)",
                 jwt.getIssuer(), sub, userId, contextRealm, java.util.Arrays.toString(roles));
 
+        // A delegated principal adopts the DATA DOMAIN of the tenant realm it operates in
+        // (from the realm's registered DomainContext), not the cross-tenant system domain.
+        // The system domain is reserved for the system realm / system admins — never a silent
+        // fallback for an ordinary tenant user. Gated so services opt in explicitly.
+        DataDomain dataDomain;
+        if (!delegatedRealmScopedDomain || contextRealm.equals(systemRealm)) {
+            dataDomain = securityUtils.getSystemDataDomain();
+        } else {
+            Optional<Realm> realmOpt = realmRepo.findByRefName(contextRealm, true, systemRealm);
+            if (realmOpt.isEmpty()) {
+                realmOpt = realmRepo.findByDatabaseName(contextRealm, true, systemRealm);
+            }
+            if (realmOpt.isEmpty() || realmOpt.get().getDomainContext() == null) {
+                // Fail closed: the realm is not a registered tenant. Do NOT grant the
+                // cross-tenant system data domain to a delegated principal.
+                Log.warnf("Delegated principal denied: realm '%s' is not a registered tenant "
+                        + "(no system-domain fallback under quantum.auth.delegated.realm-scoped-domain)", contextRealm);
+                throw new jakarta.ws.rs.ForbiddenException(
+                        "Realm '" + contextRealm + "' is not a registered tenant.");
+            }
+            dataDomain = realmOpt.get().getDomainContext().toDataDomain(userId);
+        }
+
         PrincipalContext context = new PrincipalContext.Builder()
                 .withDefaultRealm(contextRealm)
-                .withDataDomain(securityUtils.getSystemDataDomain())
+                .withDataDomain(dataDomain)
                 .withUserId(userId)
                 .withRoles(roles)
                 .withScope("AUTHENTICATED")

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemAssignRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemAssignRequest.java
@@ -1,0 +1,12 @@
+package com.e2eq.framework.rest.models;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.validation.constraints.NotNull;
+
+/** Assigns business responsibility independently of queue claiming. */
+@RegisterForReflection
+public class ParticipantWorkItemAssignRequest {
+    @NotNull
+    public Long expectedVersion;
+    public String assigneeRef;
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemReminderRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemReminderRequest.java
@@ -1,0 +1,18 @@
+package com.e2eq.framework.rest.models;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/** Schedules one in-app reminder for visible participants. */
+@RegisterForReflection
+public class ParticipantWorkItemReminderRequest {
+    @NotNull
+    public Long expectedVersion;
+    @NotNull
+    public Date triggerAt;
+    public List<String> recipientRefs = new ArrayList<>();
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemShareRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemShareRequest.java
@@ -1,0 +1,19 @@
+package com.e2eq.framework.rest.models;
+
+import com.e2eq.framework.model.persistent.tasks.TaskGrant;
+import com.e2eq.framework.model.persistent.tasks.WorkItemVisibility;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Replaces the explicit audience of a participant-owned TODO. */
+@RegisterForReflection
+public class ParticipantWorkItemShareRequest {
+    @NotNull
+    public Long expectedVersion;
+    @NotNull
+    public WorkItemVisibility visibility;
+    public List<TaskGrant> grants = new ArrayList<>();
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemUpdateRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/models/ParticipantWorkItemUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.e2eq.framework.rest.models;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Date;
+
+/** Revision-checked business edit for a participant-owned TODO. */
+@RegisterForReflection
+public class ParticipantWorkItemUpdateRequest {
+    @NotNull
+    public Long expectedVersion;
+    @NotBlank
+    public String summary;
+    public String details;
+    public Date dueDate;
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/models/WorkItemActionRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/models/WorkItemActionRequest.java
@@ -1,0 +1,31 @@
+package com.e2eq.framework.rest.models;
+
+import com.e2eq.framework.model.persistent.tasks.WorkerType;
+import com.e2eq.framework.model.persistent.tasks.TaskPayload;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Revision-checked input for claim, lifecycle, and heartbeat operations.
+ */
+@RegisterForReflection
+public class WorkItemActionRequest {
+    @NotNull
+    public Long expectedVersion;
+
+    /**
+     * Decision assessment snapshot the worker reviewed. Completion fails closed
+     * when it no longer matches the task subject's assessment version.
+     */
+    public String expectedAssessmentVersion;
+
+    public WorkerType workerType;
+
+    @Min(30)
+    public Long leaseSeconds;
+
+    public String result;
+
+    public TaskPayload resultPayload;
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/models/WorkItemError.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/models/WorkItemError.java
@@ -1,0 +1,8 @@
+package com.e2eq.framework.rest.models;
+
+import com.e2eq.framework.model.persistent.tasks.WorkItemOperationException;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record WorkItemError(WorkItemOperationException.Code code, String message) {
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
@@ -306,20 +306,21 @@ public class SecurityResource {
         Log.infof("Logging in userid: %s realm: %s",authRequest.getUserId(), realm);
 
         try {
-            AuthLoginService.LoginResult loginResult = provider == null || provider.isBlank()
-                    ? authLoginService.login(authRequest.getUserId(), authRequest.getPassword())
-                    : authLoginService.login(authRequest.getUserId(), authRequest.getPassword(), provider);
+            String providerOverride = (provider == null || provider.isBlank()) ? null : provider;
+            AuthLoginService.LoginResult loginResult = authLoginService.login(
+                    authRequest.getUserId(), authRequest.getPassword(), providerOverride, authRequest.getApplicationId());
             if (loginResult.authenticated()) {
                 Log.info("Login successful for userId:" + authRequest.getUserId() + " provider:" + loginResult.response().getAuthProvider());
                 return Response.ok(loginResult.response()).build();
             }
+            if (loginResult.needsApplicationSelection()) {
+                Log.infof("Login requires application selection for userId:%s applications:%s",
+                        authRequest.getUserId(), loginResult.applications());
+                return loginResult.toResponse();
+            }
             Log.warn("Login failed for userId:" + authRequest.getUserId() + " providers:" + loginResult.providerFailures());
-            RestError error = RestError.builder()
-                    .statusMessage("Authentication failed")
-                    .debugMessage(String.join("; ", loginResult.providerFailures()))
-                    .status(Response.Status.UNAUTHORIZED.getStatusCode())
-                    .build();
-            return Response.status(Response.Status.UNAUTHORIZED).entity(error).build();
+            // Honors the resolved status (403 for an unauthorized application, else 401).
+            return loginResult.toResponse();
 
         } catch (SecurityException e) {
             RestError error = RestError.builder()

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/UserRealmRoleResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/UserRealmRoleResource.java
@@ -1,0 +1,179 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
+import com.e2eq.framework.model.security.UserRealmRole;
+import com.e2eq.framework.rest.models.ApplicationGrantRequest;
+import com.e2eq.framework.rest.models.RestError;
+import com.e2eq.framework.util.EnvConfigUtils;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.logging.Log;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Admin surface for per-realm role assignments (the GitHub-model membership list),
+ * plus the application-scoped-auth grant. Standard CRUD comes from {@link BaseResource}
+ * (parity with {@link RealmTenantMembershipResource}); the focused
+ * {@code .../applications} endpoints are the authoritative, audited path for the
+ * application grant and are pinned to the SYSTEM realm — the same store the login
+ * path reads the grant back from — so they are correct regardless of the caller's
+ * active realm.
+ */
+@Path("/security/user-realm-roles")
+@RolesAllowed({ "admin", "system" })
+@Tag(name = "security", description = "Operations related to security")
+@IfBuildProperty(name = "quantum.system-rest.enabled", stringValue = "true", enableIfMissing = true)
+public class UserRealmRoleResource extends BaseResource<UserRealmRole, UserRealmRoleRepo> {
+
+   @Inject
+   EnvConfigUtils envConfigUtils;
+
+   protected UserRealmRoleResource(UserRealmRoleRepo repo) {
+      super(repo);
+   }
+
+   /** Read the current application grant for a (user, realm) membership. */
+   @GET
+   @Path("{userId}/{realmRefName}/applications")
+   @Produces(MediaType.APPLICATION_JSON)
+   public Response getApplicationGrant(@PathParam("userId") String userId,
+                                       @PathParam("realmRefName") String realmRefName) {
+      Optional<UserRealmRole> membership = loadMembership(userId, realmRefName);
+      if (membership.isEmpty()) {
+         return notFound(userId, realmRefName);
+      }
+      return Response.ok(membership.get()).build();
+   }
+
+   /**
+    * Set (or clear) the application grant on a (user, realm) membership. Mutates only
+    * the grant fields — roles and status are left untouched. An empty/null
+    * authorizedApplications clears the grant (reverts the user to legacy behavior).
+    */
+   @PUT
+   @Path("{userId}/{realmRefName}/applications")
+   @Consumes(MediaType.APPLICATION_JSON)
+   @Produces(MediaType.APPLICATION_JSON)
+   public Response setApplicationGrant(@PathParam("userId") String userId,
+                                       @PathParam("realmRefName") String realmRefName,
+                                       ApplicationGrantRequest request) {
+      Optional<UserRealmRole> membershipOp = loadMembership(userId, realmRefName);
+      if (membershipOp.isEmpty()) {
+         return notFound(userId, realmRefName);
+      }
+      UserRealmRole membership = membershipOp.get();
+
+      List<String> apps = normalize(request == null ? null : request.getAuthorizedApplications());
+      String defaultApp = trimToNull(request == null ? null : request.getDefaultApplication());
+
+      if (apps.isEmpty()) {
+         // Clear the grant → legacy (single-audience) behavior.
+         membership.setAuthorizedApplications(null);
+         membership.setDefaultApplication(null);
+      } else {
+         boolean wildcard = apps.contains(UserRealmRole.APPLICATION_WILDCARD);
+         List<String> concrete = new ArrayList<>(apps);
+         concrete.remove(UserRealmRole.APPLICATION_WILDCARD);
+
+         if (defaultApp != null
+                 && !UserRealmRole.APPLICATION_WILDCARD.equals(defaultApp)
+                 && !concrete.contains(defaultApp)) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(RestError.builder()
+                            .status(Response.Status.BAD_REQUEST.getStatusCode())
+                            .statusMessage("defaultApplication '" + defaultApp
+                                    + "' must be one of authorizedApplications")
+                            .build())
+                    .build();
+         }
+
+         if (wildcard) {
+            // "*" is an admin-only, deliberate grant — audit every time it is written.
+            Log.warnf("Wildcard application grant WRITTEN (audit): user=%s realm=%s by=%s",
+                    userId, realmRefName, callerName());
+         }
+
+         membership.setAuthorizedApplications(apps);
+         membership.setDefaultApplication(defaultApp);
+      }
+
+      UserRealmRole saved = repo.save(envConfigUtils.getSystemRealm(), membership);
+      return Response.ok(saved).build();
+   }
+
+   /** Clear the application grant (revert the membership to legacy behavior). */
+   @DELETE
+   @Path("{userId}/{realmRefName}/applications")
+   @Produces(MediaType.APPLICATION_JSON)
+   public Response clearApplicationGrant(@PathParam("userId") String userId,
+                                         @PathParam("realmRefName") String realmRefName) {
+      Optional<UserRealmRole> membershipOp = loadMembership(userId, realmRefName);
+      if (membershipOp.isEmpty()) {
+         return notFound(userId, realmRefName);
+      }
+      UserRealmRole membership = membershipOp.get();
+      membership.setAuthorizedApplications(null);
+      membership.setDefaultApplication(null);
+      UserRealmRole saved = repo.save(envConfigUtils.getSystemRealm(), membership);
+      return Response.ok(saved).build();
+   }
+
+   private Optional<UserRealmRole> loadMembership(String userId, String realmRefName) {
+      return repo.findAssignmentForRealmWithIgnoreRules(userId, realmRefName, envConfigUtils.getSystemRealm());
+   }
+
+   private Response notFound(String userId, String realmRefName) {
+      return Response.status(Response.Status.NOT_FOUND)
+              .entity(RestError.builder()
+                      .status(Response.Status.NOT_FOUND.getStatusCode())
+                      .statusMessage("No realm membership for userId '" + userId
+                              + "' in realm '" + realmRefName + "'")
+                      .build())
+              .build();
+   }
+
+   private String callerName() {
+      try {
+         return (jwt != null && jwt.getName() != null) ? jwt.getName() : "unknown";
+      } catch (RuntimeException e) {
+         return "unknown";
+      }
+   }
+
+   private static List<String> normalize(List<String> apps) {
+      if (apps == null) {
+         return List.of();
+      }
+      LinkedHashSet<String> out = new LinkedHashSet<>();
+      for (String app : apps) {
+         String t = trimToNull(app);
+         if (t != null) {
+            out.add(t);
+         }
+      }
+      return new ArrayList<>(out);
+   }
+
+   private static String trimToNull(String s) {
+      if (s == null) {
+         return null;
+      }
+      String t = s.trim();
+      return t.isEmpty() ? null : t;
+   }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/WorkItemOperationExceptionMapper.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/WorkItemOperationExceptionMapper.java
@@ -1,0 +1,24 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.model.persistent.tasks.WorkItemOperationException;
+import com.e2eq.framework.rest.models.WorkItemError;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class WorkItemOperationExceptionMapper implements ExceptionMapper<WorkItemOperationException> {
+    @Override
+    public Response toResponse(WorkItemOperationException exception) {
+        Response.Status status = switch (exception.getCode()) {
+            case INVALID_REQUEST -> Response.Status.BAD_REQUEST;
+            case NOT_FOUND -> Response.Status.NOT_FOUND;
+            case NOT_ELIGIBLE -> Response.Status.FORBIDDEN;
+            case NOT_ASSIGNED, LEASE_EXPIRED, INVALID_TRANSITION, REVISION_CONFLICT -> Response.Status.CONFLICT;
+            case INTERNAL_ERROR -> Response.Status.INTERNAL_SERVER_ERROR;
+        };
+        return Response.status(status)
+                .entity(new WorkItemError(exception.getCode(), exception.getMessage()))
+                .build();
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/WorkItemResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/WorkItemResource.java
@@ -1,0 +1,208 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.annotations.FunctionalMapping;
+import com.e2eq.framework.model.persistent.morphia.CompletionTaskRepo;
+import com.e2eq.framework.model.persistent.tasks.CompletionTask;
+import com.e2eq.framework.model.persistent.tasks.WorkItemOperationException;
+import com.e2eq.framework.model.persistent.tasks.WorkerType;
+import com.e2eq.framework.rest.models.WorkItemActionRequest;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Governed queue API shared by human, agent, and service workers.
+ */
+@Path("/work-items")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@RolesAllowed({"user", "admin", "system"})
+@FunctionalMapping(area = "TASK", domain = "COMPLETION_TASK")
+public class WorkItemResource {
+    private static final long DEFAULT_AGENT_LEASE_SECONDS = 300;
+
+    @Inject
+    CompletionTaskRepo repo;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @POST
+    @RolesAllowed({"admin", "system"})
+    @Operation(operationId = "createWorkItem", summary = "Create a governed work item")
+    public CompletionTask create(@QueryParam("groupId") String groupId, CompletionTask workItem) {
+        return repo.createWorkItem(workItem, groupId, actorRef());
+    }
+
+    @GET
+    @Path("eligible")
+    @Operation(operationId = "listEligibleWorkItems", summary = "List work items the current actor may claim")
+    public List<CompletionTask> eligible(@QueryParam("workerType") @DefaultValue("HUMAN") WorkerType workerType,
+                                         @QueryParam("queueRef") String queueRef,
+                                         @QueryParam("limit") @DefaultValue("50") int limit) {
+        WorkerType authorizedWorkerType = authorizeWorkerType(workerType);
+        return repo.listEligible(authorizedWorkerType, identity.getRoles(),
+                identityValues("profileRefs"), identityValues("capabilityRefs"), queueRef, limit);
+    }
+
+    @GET
+    @Path("mine")
+    @Operation(operationId = "listMyWorkItems", summary = "List work items currently claimed by the actor")
+    public List<CompletionTask> mine(@QueryParam("limit") @DefaultValue("50") int limit) {
+        return repo.listClaimedBy(actorRef(), limit);
+    }
+
+    @GET
+    @Path("{id}")
+    @Operation(operationId = "getWorkItem", summary = "Get a visible work item for a queue deep link")
+    public CompletionTask get(@PathParam("id") String id,
+                              @QueryParam("workerType") @DefaultValue("HUMAN") WorkerType workerType) {
+        WorkerType authorizedWorkerType = authorizeWorkerType(workerType);
+        return repo.getVisible(id, actorRef(), authorizedWorkerType, identity.getRoles(),
+                identityValues("profileRefs"), identityValues("capabilityRefs"));
+    }
+
+    @POST
+    @Path("{id}/claim")
+    @Operation(operationId = "claimWorkItem", summary = "Atomically claim an eligible work item")
+    public CompletionTask claim(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        WorkerType workerType = authorizeWorkerType(
+                request.workerType == null ? WorkerType.HUMAN : request.workerType);
+        return repo.claim(id, request.expectedVersion, actorRef(), workerType, identity.getRoles(),
+                identityValues("profileRefs"), identityValues("capabilityRefs"), lease(workerType, request));
+    }
+
+    @POST
+    @Path("{id}/start")
+    @Operation(operationId = "startWorkItem", summary = "Move a claimed work item into progress")
+    public CompletionTask start(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        return repo.start(id, request.expectedVersion, actorRef());
+    }
+
+    @POST
+    @Path("{id}/complete")
+    @Operation(operationId = "completeWorkItem", summary = "Complete a work item and make its result available to orchestration")
+    public CompletionTask complete(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        return repo.complete(id, request.expectedVersion, actorRef(), request.expectedAssessmentVersion,
+                request.result, request.resultPayload);
+    }
+
+    @POST
+    @Path("{id}/fail")
+    @Operation(operationId = "failWorkItem", summary = "Fail a work item with an explicit result or reason")
+    public CompletionTask fail(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        return repo.fail(id, request.expectedVersion, actorRef(), request.result, request.resultPayload);
+    }
+
+    @POST
+    @Path("{id}/release")
+    @Operation(operationId = "releaseWorkItem", summary = "Release a claimed work item back to its queue")
+    public CompletionTask release(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        return repo.release(id, request.expectedVersion, actorRef());
+    }
+
+    @POST
+    @Path("{id}/heartbeat")
+    @Operation(operationId = "heartbeatWorkItem", summary = "Extend the lease for an active work item")
+    public CompletionTask heartbeat(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        long leaseSeconds = request.leaseSeconds == null ? DEFAULT_AGENT_LEASE_SECONDS : request.leaseSeconds;
+        if (leaseSeconds < 30 || leaseSeconds > 3600) {
+            throw invalid("leaseSeconds must be between 30 and 3600");
+        }
+        return repo.heartbeat(id, request.expectedVersion, actorRef(), Duration.ofSeconds(leaseSeconds));
+    }
+
+    @POST
+    @Path("{id}/cancel")
+    @RolesAllowed({"admin", "system"})
+    @Operation(operationId = "cancelWorkItem", summary = "Cancel a non-terminal work item")
+    public CompletionTask cancel(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        return repo.cancel(id, request.expectedVersion);
+    }
+
+    @POST
+    @Path("{id}/expire")
+    @RolesAllowed("system")
+    @Operation(operationId = "expireWorkItem", summary = "Expire a non-terminal work item")
+    public CompletionTask expire(@PathParam("id") String id, @Valid WorkItemActionRequest request) {
+        requireRequest(request);
+        return repo.expire(id, request.expectedVersion);
+    }
+
+    private Duration lease(WorkerType workerType, WorkItemActionRequest request) {
+        if (workerType == WorkerType.HUMAN && request.leaseSeconds == null) {
+            return null;
+        }
+        long leaseSeconds = request.leaseSeconds == null ? DEFAULT_AGENT_LEASE_SECONDS : request.leaseSeconds;
+        if (leaseSeconds < 30 || leaseSeconds > 3600) {
+            throw invalid("leaseSeconds must be between 30 and 3600");
+        }
+        return Duration.ofSeconds(leaseSeconds);
+    }
+
+    private WorkerType authorizeWorkerType(WorkerType requested) {
+        if (requested == WorkerType.HUMAN) {
+            return requested;
+        }
+        if (!identity.hasRole("system") && !identity.hasRole("admin")) {
+            throw new WorkItemOperationException(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                    "Only an agent/service identity may use the " + requested + " queue");
+        }
+        return requested;
+    }
+
+    private void requireRequest(WorkItemActionRequest request) {
+        if (request == null || request.expectedVersion == null) {
+            throw invalid("expectedVersion is required");
+        }
+    }
+
+    private WorkItemOperationException invalid(String message) {
+        return new WorkItemOperationException(WorkItemOperationException.Code.INVALID_REQUEST, message);
+    }
+
+    private String actorRef() {
+        if (identity == null || identity.isAnonymous() || identity.getPrincipal() == null) {
+            throw new WorkItemOperationException(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                    "An authenticated actor is required");
+        }
+        return identity.getPrincipal().getName();
+    }
+
+    private Set<String> identityValues(String attributeName) {
+        Object value = identity.getAttribute(attributeName);
+        if (value == null) {
+            return Set.of();
+        }
+        if (value instanceof Collection<?> values) {
+            Set<String> result = new LinkedHashSet<>();
+            values.stream().map(String::valueOf).forEach(result::add);
+            return result;
+        }
+        return Set.of(String.valueOf(value));
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
@@ -35,11 +35,19 @@ public class AuthLoginService {
     @Inject
     EnvConfigUtils envConfigUtils;
 
+    /** Application-authorization signals a provider may return as a negative login response. */
+    private static final String APP_SELECTION_REQUIRED = "ApplicationSelectionRequired";
+    private static final String APP_NOT_AUTHORIZED = "ApplicationNotAuthorized";
+
     public LoginResult login(String userId, String password) {
-        return login(userId, password, null);
+        return login(userId, password, null, null);
     }
 
     public LoginResult login(String userId, String password, String providerOverride) {
+        return login(userId, password, providerOverride, null);
+    }
+
+    public LoginResult login(String userId, String password, String providerOverride, String applicationId) {
         Optional<CredentialUserIdPassword> credentialOptional = findLoginCredential(userId);
         List<AuthProvider> authProviders = authProviderFactory.getLoginProviders(
                 providerOverride,
@@ -47,7 +55,7 @@ public class AuthLoginService {
 
         List<String> providerFailures = new ArrayList<>();
         for (AuthProvider authProvider : authProviders) {
-            AuthProvider.LoginResponse loginResponse = authProvider.login(userId, password);
+            AuthProvider.LoginResponse loginResponse = authProvider.login(userId, password, applicationId);
             if (loginResponse.authenticated() && loginResponse.positiveResponse() != null) {
                 Optional<CredentialUserIdPassword> credentialOp = findCredential(
                         loginResponse.positiveResponse().identity() != null
@@ -57,6 +65,19 @@ public class AuthLoginService {
                         loginResponse.positiveResponse().userId());
                 AuthResponse response = toAuthResponse(authProvider, loginResponse, credentialOp.orElse(null));
                 return LoginResult.success(response);
+            }
+            // Application-authorization is a definitive decision for an authenticated user
+            // (the password matched but the app is unauthorized / needs selecting); do not
+            // fall through to other providers, which don't model app scoping.
+            AuthProvider.LoginNegativeResponse negative = loginResponse.negativeResponse();
+            if (negative != null && APP_SELECTION_REQUIRED.equals(negative.errorType())) {
+                List<String> applications = (negative.errorDetails() == null || negative.errorDetails().isBlank())
+                        ? List.of()
+                        : List.of(negative.errorDetails().split(","));
+                return LoginResult.needsApplicationSelection(applications, negative.errorMessage());
+            }
+            if (negative != null && APP_NOT_AUTHORIZED.equals(negative.errorType())) {
+                return LoginResult.applicationDenied(negative.errorMessage());
             }
             providerFailures.add(loginFailure(authProvider, loginResponse));
         }
@@ -126,6 +147,12 @@ public class AuthLoginService {
         response.setRoles(positive.roleAssignments().stream().map(RoleAssignment::toString).collect(Collectors.toList()));
         response.setAuthProvider(authProvider.getName());
         response.setAccessibleRealms(resolveAccessibleRealms(credential));
+        // Application-scoped auth: surface the token's aud set + azp so the UI can
+        // render an app switcher and know the active app (null when not configured).
+        if (positive.audiences() != null) {
+            response.setApplications(new ArrayList<>(positive.audiences()));
+        }
+        response.setActiveApplication(positive.activeApplication());
         return response;
     }
 
@@ -136,29 +163,58 @@ public class AuthLoginService {
         return authProvider.getName() + ": Authentication failed";
     }
 
-    public record LoginResult(AuthResponse response, List<String> providerFailures) {
+    public record LoginResult(AuthResponse response,
+                              List<String> providerFailures,
+                              int status,
+                              List<String> applications,
+                              String message) {
         public static LoginResult success(AuthResponse response) {
-            return new LoginResult(response, List.of());
+            return new LoginResult(response, List.of(), Response.Status.OK.getStatusCode(), null, null);
         }
 
         public static LoginResult failure(List<String> providerFailures) {
-            return new LoginResult(null, List.copyOf(providerFailures));
+            return new LoginResult(null, List.copyOf(providerFailures),
+                    Response.Status.UNAUTHORIZED.getStatusCode(), null, null);
+        }
+
+        /** Authenticated, but more than one application is authorized and none was selected. */
+        public static LoginResult needsApplicationSelection(List<String> applications, String message) {
+            return new LoginResult(null, List.of(), Response.Status.BAD_REQUEST.getStatusCode(),
+                    List.copyOf(applications), message);
+        }
+
+        /** Authenticated, but the requested application is not authorized for this user/realm. */
+        public static LoginResult applicationDenied(String message) {
+            return new LoginResult(null, List.of(), Response.Status.FORBIDDEN.getStatusCode(), null, message);
         }
 
         public boolean authenticated() {
             return response != null;
         }
 
+        public boolean needsApplicationSelection() {
+            return status == Response.Status.BAD_REQUEST.getStatusCode();
+        }
+
         public Response toResponse() {
             if (authenticated()) {
                 return Response.ok(response).build();
             }
+            if (needsApplicationSelection()) {
+                return Response.status(status)
+                        .entity(java.util.Map.of(
+                                "status", status,
+                                "statusMessage", message != null ? message : "Application selection required",
+                                "errorType", "ApplicationSelectionRequired",
+                                "applications", applications != null ? applications : List.of()))
+                        .build();
+            }
             RestError error = RestError.builder()
-                    .statusMessage("Authentication failed")
+                    .statusMessage(message != null ? message : "Authentication failed")
                     .debugMessage(String.join("; ", providerFailures))
-                    .status(Response.Status.UNAUTHORIZED.getStatusCode())
+                    .status(status)
                     .build();
-            return Response.status(Response.Status.UNAUTHORIZED).entity(error).build();
+            return Response.status(status).entity(error).build();
         }
     }
 }

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -5,6 +5,7 @@ import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
 
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.auth.ApplicationAuthorizationResolver;
 import com.e2eq.framework.model.auth.AuthProvider;
 import com.e2eq.framework.model.auth.ClaimsAuthProvider;
 import com.e2eq.framework.model.auth.ProviderClaims;
@@ -18,6 +19,7 @@ import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
 import com.e2eq.framework.model.security.CredentialRefreshToken;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.model.security.UserRealmRole;
 import com.e2eq.framework.plugins.BaseAuthProvider;
 import com.e2eq.framework.model.security.UserGroup;
 import com.e2eq.framework.util.EncryptionUtils;
@@ -478,6 +480,11 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
 
    @Override
    public LoginResponse login (String userId, String password) {
+      return login(userId, password, (String) null);
+   }
+
+   @Override
+   public LoginResponse login (String userId, String password, String applicationId) {
       try {
          String configuredRealm = envConfigUtils.getSystemRealm();
          Log.infof("Checking for auth against %s realm", configuredRealm);
@@ -527,20 +534,65 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                   String tokenRealm = (credential.getDomainContext() != null)
                      ? credential.getDomainContext().getDefaultRealm()
                      : envConfigUtils.getSystemRealm();
+                  Optional<UserRealmRole> realmAssignment = Optional.empty();
                   java.util.Set<String> realmAssignedRoles = new java.util.LinkedHashSet<>();
                   try {
-                     realmAssignedRoles.addAll(userRealmRoleRepo.findActiveRolesForRealmWithIgnoreRules(
-                        userId, tokenRealm, envConfigUtils.getSystemRealm()));
+                     realmAssignment = userRealmRoleRepo.findActiveAssignmentForRealmWithIgnoreRules(
+                        userId, tokenRealm, envConfigUtils.getSystemRealm());
+                     realmAssignment.map(UserRealmRole::getRoles).ifPresent(realmAssignedRoles::addAll);
                   } catch (Exception e) {
                      Log.warn("Failed to resolve per-realm role assignments; continuing with credential roles", e);
                   }
                   groups.addAll(realmAssignedRoles);
 
-                  String authToken = TokenUtils.generateUserToken(
-                     subject,
-                     groups,
-                     TokenUtils.expiresAt(durationInSeconds),
-                     issuer);
+                  // Application-scoped auth: resolve which application(s) this token is
+                  // scoped to from the user's per-realm grant. LEGACY = no grant configured
+                  // (single default audience, unchanged behavior); RESOLVED = multi-aud
+                  // token + azp; AMBIGUOUS/DENIED short-circuit to a negative response the
+                  // login resource maps to 400 (needs selection) / 403 (not authorized).
+                  ApplicationAuthorizationResolver.Result appAuth = ApplicationAuthorizationResolver.resolve(
+                     realmAssignment.map(UserRealmRole::getAuthorizedApplications).orElse(null),
+                     realmAssignment.map(UserRealmRole::getDefaultApplication).orElse(null),
+                     applicationId);
+                  switch (appAuth.outcome()) {
+                     case AMBIGUOUS:
+                        return new LoginResponse(false,
+                           new LoginNegativeResponse(userId, 400, 300,
+                              "Multiple applications are authorized; specify which application to sign into",
+                              "ApplicationSelectionRequired",
+                              String.join(",", appAuth.candidates()),
+                              tokenRealm));
+                     case DENIED:
+                        return new LoginResponse(false,
+                           new LoginNegativeResponse(userId, 403, 403,
+                              "Not authorized for application: " + appAuth.deniedApplication(),
+                              "ApplicationNotAuthorized",
+                              appAuth.deniedApplication(),
+                              tokenRealm));
+                     default:
+                        break; // LEGACY or RESOLVED — mint below
+                  }
+
+                  String authToken;
+                  if (appAuth.resolved()) {
+                     if (appAuth.wildcard()) {
+                        Log.warnf("Wildcard application grant exercised (audit): user=%s realm=%s activeApplication=%s",
+                           userId, tokenRealm, appAuth.activeApplication());
+                     }
+                     authToken = TokenUtils.generateUserToken(
+                        subject,
+                        groups,
+                        appAuth.audiences(),
+                        appAuth.activeApplication(),
+                        TokenUtils.expiresAt(durationInSeconds),
+                        issuer);
+                  } else {
+                     authToken = TokenUtils.generateUserToken(
+                        subject,
+                        groups,
+                        TokenUtils.expiresAt(durationInSeconds),
+                        issuer);
+                  }
 
                   String refreshToken = generateRefreshToken(credential.getUserId(), authToken,
                      TokenUtils.currentTimeInSecs() + durationInSeconds + TokenUtils.REFRESH_ADDITIONAL_DURATION_SECONDS);
@@ -597,7 +649,9 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                         refreshToken,
                         TokenUtils.currentTimeInSecs() + durationInSeconds,
                         mongodbConnectionString,
-                        realm)
+                        realm,
+                        appAuth.resolved() ? appAuth.audiences() : null,
+                        appAuth.resolved() ? appAuth.activeApplication() : null)
                   );
                } else {
                   return new LoginResponse(false,

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
@@ -189,6 +189,49 @@ public class TokenUtils {
 		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
 	}
 
+	/**
+	 * Application-scoped token: mints a MULTI-audience token whose {@code aud} is the
+	 * set of applications the user is authorized for in the active realm (multi-aud
+	 * SSO — each suite app accepts a token whose {@code aud} contains its own id), and
+	 * an {@code azp} claim naming the application actively being entered. Claims
+	 * otherwise mirror {@link #generateUserToken(String, Set, long, String)}.
+	 *
+	 * @param audiences         the authorized application set (becomes {@code aud}); must be non-empty
+	 * @param activeApplication the actively-entered application (becomes {@code azp}); may be null
+	 */
+	public static String generateUserToken(String subject,
+											Set<String> groups,
+											Set<String> audiences,
+											String activeApplication,
+											long expiresAt,
+											String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+		Objects.requireNonNull(subject, "subject cannot be null");
+		Objects.requireNonNull(issuer, "Issuer cannot be null");
+		if (audiences == null || audiences.isEmpty()) {
+			throw new ValidationException("audiences cannot be empty for an application-scoped token");
+		}
+		if (expiresAt <= REFRESH_ADDITIONAL_DURATION_SECONDS) {
+			throw new ValidationException("Duration must be greater than" + REFRESH_ADDITIONAL_DURATION_SECONDS + " seconds");
+		}
+
+		PrivateKey privateKey = cachedPrivateKey != null ? cachedPrivateKey : readPrivateKey(privateKeyLocation);
+
+		JwtClaimsBuilder claimsBuilder = Jwt.claims();
+		long currentTimeInSecs = currentTimeInSecs();
+		claimsBuilder.issuer(issuer);
+		claimsBuilder.subject(subject);
+		claimsBuilder.issuedAt(currentTimeInSecs);
+		claimsBuilder.audience(audiences);
+		claimsBuilder.expiresAt(expiresAt);
+		claimsBuilder.groups(groups);
+		claimsBuilder.claim("scope", AUTH_SCOPE);
+		if (activeApplication != null && !activeApplication.isBlank()) {
+			claimsBuilder.claim("azp", activeApplication);
+		}
+		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
+	}
+
 	public static String generateRefreshToken(String subject,  long durationInSeconds, String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
 
                 PrivateKey privateKey = cachedPrivateKey != null ? cachedPrivateKey : readPrivateKey(privateKeyLocation);

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
@@ -1,0 +1,149 @@
+package com.e2eq.framework.model.auth;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Resolves which application(s) a token should be scoped to at login, from a
+ * user's per-(realm) application grant. Pure function — no I/O — so it is
+ * exhaustively unit-testable and free of the auth provider's concerns.
+ *
+ * <p>Decisions this encodes (application-scoped auth, decisions locked 2026-07-12):
+ * <ul>
+ *   <li><b>Nested (realm, application):</b> the grant is read from the user's
+ *       realm membership, so the input here is already realm-specific.</li>
+ *   <li><b>Multi-aud SSO:</b> a successful resolution returns the ENTIRE authorized
+ *       set as the audiences (the token's {@code aud}); each suite app accepts a
+ *       token whose {@code aud} contains its own id, so no re-auth to move between
+ *       apps in the realm. The actively-entered app is returned separately as the
+ *       {@code azp}.</li>
+ *   <li><b>Resolution order:</b> explicit requested app → single authorized app →
+ *       configured default → otherwise ambiguous (the caller returns the set so the
+ *       login UI can prompt). Origin/host is never consulted.</li>
+ *   <li><b>{@code "*"} guardrail:</b> a wildcard grant is "may enter any app, but
+ *       must name which" — it requires an explicit requested app (the installed set
+ *       is not enumerable here), scopes the token to just that app, and flags the
+ *       result so the caller can audit-log the wildcard issuance.</li>
+ * </ul>
+ */
+public final class ApplicationAuthorizationResolver {
+
+    public static final String WILDCARD = "*";
+
+    private ApplicationAuthorizationResolver() {
+    }
+
+    public enum Outcome {
+        /** No application grant configured for this membership — use legacy (single-audience) behavior. */
+        LEGACY,
+        /** Resolved to a concrete audience set + active application. */
+        RESOLVED,
+        /** More than one app authorized and none selected — caller should prompt with {@link Result#candidates()}. */
+        AMBIGUOUS,
+        /** An explicit application was requested that the user is not authorized for. */
+        DENIED
+    }
+
+    public record Result(Outcome outcome,
+                         Set<String> audiences,
+                         String activeApplication,
+                         List<String> candidates,
+                         boolean wildcard,
+                         String deniedApplication) {
+
+        public boolean resolved() {
+            return outcome == Outcome.RESOLVED;
+        }
+
+        static Result legacy() {
+            return new Result(Outcome.LEGACY, null, null, List.of(), false, null);
+        }
+
+        static Result resolved(Set<String> audiences, String activeApplication, boolean wildcard) {
+            return new Result(Outcome.RESOLVED, audiences, activeApplication, List.of(), wildcard, null);
+        }
+
+        static Result ambiguous(List<String> candidates, boolean wildcard) {
+            return new Result(Outcome.AMBIGUOUS, null, null, List.copyOf(candidates), wildcard, null);
+        }
+
+        static Result denied(String deniedApplication) {
+            return new Result(Outcome.DENIED, null, null, List.of(), false, deniedApplication);
+        }
+    }
+
+    /**
+     * @param authorizedApplications the membership's grant (may be null/empty, a concrete list, or contain {@code "*"})
+     * @param defaultApplication     the app to assume when several are authorized and none is requested (optional)
+     * @param requestedApplicationId the app the caller is signing into (optional)
+     */
+    public static Result resolve(List<String> authorizedApplications,
+                                 String defaultApplication,
+                                 String requestedApplicationId) {
+        List<String> granted = normalize(authorizedApplications);
+        if (granted.isEmpty()) {
+            return Result.legacy();
+        }
+
+        String requested = trimToNull(requestedApplicationId);
+        String defaultApp = trimToNull(defaultApplication);
+        boolean wildcard = granted.contains(WILDCARD);
+
+        // Concrete apps that are actually addressable as audiences (wildcard is not an audience).
+        LinkedHashSet<String> concrete = new LinkedHashSet<>(granted);
+        concrete.remove(WILDCARD);
+
+        if (wildcard) {
+            // "*" = may enter any app, but must name which; token is scoped to that one app.
+            if (requested == null) {
+                // Can't enumerate installed apps from this layer, so we can't default a "*" grant.
+                return Result.ambiguous(new ArrayList<>(concrete), true);
+            }
+            LinkedHashSet<String> aud = new LinkedHashSet<>();
+            aud.add(requested);
+            return Result.resolved(aud, requested, true);
+        }
+
+        if (requested != null) {
+            if (concrete.contains(requested)) {
+                return Result.resolved(new LinkedHashSet<>(concrete), requested, false);
+            }
+            return Result.denied(requested);
+        }
+
+        if (concrete.size() == 1) {
+            String only = concrete.iterator().next();
+            return Result.resolved(new LinkedHashSet<>(concrete), only, false);
+        }
+
+        if (defaultApp != null && concrete.contains(defaultApp)) {
+            return Result.resolved(new LinkedHashSet<>(concrete), defaultApp, false);
+        }
+
+        return Result.ambiguous(new ArrayList<>(concrete), false);
+    }
+
+    private static List<String> normalize(List<String> apps) {
+        if (apps == null) {
+            return List.of();
+        }
+        LinkedHashSet<String> out = new LinkedHashSet<>();
+        for (String app : apps) {
+            String t = trimToNull(app);
+            if (t != null) {
+                out.add(t);
+            }
+        }
+        return new ArrayList<>(out);
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProvider.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProvider.java
@@ -35,8 +35,27 @@ public interface AuthProvider {
             @JsonProperty("refreshToken") String refreshToken,
             @JsonProperty("expirationTime") long expirationTime,
             @JsonProperty("mongodbUrl") String mongodbUrl,
-            @JsonProperty("realm") String realm
+            @JsonProperty("realm") String realm,
+            // Application-scoped auth: the token's aud set (all apps authorized in the
+            // active realm) and azp (the app actively entered). Null when app scoping
+            // is not configured for this user/realm (legacy single-audience token).
+            @JsonProperty("audiences") Set<String> audiences,
+            @JsonProperty("activeApplication") String activeApplication
             ) {
+        // Backward-compatible constructor (pre application-scoping): no aud set / azp.
+        public LoginPositiveResponse(String userId,
+                                     SecurityIdentity identity,
+                                     Set<String> roles,
+                                     java.util.List<RoleAssignment> roleAssignments,
+                                     String accessToken,
+                                     String refreshToken,
+                                     long expirationTime,
+                                     String mongodbUrl,
+                                     String realm) {
+            this(userId, identity, roles, roleAssignments, accessToken, refreshToken,
+                 expirationTime, mongodbUrl, realm, null, null);
+        }
+
         public LoginPositiveResponse(String userId,
                                      SecurityIdentity identity,
                                      Set<String> roles,
@@ -56,7 +75,9 @@ public interface AuthProvider {
                  refreshToken,
                  expirationTime,
                  mongodbUrl,
-                 realm);
+                 realm,
+                 null,
+                 null);
         }
     };
 
@@ -84,6 +105,22 @@ public interface AuthProvider {
     }
 
     LoginResponse login(String userId, String password);
+
+    /**
+     * Application-scoped login (application-scoped auth). Providers that support it
+     * resolve the user's authorized application set for the active realm, scope the
+     * token's {@code aud}/{@code azp} accordingly, and may return a selection-required
+     * or not-authorized negative response. The default ignores the applicationId and
+     * behaves exactly like {@link #login(String, String)}, so providers that don't
+     * model application scoping are unaffected.
+     *
+     * @param applicationId the application being signed into, or null to let the
+     *                      provider resolve it (single → assumed, many → default/prompt)
+     */
+    default LoginResponse login(String userId, String password, String applicationId) {
+        return login(userId, password);
+    }
+
     LoginResponse refreshTokens(String refreshToken);
 
     /**

--- a/quantum-models/src/main/java/com/e2eq/framework/model/persistent/base/StateGraphManager.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/persistent/base/StateGraphManager.java
@@ -92,10 +92,17 @@ public class StateGraphManager {
         }
 
         field.setAccessible(true);
-        String currentState = (String) field.get(entity);
+        Object currentValue = field.get(entity);
+        String currentState = stateName(currentValue);
 
-        validateTransition(stateGraph.graphName(), currentState != null ? currentState : "", newState);
-        field.set(entity, newState);
+        validateTransition(stateGraph.graphName(), currentState, newState);
+        if (field.getType().isEnum()) {
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            Object enumValue = Enum.valueOf((Class<? extends Enum>) field.getType(), newState);
+            field.set(entity, enumValue);
+        } else {
+            field.set(entity, newState);
+        }
     }
 
     /**
@@ -104,6 +111,13 @@ public class StateGraphManager {
      */
     public Map<String, StringState> getStateGraphs() {
         return Collections.unmodifiableMap(stateGraphs);
+    }
+
+    public static String stateName(Object value) {
+        if (value == null) {
+            return "";
+        }
+        return value instanceof Enum<?> enumValue ? enumValue.name() : value.toString();
     }
 
     /**

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/UserRealmRole.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/UserRealmRole.java
@@ -50,6 +50,31 @@ public class UserRealmRole extends BaseModel {
    /** Roles the user holds IN THAT REALM (e.g. admin, user, viewer). */
    protected List<String> roles;
 
+   /**
+    * Applications this user may authenticate for IN THIS REALM (application-scoped
+    * auth; nested (realm, application) grant). Values are {@code ApplicationDefinition.refName}s
+    * (the app registry lives in the enterprise layer, so these are held as plain
+    * refName strings here, not a typed reference). Semantics:
+    * <ul>
+    *   <li>{@code null}/empty — NOT configured: legacy behavior (single default
+    *       audience, no app scoping). Backward compatible.</li>
+    *   <li>a concrete list — the token's {@code aud} is the whole set (multi-aud
+    *       SSO across the suite); the active app is resolved into {@code azp}.</li>
+    *   <li>{@code "*"} — admin-only, audited "any app" grant. Because the installed
+    *       app set isn't enumerable from this layer, a {@code *} grant requires the
+    *       caller to name the applicationId; the token is scoped to that app.</li>
+    * </ul>
+    */
+   protected List<String> authorizedApplications;
+
+   /**
+    * The app to assume when the caller doesn't pass an applicationId and more than
+    * one is authorized. Must be one of {@link #authorizedApplications}. Optional.
+    */
+   protected String defaultApplication;
+
+   public static final String APPLICATION_WILDCARD = "*";
+
    /** Org within the realm that sponsored/invited this user (provenance). */
    protected String sponsoringOrgRefName;
 

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/ApplicationGrantRequest.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/ApplicationGrantRequest.java
@@ -1,0 +1,27 @@
+package com.e2eq.framework.rest.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Sets the application-scoped-auth grant on a realm membership: which applications
+ * a user may authenticate for IN A REALM, and the default when several are authorized.
+ * An empty/null {@link #authorizedApplications} clears the grant (reverts to legacy,
+ * single-audience behavior). {@code "*"} is an admin-only, audited wildcard.
+ */
+@RegisterForReflection
+@Data
+@NoArgsConstructor
+public class ApplicationGrantRequest {
+    /** ApplicationDefinition refNames the user may authenticate for; may contain {@code "*"}. */
+    @JsonProperty("authorizedApplications")
+    protected List<String> authorizedApplications;
+
+    /** The app to assume when several are authorized and none is passed at login; optional. */
+    @JsonProperty("defaultApplication")
+    protected String defaultApplication;
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthRequest.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthRequest.java
@@ -21,6 +21,13 @@ public class AuthRequest  {
    protected String tenantId;
    protected String accountId;
    protected String realm;
+   /**
+    * The application the user is signing into (application-scoped auth). Optional:
+    * when omitted and exactly one app is authorized it is assumed; when multiple are
+    * authorized the default is used, or a 400 lists the choices for the login UI.
+    * Named to match the OAuth {@code client_id}/{@code audience} concept.
+    */
+   protected String applicationId;
    protected boolean rememberme;
 
    public AuthRequest(String userId, String password) {

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthResponse.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthResponse.java
@@ -22,6 +22,10 @@ public class AuthResponse {
     protected List<String> roles;
     protected String authProvider;
     protected List<AccessibleRealmInfo> accessibleRealms;
+    /** Applications this token is valid for (the token's {@code aud} set). Null when app scoping is not configured. */
+    protected List<String> applications;
+    /** The application actively entered (the token's {@code azp} claim). Null when app scoping is not configured. */
+    protected String activeApplication;
 
     // Backward-compatible constructor
     public AuthResponse(String access_token, String refresh_token, long expires_at) {

--- a/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
@@ -1,0 +1,118 @@
+package com.e2eq.framework.model.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exhaustive coverage of the application-scoped-auth resolution algorithm
+ * (LEGACY / RESOLVED / AMBIGUOUS / DENIED, plus the {@code "*"} guardrail and
+ * multi-aud semantics).
+ */
+class ApplicationAuthorizationResolverTest {
+
+    @Test
+    void nullGrant_isLegacy() {
+        var r = ApplicationAuthorizationResolver.resolve(null, null, "scheduler");
+        assertEquals(ApplicationAuthorizationResolver.Outcome.LEGACY, r.outcome());
+        assertNull(r.audiences());
+        assertNull(r.activeApplication());
+    }
+
+    @Test
+    void emptyGrant_isLegacy() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of(), null, "scheduler");
+        assertEquals(ApplicationAuthorizationResolver.Outcome.LEGACY, r.outcome());
+    }
+
+    @Test
+    void blankOnlyGrant_isLegacy() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("", "  "), null, null);
+        assertEquals(ApplicationAuthorizationResolver.Outcome.LEGACY, r.outcome());
+    }
+
+    @Test
+    void singleApp_noRequest_assumesIt() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("scheduler"), null, null);
+        assertTrue(r.resolved());
+        assertEquals("scheduler", r.activeApplication());
+        assertEquals(List.of("scheduler"), List.copyOf(r.audiences()));
+        assertFalse(r.wildcard());
+    }
+
+    @Test
+    void multipleApps_noRequest_noDefault_isAmbiguous() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("scheduler", "di"), null, null);
+        assertEquals(ApplicationAuthorizationResolver.Outcome.AMBIGUOUS, r.outcome());
+        assertEquals(List.of("scheduler", "di"), r.candidates());
+    }
+
+    @Test
+    void multipleApps_noRequest_usesDefault_audIsWholeSet() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("scheduler", "di"), "di", null);
+        assertTrue(r.resolved());
+        assertEquals("di", r.activeApplication());
+        // multi-aud: aud is the whole authorized set, not just the active app
+        assertEquals(List.of("scheduler", "di"), List.copyOf(r.audiences()));
+    }
+
+    @Test
+    void multipleApps_defaultNotInSet_isAmbiguous() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("scheduler", "di"), "ghost", null);
+        assertEquals(ApplicationAuthorizationResolver.Outcome.AMBIGUOUS, r.outcome());
+    }
+
+    @Test
+    void explicitRequest_inSet_resolvesWithWholeSetAsAud() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("scheduler", "di", "psa"), "di", "scheduler");
+        assertTrue(r.resolved());
+        assertEquals("scheduler", r.activeApplication());
+        assertEquals(List.of("scheduler", "di", "psa"), List.copyOf(r.audiences()));
+    }
+
+    @Test
+    void explicitRequest_notInSet_isDenied() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("scheduler", "di"), null, "fulfillment");
+        assertEquals(ApplicationAuthorizationResolver.Outcome.DENIED, r.outcome());
+        assertEquals("fulfillment", r.deniedApplication());
+    }
+
+    @Test
+    void wildcard_withRequest_scopesToRequestedOnly_andFlagsWildcard() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("*"), null, "anything");
+        assertTrue(r.resolved());
+        assertTrue(r.wildcard());
+        assertEquals("anything", r.activeApplication());
+        // cannot enumerate installed apps, so aud is scoped to just the named app
+        assertEquals(List.of("anything"), List.copyOf(r.audiences()));
+    }
+
+    @Test
+    void wildcard_withoutRequest_isAmbiguous() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("*"), null, null);
+        assertEquals(ApplicationAuthorizationResolver.Outcome.AMBIGUOUS, r.outcome());
+        assertTrue(r.wildcard());
+    }
+
+    @Test
+    void wildcardPlusConcrete_withRequest_scopesToRequested() {
+        // "*" dominates: any requested app is allowed and the token is scoped to it
+        var r = ApplicationAuthorizationResolver.resolve(List.of("*", "scheduler"), "scheduler", "di");
+        assertTrue(r.resolved());
+        assertTrue(r.wildcard());
+        assertEquals("di", r.activeApplication());
+        assertEquals(List.of("di"), List.copyOf(r.audiences()));
+    }
+
+    @Test
+    void requestIsTrimmed() {
+        var r = ApplicationAuthorizationResolver.resolve(List.of("scheduler", "di"), null, "  scheduler  ");
+        assertTrue(r.resolved());
+        assertEquals("scheduler", r.activeApplication());
+    }
+}

--- a/quantum-models/src/test/java/com/e2eq/framework/model/persistent/base/StateGraphManagerEnumTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/persistent/base/StateGraphManagerEnumTest.java
@@ -1,0 +1,59 @@
+package com.e2eq.framework.model.persistent.base;
+
+import com.e2eq.framework.annotations.StateGraph;
+import com.e2eq.framework.annotations.Stateful;
+import com.e2eq.framework.model.persistent.StateNode;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StateGraphManagerEnumTest {
+
+    @Test
+    void readsAndSetsEnumBackedStateFields() throws Exception {
+        StateGraphManager manager = newManager();
+        StateNode open = node("OPEN", true, false);
+        StateNode claimed = node("CLAIMED", false, false);
+        Map<String, StateNode> states = new LinkedHashMap<>();
+        states.put("OPEN", open);
+        states.put("CLAIMED", claimed);
+        manager.defineStateGraph(StringState.builder()
+                .fieldName("testEnumLifecycle")
+                .states(states)
+                .transitions(Map.of("OPEN", List.of(claimed), "CLAIMED", List.of()))
+                .build());
+
+        EnumEntity entity = new EnumEntity();
+        entity.status = Status.OPEN;
+        manager.setState(entity, "status", "CLAIMED");
+
+        assertEquals(Status.CLAIMED, entity.status);
+        assertEquals("CLAIMED", StateGraphManager.stateName(entity.status));
+    }
+
+    private static StateGraphManager newManager() throws Exception {
+        Constructor<StateGraphManager> constructor = StateGraphManager.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    private static StateNode node(String state, boolean initial, boolean terminal) {
+        return StateNode.builder().state(state).initialState(initial).finalState(terminal).build();
+    }
+
+    enum Status {
+        OPEN,
+        CLAIMED
+    }
+
+    @Stateful
+    static class EnumEntity {
+        @StateGraph(graphName = "testEnumLifecycle")
+        Status status;
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/CompletionTaskRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/CompletionTaskRepo.java
@@ -1,61 +1,564 @@
 package com.e2eq.framework.model.persistent.morphia;
 
+import com.e2eq.framework.model.persistent.InvalidStateTransitionException;
 import com.e2eq.framework.model.persistent.tasks.CompletionTask;
 import com.e2eq.framework.model.persistent.tasks.CompletionTaskGroup;
+import com.e2eq.framework.model.persistent.tasks.TaskAssignment;
+import com.e2eq.framework.model.persistent.tasks.TaskAccess;
+import com.e2eq.framework.model.persistent.tasks.TaskActivity;
+import com.e2eq.framework.model.persistent.tasks.TaskGrant;
+import com.e2eq.framework.model.persistent.tasks.TaskEligibility;
+import com.e2eq.framework.model.persistent.tasks.TaskPayload;
+import com.e2eq.framework.model.persistent.tasks.TaskProvenance;
+import com.e2eq.framework.model.persistent.tasks.TaskReminder;
+import com.e2eq.framework.model.persistent.tasks.ReminderStatus;
+import com.e2eq.framework.model.persistent.tasks.WorkItemOperationException;
+import com.e2eq.framework.model.persistent.tasks.WorkItemKind;
+import com.e2eq.framework.model.persistent.tasks.WorkItemPermission;
+import com.e2eq.framework.model.persistent.tasks.WorkItemVisibility;
+import com.e2eq.framework.model.persistent.tasks.WorkerType;
+import com.mongodb.client.model.ReturnDocument;
+import dev.morphia.ModifyOptions;
+import dev.morphia.query.FindOptions;
 import dev.morphia.query.Query;
+import dev.morphia.query.Sort;
+import dev.morphia.query.filters.Filter;
 import dev.morphia.query.filters.Filters;
+import dev.morphia.query.updates.UpdateOperator;
+import dev.morphia.query.updates.UpdateOperators;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.bson.types.ObjectId;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 /**
- * Repository for {@link CompletionTask} entities.  Basic helper methods are
- * provided to create tasks and mark them as completed.
+ * Repository for legacy completion tasks and governed work items. The work-item
+ * methods enforce eligibility, ownership, leases, state transitions, and
+ * optimistic revision checks at the persistence boundary.
  */
 @ApplicationScoped
 public class CompletionTaskRepo extends MorphiaRepo<CompletionTask> {
 
+    private static final int MAX_QUEUE_PAGE_SIZE = 200;
+
     @Inject
     CompletionTaskGroupRepo groupRepo;
 
+    /** Legacy creation path retained for existing onboarding integrations. */
     public CompletionTask createTask(CompletionTask task, String groupId) {
         return createTask(getSecurityContextRealmId(), task, groupId);
     }
 
+    /** Legacy creation path retained for existing onboarding integrations. */
     public CompletionTask createTask(String realm, CompletionTask task, String groupId) {
-        if (groupId != null) {
-            Optional<CompletionTaskGroup> group = groupRepo.findById(new ObjectId(groupId), realm, true);
-            group.ifPresent(task::setGroup);
-        }
+        attachGroup(realm, task, groupId);
+        Date now = new Date();
         task.setStatus(CompletionTask.Status.PENDING);
-        task.setCreatedDate(new java.util.Date());
+        task.setCreatedDate(now);
+        task.setUpdatedDate(now);
         CompletionTask saved = save(realm, task);
-        if (groupId != null) {
-            groupRepo.updateStatus(realm, groupId, CompletionTaskGroup.Status.RUNNING);
-        }
+        markGroupRunning(realm, groupId);
         return saved;
     }
 
+    public CompletionTask createWorkItem(CompletionTask task, String groupId, String createdBy) {
+        return createWorkItem(getSecurityContextRealmId(), task, groupId, createdBy);
+    }
+
+    public CompletionTask createWorkItem(String realm,
+                                         CompletionTask task,
+                                         String groupId,
+                                         String createdBy) {
+        validateNewWorkItem(task);
+        if (task.getKind() == null) {
+            task.setKind(WorkItemKind.PROCESS_TASK);
+        }
+        attachGroup(realm, task, groupId);
+        Date now = new Date();
+        task.setStatus(CompletionTask.Status.OPEN);
+        task.setCreatedDate(now);
+        task.setUpdatedDate(now);
+        if (task.getPriority() == null) {
+            task.setPriority(0);
+        }
+        if (task.getEligibility() == null) {
+            task.setEligibility(TaskEligibility.builder()
+                    .workerTypes(new LinkedHashSet<>(Set.of(WorkerType.HUMAN)))
+                    .build());
+        }
+        if (task.getAssignment() == null) {
+            task.setAssignment(TaskAssignment.builder().queueRef("default").build());
+        }
+        if (task.getProvenance() != null && task.getProvenance().getCreatedBy() == null) {
+            task.getProvenance().setCreatedBy(createdBy);
+        }
+        CompletionTask saved = save(realm, task);
+        markGroupRunning(realm, groupId);
+        return saved;
+    }
+
+    /**
+     * Create participant-owned work. Ownership, creator attribution, initial
+     * visibility, and responsibility are server assigned and cannot be widened
+     * by a client supplied body.
+     */
+    public CompletionTask createParticipantWorkItem(CompletionTask task, String createdBy) {
+        validateNewWorkItem(task);
+        Date now = new Date();
+        task.setKind(WorkItemKind.TODO);
+        task.setStatus(CompletionTask.Status.OPEN);
+        task.setCreatedDate(now);
+        task.setUpdatedDate(now);
+        task.setCompletedDate(null);
+        task.setResult(null);
+        task.setPriority(task.getPriority() == null ? 0 : task.getPriority());
+        task.setEligibility(TaskEligibility.builder()
+                .workerTypes(new LinkedHashSet<>(Set.of(WorkerType.HUMAN)))
+                .build());
+        task.setAssignment(TaskAssignment.builder()
+                .assigneeRef(createdBy)
+                .assignedBy(createdBy)
+                .assignedAt(now)
+                .build());
+        task.setAccess(TaskAccess.builder()
+                .ownerRef(createdBy)
+                .visibility(WorkItemVisibility.PRIVATE)
+                .build());
+        TaskProvenance provenance = task.getProvenance() == null
+                ? TaskProvenance.builder().build() : task.getProvenance();
+        provenance.setCreatedBy(createdBy);
+        task.setProvenance(provenance);
+        task.setReminders(new ArrayList<>());
+        task.setActivity(new ArrayList<>(List.of(activity("CREATED", createdBy, "Private to-do created", now))));
+        return save(getSecurityContextRealmId(), task);
+    }
+
+    /** Indexed participant projection; queue claiming semantics remain unchanged. */
+    public List<CompletionTask> listParticipating(String actorRef, String workbookRef, int limit) {
+        if (actorRef == null || actorRef.isBlank()) {
+            throw failure(WorkItemOperationException.Code.NOT_ELIGIBLE, "An authenticated actor is required");
+        }
+        int safeLimit = Math.max(1, Math.min(limit, MAX_QUEUE_PAGE_SIZE));
+        List<Filter> filters = new ArrayList<>();
+        filters.add(Filters.eq("kind", WorkItemKind.TODO));
+        if (workbookRef != null && !workbookRef.isBlank()) {
+            filters.add(Filters.eq("subject.workbookRef", workbookRef));
+        }
+        filters.add(Filters.or(
+                Filters.eq("access.ownerRef", actorRef),
+                Filters.eq("assignment.assigneeRef", actorRef),
+                Filters.eq("access.grants.principalRef", actorRef)));
+        Filter[] securedFilters = getFilterArray(filters, CompletionTask.class);
+        List<CompletionTask> result = new ArrayList<>();
+        getMorphiaDataStoreWrapper().getDataStore(getSecurityContextRealmId())
+                .find(CompletionTask.class)
+                .filter(securedFilters)
+                .iterator(new FindOptions().sort(Sort.descending("updatedDate")).limit(safeLimit))
+                .forEachRemaining(task -> {
+                    if (canViewParticipant(task, actorRef)) result.add(task);
+                });
+        return result;
+    }
+
+    public CompletionTask getParticipantVisible(String id, String actorRef) {
+        CompletionTask task = requireParticipantTask(id);
+        requireParticipantView(task, actorRef);
+        return task;
+    }
+
+    public CompletionTask updateParticipantWorkItem(String id,
+                                                    long expectedVersion,
+                                                    String actorRef,
+                                                    String summary,
+                                                    String details,
+                                                    Date dueDate) {
+        CompletionTask current = requireParticipantTask(id);
+        requireParticipantEdit(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        if (summary == null || summary.isBlank()) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST, "summary is required");
+        }
+        Date now = new Date();
+        List<TaskActivity> activity = appendActivity(current, "UPDATED", actorRef, "To-do details updated", now);
+        return atomicParticipantUpdate(current, expectedVersion,
+                UpdateOperators.set("summary", summary.trim()),
+                UpdateOperators.set("details", blankToNull(details)),
+                UpdateOperators.set("dueDate", dueDate),
+                UpdateOperators.set("activity", activity),
+                UpdateOperators.set("updatedDate", now));
+    }
+
+    public CompletionTask shareParticipantWorkItem(String id,
+                                                   long expectedVersion,
+                                                   String actorRef,
+                                                   WorkItemVisibility visibility,
+                                                   List<TaskGrant> grants) {
+        CompletionTask current = requireParticipantTask(id);
+        requireOwner(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        List<TaskGrant> normalized = normalizeGrants(grants, actorRef);
+        WorkItemVisibility effectiveVisibility = normalized.isEmpty()
+                ? WorkItemVisibility.PRIVATE : WorkItemVisibility.RESTRICTED;
+        if (visibility != null && visibility != effectiveVisibility) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST,
+                    "visibility must be PRIVATE with no grants or RESTRICTED with at least one grant");
+        }
+        TaskAccess access = TaskAccess.builder()
+                .ownerRef(actorRef)
+                .visibility(effectiveVisibility)
+                .grants(normalized)
+                .build();
+        Date now = new Date();
+        return atomicParticipantUpdate(current, expectedVersion,
+                UpdateOperators.set("access", access),
+                UpdateOperators.set("activity", appendActivity(current, "SHARED", actorRef,
+                        normalized.isEmpty() ? "Sharing removed" : "Shared with " + normalized.size() + " participant(s)", now)),
+                UpdateOperators.set("updatedDate", now));
+    }
+
+    public CompletionTask assignParticipantWorkItem(String id,
+                                                    long expectedVersion,
+                                                    String actorRef,
+                                                    String assigneeRef) {
+        CompletionTask current = requireParticipantTask(id);
+        requireOwner(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        String effectiveAssignee = blankToNull(assigneeRef);
+        if (effectiveAssignee == null) effectiveAssignee = actorRef;
+        if (!Objects.equals(effectiveAssignee, actorRef)
+                && (current.getAccess() == null
+                || !current.getAccess().permits(effectiveAssignee, WorkItemPermission.EDIT))) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST,
+                    "The assignee must have EDIT access to the work item");
+        }
+        Date now = new Date();
+        return atomicParticipantUpdate(current, expectedVersion,
+                UpdateOperators.set("assignment.assigneeRef", effectiveAssignee),
+                UpdateOperators.set("assignment.assignedBy", actorRef),
+                UpdateOperators.set("assignment.assignedAt", now),
+                UpdateOperators.set("activity", appendActivity(current, "ASSIGNED", actorRef,
+                        "Assigned to " + effectiveAssignee, now)),
+                UpdateOperators.set("updatedDate", now));
+    }
+
+    public CompletionTask addParticipantReminder(String id,
+                                                 long expectedVersion,
+                                                 String actorRef,
+                                                 Date triggerAt,
+                                                 List<String> recipientRefs) {
+        CompletionTask current = requireParticipantTask(id);
+        requireParticipantEdit(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        if (triggerAt == null || !triggerAt.after(new Date())) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST, "triggerAt must be in the future");
+        }
+        List<String> recipients = recipientRefs == null || recipientRefs.isEmpty()
+                ? List.of(actorRef)
+                : recipientRefs.stream().filter(Objects::nonNull).map(String::trim)
+                .filter(value -> !value.isEmpty()).distinct().toList();
+        if (recipients.isEmpty() || recipients.stream().anyMatch(ref -> !canViewParticipant(current, ref))) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST,
+                    "Every reminder recipient must be able to view the work item");
+        }
+        Date now = new Date();
+        TaskReminder reminder = TaskReminder.builder()
+                .reminderId(UUID.randomUUID().toString())
+                .triggerAt(triggerAt)
+                .createdBy(actorRef)
+                .recipientRefs(new ArrayList<>(recipients))
+                .build();
+        List<TaskReminder> reminders = new ArrayList<>(safeList(current.getReminders()));
+        reminders.add(reminder);
+        return atomicParticipantUpdate(current, expectedVersion,
+                UpdateOperators.set("reminders", reminders),
+                UpdateOperators.set("activity", appendActivity(current, "REMINDER_SCHEDULED", actorRef,
+                        "Reminder scheduled for " + triggerAt, now)),
+                UpdateOperators.set("updatedDate", now));
+    }
+
+    public CompletionTask cancelParticipantReminder(String id,
+                                                    String reminderId,
+                                                    long expectedVersion,
+                                                    String actorRef) {
+        CompletionTask current = requireParticipantTask(id);
+        requireParticipantEdit(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        List<TaskReminder> reminders = new ArrayList<>(safeList(current.getReminders()));
+        TaskReminder reminder = reminders.stream()
+                .filter(value -> value != null && Objects.equals(reminderId, value.getReminderId()))
+                .findFirst()
+                .orElseThrow(() -> failure(WorkItemOperationException.Code.NOT_FOUND,
+                        "Reminder " + reminderId + " was not found"));
+        if (!Objects.equals(actorRef, reminder.getCreatedBy())
+                && (current.getAccess() == null || !current.getAccess().isOwner(actorRef))) {
+            throw failure(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                    "Only the reminder creator or work-item owner may cancel it");
+        }
+        Date now = new Date();
+        reminder.setStatus(ReminderStatus.CANCELLED);
+        reminder.setCancelledAt(now);
+        return atomicParticipantUpdate(current, expectedVersion,
+                UpdateOperators.set("reminders", reminders),
+                UpdateOperators.set("activity", appendActivity(current, "REMINDER_CANCELLED", actorRef,
+                        "Reminder cancelled", now)),
+                UpdateOperators.set("updatedDate", now));
+    }
+
+    public CompletionTask completeParticipantWorkItem(String id, long expectedVersion, String actorRef) {
+        return transitionParticipantWorkItem(id, expectedVersion, actorRef,
+                CompletionTask.Status.OPEN, CompletionTask.Status.COMPLETED, "COMPLETED", "To-do completed");
+    }
+
+    public CompletionTask reopenParticipantWorkItem(String id, long expectedVersion, String actorRef) {
+        return transitionParticipantWorkItem(id, expectedVersion, actorRef,
+                CompletionTask.Status.COMPLETED, CompletionTask.Status.OPEN, "REOPENED", "To-do reopened");
+    }
+
+    public List<CompletionTask> listEligible(WorkerType workerType,
+                                             Set<String> roles,
+                                             Set<String> profiles,
+                                             Set<String> capabilities,
+                                             String queueRef,
+                                             int limit) {
+        String realm = getSecurityContextRealmId();
+        int safeLimit = Math.max(1, Math.min(limit, MAX_QUEUE_PAGE_SIZE));
+        List<Filter> filters = new ArrayList<>();
+        filters.add(Filters.in("status", List.of(CompletionTask.Status.OPEN, CompletionTask.Status.PENDING)));
+        if (queueRef != null && !queueRef.isBlank()) {
+            filters.add(Filters.eq("assignment.queueRef", queueRef));
+        }
+
+        Filter[] securedFilters = getFilterArray(filters, CompletionTask.class);
+        Query<CompletionTask> query = getMorphiaDataStoreWrapper().getDataStore(realm)
+                .find(CompletionTask.class)
+                .filter(securedFilters);
+        FindOptions options = new FindOptions()
+                .sort(Sort.descending("priority"), Sort.ascending("createdDate"))
+                .limit(MAX_QUEUE_PAGE_SIZE);
+
+        List<CompletionTask> eligible = new ArrayList<>();
+        query.iterator(options).forEachRemaining(task -> {
+            if (eligible.size() < safeLimit && isEligible(task, workerType, roles, profiles, capabilities)) {
+                eligible.add(task);
+            }
+        });
+        return eligible;
+    }
+
+    public List<CompletionTask> listClaimedBy(String actorRef, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, MAX_QUEUE_PAGE_SIZE));
+        List<Filter> filters = new ArrayList<>();
+        filters.add(Filters.eq("assignment.claimedBy", actorRef));
+        filters.add(Filters.in("status", List.of(
+                CompletionTask.Status.CLAIMED,
+                CompletionTask.Status.IN_PROGRESS)));
+        Filter[] securedFilters = getFilterArray(filters, CompletionTask.class);
+
+        List<CompletionTask> tasks = new ArrayList<>();
+        getMorphiaDataStoreWrapper().getDataStore(getSecurityContextRealmId())
+                .find(CompletionTask.class)
+                .filter(securedFilters)
+                .iterator(new FindOptions().sort(Sort.descending("priority")).limit(safeLimit))
+                .forEachRemaining(tasks::add);
+        return tasks;
+    }
+
+    /**
+     * Resolve a deep-linked work item without weakening queue visibility. A
+     * worker may read its own claim, or an open item it is currently eligible
+     * to claim. All reads still pass through the realm security filter.
+     */
+    public CompletionTask getVisible(String id,
+                                     String actorRef,
+                                     WorkerType workerType,
+                                     Set<String> roles,
+                                     Set<String> profiles,
+                                     Set<String> capabilities) {
+        CompletionTask task = requireTask(getSecurityContextRealmId(), id);
+        TaskAssignment assignment = task.getAssignment();
+        if (assignment != null && Objects.equals(actorRef, assignment.getClaimedBy())) {
+            return task;
+        }
+        if ((task.getStatus() == CompletionTask.Status.OPEN
+                || task.getStatus() == CompletionTask.Status.PENDING)
+                && isEligible(task, workerType, roles, profiles, capabilities)) {
+            return task;
+        }
+        throw failure(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                "Actor may not view work item " + id);
+    }
+
+    public CompletionTask claim(String id,
+                                long expectedVersion,
+                                String actorRef,
+                                WorkerType workerType,
+                                Set<String> roles,
+                                Set<String> profiles,
+                                Set<String> capabilities,
+                                Duration leaseDuration) {
+        String realm = getSecurityContextRealmId();
+        CompletionTask current = requireTask(realm, id);
+        requireExpectedVersion(current, expectedVersion);
+        if (!isEligible(current, workerType, roles, profiles, capabilities)) {
+            throw failure(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                    "Actor is not eligible to claim work item " + id);
+        }
+        requireActionAllowed(current, "CLAIM");
+        if (current.getStatus() != CompletionTask.Status.OPEN
+                && current.getStatus() != CompletionTask.Status.PENDING) {
+            throw invalidTransition(current, CompletionTask.Status.CLAIMED);
+        }
+
+        Date now = new Date();
+        Date leaseUntil = leaseDuration == null ? null : Date.from(now.toInstant().plus(leaseDuration));
+        return atomicTransition(realm, current, expectedVersion, actorRef,
+                List.of(CompletionTask.Status.OPEN, CompletionTask.Status.PENDING),
+                CompletionTask.Status.CLAIMED,
+                UpdateOperators.set("assignment.claimedBy", actorRef),
+                UpdateOperators.set("assignment.claimedWorkerType", workerType),
+                UpdateOperators.set("assignment.claimedAt", now),
+                UpdateOperators.set("assignment.heartbeatAt", now),
+                UpdateOperators.set("assignment.leaseUntil", leaseUntil));
+    }
+
+    public CompletionTask start(String id, long expectedVersion, String actorRef) {
+        requireActionAllowed(requireTask(getSecurityContextRealmId(), id), "START");
+        return ownedTransition(id, expectedVersion, actorRef,
+                List.of(CompletionTask.Status.CLAIMED), CompletionTask.Status.IN_PROGRESS,
+                UpdateOperators.set("startedDate", new Date()));
+    }
+
+    public CompletionTask complete(String id,
+                                   long expectedVersion,
+                                   String actorRef,
+                                   String expectedAssessmentVersion,
+                                   String result,
+                                   TaskPayload resultPayload) {
+        requireActionAllowed(requireTask(getSecurityContextRealmId(), id), "COMPLETE");
+        CompletionTask current = requireTask(getSecurityContextRealmId(), id);
+        requireAssessmentVersion(current, expectedAssessmentVersion);
+        TaskPayload capturedPayload = validateAndAttributeResult(current, resultPayload, actorRef);
+        CompletionTask task = ownedTransition(id, expectedVersion, actorRef,
+                List.of(CompletionTask.Status.CLAIMED, CompletionTask.Status.IN_PROGRESS),
+                CompletionTask.Status.COMPLETED,
+                UpdateOperators.set("result", result),
+                UpdateOperators.set("resultPayload", capturedPayload),
+                UpdateOperators.set("completedDate", new Date()));
+        notifyGroup(task);
+        return task;
+    }
+
+    public CompletionTask fail(String id,
+                               long expectedVersion,
+                               String actorRef,
+                               String result,
+                               TaskPayload resultPayload) {
+        requireActionAllowed(requireTask(getSecurityContextRealmId(), id), "FAIL");
+        CompletionTask current = requireTask(getSecurityContextRealmId(), id);
+        TaskPayload capturedPayload = validateAndAttributeResult(current, resultPayload, actorRef);
+        CompletionTask task = ownedTransition(id, expectedVersion, actorRef,
+                List.of(CompletionTask.Status.CLAIMED, CompletionTask.Status.IN_PROGRESS),
+                CompletionTask.Status.FAILED,
+                UpdateOperators.set("result", result),
+                UpdateOperators.set("resultPayload", capturedPayload),
+                UpdateOperators.set("completedDate", new Date()));
+        notifyGroup(task);
+        return task;
+    }
+
+    public CompletionTask release(String id, long expectedVersion, String actorRef) {
+        requireActionAllowed(requireTask(getSecurityContextRealmId(), id), "RELEASE");
+        return ownedTransition(id, expectedVersion, actorRef,
+                List.of(CompletionTask.Status.CLAIMED, CompletionTask.Status.IN_PROGRESS),
+                CompletionTask.Status.OPEN,
+                UpdateOperators.unset("assignment.claimedBy"),
+                UpdateOperators.unset("assignment.claimedWorkerType"),
+                UpdateOperators.unset("assignment.claimedAt"),
+                UpdateOperators.unset("assignment.heartbeatAt"),
+                UpdateOperators.unset("assignment.leaseUntil"));
+    }
+
+    public CompletionTask heartbeat(String id,
+                                    long expectedVersion,
+                                    String actorRef,
+                                    Duration leaseDuration) {
+        String realm = getSecurityContextRealmId();
+        CompletionTask current = requireTask(realm, id);
+        requireActionAllowed(current, "HEARTBEAT");
+        requireOwnedAndLive(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        Date now = new Date();
+        Date leaseUntil = Date.from(now.toInstant().plus(leaseDuration));
+        return atomicUpdate(realm, current, expectedVersion, actorRef,
+                List.of(CompletionTask.Status.CLAIMED, CompletionTask.Status.IN_PROGRESS),
+                UpdateOperators.set("assignment.heartbeatAt", now),
+                UpdateOperators.set("assignment.leaseUntil", leaseUntil),
+                UpdateOperators.set("updatedDate", now));
+    }
+
+    public CompletionTask cancel(String id, long expectedVersion) {
+        String realm = getSecurityContextRealmId();
+        CompletionTask current = requireTask(realm, id);
+        requireExpectedVersion(current, expectedVersion);
+        requireActionAllowed(current, "CANCEL");
+        List<CompletionTask.Status> allowed = List.of(
+                CompletionTask.Status.OPEN,
+                CompletionTask.Status.CLAIMED,
+                CompletionTask.Status.IN_PROGRESS);
+        if (!allowed.contains(current.getStatus())) {
+            throw invalidTransition(current, CompletionTask.Status.CANCELLED);
+        }
+        CompletionTask task = atomicTransition(realm, current, expectedVersion, null,
+                allowed, CompletionTask.Status.CANCELLED,
+                UpdateOperators.set("completedDate", new Date()));
+        notifyGroup(task);
+        return task;
+    }
+
+    public CompletionTask expire(String id, long expectedVersion) {
+        String realm = getSecurityContextRealmId();
+        CompletionTask current = requireTask(realm, id);
+        requireExpectedVersion(current, expectedVersion);
+        List<CompletionTask.Status> allowed = List.of(
+                CompletionTask.Status.OPEN,
+                CompletionTask.Status.CLAIMED,
+                CompletionTask.Status.IN_PROGRESS);
+        if (!allowed.contains(current.getStatus())) {
+            throw invalidTransition(current, CompletionTask.Status.EXPIRED);
+        }
+        CompletionTask task = atomicTransition(realm, current, expectedVersion, null,
+                allowed, CompletionTask.Status.EXPIRED,
+                UpdateOperators.set("completedDate", new Date()));
+        notifyGroup(task);
+        return task;
+    }
+
+    /** Legacy completion path retained for existing clients. */
     public Optional<CompletionTask> completeTask(String id, CompletionTask.Status status, String result) {
         return completeTask(getSecurityContextRealmId(), id, status, result);
     }
 
+    /** Legacy completion path retained for existing clients. */
     public Optional<CompletionTask> completeTask(String realm, String id, CompletionTask.Status status, String result) {
         Optional<CompletionTask> opt = findById(new ObjectId(id), realm, true);
         if (opt.isPresent()) {
             CompletionTask task = opt.get();
             task.setStatus(status);
-            task.setCompletedDate(new java.util.Date());
+            task.setCompletedDate(new Date());
+            task.setUpdatedDate(new Date());
             task.setResult(result);
             save(realm, task);
-            if (task.getGroup() != null) {
-                groupRepo.notifyGroup(task.getGroup().getId().toString(), "task:" + id + ":" + status);
-                refreshGroupStatus(realm, task.getGroup().getId().toString());
-            }
+            notifyGroup(realm, task);
             return Optional.of(task);
         }
         return Optional.empty();
@@ -76,20 +579,370 @@ public class CompletionTaskRepo extends MorphiaRepo<CompletionTask> {
         return tasks;
     }
 
+    private CompletionTask ownedTransition(String id,
+                                           long expectedVersion,
+                                           String actorRef,
+                                           List<CompletionTask.Status> allowedStatuses,
+                                           CompletionTask.Status targetStatus,
+                                           UpdateOperator... updates) {
+        String realm = getSecurityContextRealmId();
+        CompletionTask current = requireTask(realm, id);
+        requireOwnedAndLive(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        if (!allowedStatuses.contains(current.getStatus())) {
+            throw invalidTransition(current, targetStatus);
+        }
+        return atomicTransition(realm, current, expectedVersion, actorRef,
+                allowedStatuses, targetStatus, updates);
+    }
+
+    private CompletionTask transitionParticipantWorkItem(String id,
+                                                         long expectedVersion,
+                                                         String actorRef,
+                                                         CompletionTask.Status expectedStatus,
+                                                         CompletionTask.Status targetStatus,
+                                                         String action,
+                                                         String detail) {
+        CompletionTask current = requireParticipantTask(id);
+        requireParticipantEdit(current, actorRef);
+        requireExpectedVersion(current, expectedVersion);
+        if (current.getStatus() != expectedStatus) {
+            throw invalidTransition(current, targetStatus);
+        }
+        try {
+            stateGraphManager.validateTransition(
+                    com.e2eq.framework.model.persistent.tasks.CompletionTaskStateGraph.GRAPH_NAME,
+                    expectedStatus.name(), targetStatus.name());
+        } catch (InvalidStateTransitionException e) {
+            throw failure(WorkItemOperationException.Code.INVALID_TRANSITION, e.getMessage());
+        }
+        Date now = new Date();
+        List<UpdateOperator> updates = new ArrayList<>();
+        updates.add(UpdateOperators.set("status", targetStatus));
+        updates.add(UpdateOperators.set("completedDate",
+                targetStatus == CompletionTask.Status.COMPLETED ? now : null));
+        updates.add(UpdateOperators.set("activity", appendActivity(current, action, actorRef, detail, now)));
+        updates.add(UpdateOperators.set("updatedDate", now));
+        return atomicParticipantUpdate(current, expectedVersion,
+                updates.toArray(new UpdateOperator[0]));
+    }
+
+    private CompletionTask atomicParticipantUpdate(CompletionTask current,
+                                                   long expectedVersion,
+                                                   UpdateOperator... updates) {
+        List<UpdateOperator> allUpdates = new ArrayList<>();
+        allUpdates.add(UpdateOperators.inc("version", 1L));
+        allUpdates.addAll(Arrays.asList(updates));
+        CompletionTask updated = getMorphiaDataStoreWrapper().getDataStore(getSecurityContextRealmId())
+                .find(CompletionTask.class)
+                .filter(Filters.eq("_id", current.getId()),
+                        Filters.eq("version", expectedVersion),
+                        Filters.eq("kind", WorkItemKind.TODO))
+                .modify(new ModifyOptions().returnDocument(ReturnDocument.AFTER),
+                        allUpdates.get(0), allUpdates.subList(1, allUpdates.size()).toArray(new UpdateOperator[0]));
+        if (updated == null) {
+            throw failure(WorkItemOperationException.Code.REVISION_CONFLICT,
+                    "Work item changed before the operation could be applied; refresh and retry");
+        }
+        return updated;
+    }
+
+    private CompletionTask atomicTransition(String realm,
+                                            CompletionTask current,
+                                            long expectedVersion,
+                                            String actorRef,
+                                            List<CompletionTask.Status> allowedStatuses,
+                                            CompletionTask.Status targetStatus,
+                                            UpdateOperator... updates) {
+        try {
+            stateGraphManager.validateTransition(
+                    com.e2eq.framework.model.persistent.tasks.CompletionTaskStateGraph.GRAPH_NAME,
+                    current.getStatus().name(), targetStatus.name());
+        } catch (InvalidStateTransitionException e) {
+            throw new WorkItemOperationException(
+                    WorkItemOperationException.Code.INVALID_TRANSITION, e.getMessage());
+        }
+
+        List<UpdateOperator> allUpdates = new ArrayList<>();
+        allUpdates.add(UpdateOperators.set("status", targetStatus));
+        allUpdates.add(UpdateOperators.set("updatedDate", new Date()));
+        allUpdates.add(UpdateOperators.inc("version", 1L));
+        allUpdates.addAll(Arrays.asList(updates));
+        return atomicModify(realm, current, expectedVersion, actorRef, allowedStatuses, allUpdates);
+    }
+
+    private CompletionTask atomicUpdate(String realm,
+                                        CompletionTask current,
+                                        long expectedVersion,
+                                        String actorRef,
+                                        List<CompletionTask.Status> allowedStatuses,
+                                        UpdateOperator... updates) {
+        List<UpdateOperator> allUpdates = new ArrayList<>();
+        allUpdates.add(UpdateOperators.inc("version", 1L));
+        allUpdates.addAll(Arrays.asList(updates));
+        return atomicModify(realm, current, expectedVersion, actorRef, allowedStatuses, allUpdates);
+    }
+
+    private CompletionTask atomicModify(String realm,
+                                        CompletionTask current,
+                                        long expectedVersion,
+                                        String actorRef,
+                                        List<CompletionTask.Status> allowedStatuses,
+                                        List<UpdateOperator> updates) {
+        List<Filter> filters = new ArrayList<>();
+        filters.add(Filters.eq("_id", current.getId()));
+        filters.add(Filters.eq("version", expectedVersion));
+        filters.add(Filters.in("status", allowedStatuses));
+        if (actorRef != null && current.getStatus() != CompletionTask.Status.OPEN
+                && current.getStatus() != CompletionTask.Status.PENDING) {
+            filters.add(Filters.eq("assignment.claimedBy", actorRef));
+        }
+
+        CompletionTask updated = getMorphiaDataStoreWrapper().getDataStore(realm)
+                .find(CompletionTask.class)
+                .filter(filters.toArray(new Filter[0]))
+                .modify(new ModifyOptions().returnDocument(ReturnDocument.AFTER),
+                        updates.get(0), updates.subList(1, updates.size()).toArray(new UpdateOperator[0]));
+        if (updated == null) {
+            throw failure(WorkItemOperationException.Code.REVISION_CONFLICT,
+                    "Work item changed before the operation could be applied; refresh and retry");
+        }
+        return updated;
+    }
+
+    private CompletionTask requireTask(String realm, String id) {
+        if (id == null || !ObjectId.isValid(id)) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST, "Invalid work item id");
+        }
+        return findById(new ObjectId(id), realm, false)
+                .orElseThrow(() -> failure(WorkItemOperationException.Code.NOT_FOUND,
+                        "Work item " + id + " was not found"));
+    }
+
+    private CompletionTask requireParticipantTask(String id) {
+        CompletionTask task = requireTask(getSecurityContextRealmId(), id);
+        if (task.getKind() != WorkItemKind.TODO || task.getAccess() == null) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST,
+                    "Work item " + id + " is not participant-owned work");
+        }
+        return task;
+    }
+
+    private void requireParticipantView(CompletionTask task, String actorRef) {
+        if (!canViewParticipant(task, actorRef)) {
+            throw failure(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                    "Actor may not view work item " + task.getId());
+        }
+    }
+
+    private void requireParticipantEdit(CompletionTask task, String actorRef) {
+        TaskAccess access = task.getAccess();
+        boolean assigned = task.getAssignment() != null
+                && Objects.equals(actorRef, task.getAssignment().getAssigneeRef());
+        if (!assigned && (access == null || !access.permits(actorRef, WorkItemPermission.EDIT))) {
+            throw failure(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                    "Actor may not edit work item " + task.getId());
+        }
+    }
+
+    private void requireOwner(CompletionTask task, String actorRef) {
+        if (task.getAccess() == null || !task.getAccess().isOwner(actorRef)) {
+            throw failure(WorkItemOperationException.Code.NOT_ELIGIBLE,
+                    "Only the work-item owner may change sharing or assignment");
+        }
+    }
+
+    private boolean canViewParticipant(CompletionTask task, String actorRef) {
+        if (task == null || actorRef == null || task.getKind() != WorkItemKind.TODO) return false;
+        if (task.getAssignment() != null && Objects.equals(actorRef, task.getAssignment().getAssigneeRef())) {
+            return true;
+        }
+        return task.getAccess() != null && task.getAccess().permits(actorRef, WorkItemPermission.VIEW);
+    }
+
+    private List<TaskGrant> normalizeGrants(List<TaskGrant> grants, String ownerRef) {
+        if (grants == null) return List.of();
+        java.util.LinkedHashMap<String, TaskGrant> unique = new java.util.LinkedHashMap<>();
+        for (TaskGrant grant : grants) {
+            if (grant == null || grant.getPrincipalRef() == null || grant.getPrincipalRef().isBlank()) continue;
+            String principal = grant.getPrincipalRef().trim();
+            if (Objects.equals(principal, ownerRef)) continue;
+            Set<WorkItemPermission> permissions = grant.getPermissions() == null
+                    ? new LinkedHashSet<>() : new LinkedHashSet<>(grant.getPermissions());
+            if (permissions.isEmpty()) permissions.add(WorkItemPermission.VIEW);
+            permissions.add(WorkItemPermission.VIEW);
+            unique.put(principal, TaskGrant.builder()
+                    .principalRef(principal)
+                    .permissions(permissions)
+                    .build());
+        }
+        return new ArrayList<>(unique.values());
+    }
+
+    private List<TaskActivity> appendActivity(CompletionTask task,
+                                              String action,
+                                              String actorRef,
+                                              String detail,
+                                              Date occurredAt) {
+        List<TaskActivity> result = new ArrayList<>(safeList(task.getActivity()));
+        result.add(activity(action, actorRef, detail, occurredAt));
+        return result;
+    }
+
+    private static TaskActivity activity(String action, String actorRef, String detail, Date occurredAt) {
+        return TaskActivity.builder()
+                .action(action)
+                .actorRef(actorRef)
+                .detail(detail)
+                .occurredAt(occurredAt)
+                .build();
+    }
+
+    private static <T> List<T> safeList(List<T> values) {
+        return values == null ? List.of() : values;
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    private void requireExpectedVersion(CompletionTask task, long expectedVersion) {
+        if (task.getVersion() == null || task.getVersion() != expectedVersion) {
+            throw failure(WorkItemOperationException.Code.REVISION_CONFLICT,
+                    "Expected revision " + expectedVersion + " but found " + task.getVersion());
+        }
+    }
+
+    private void requireAssessmentVersion(CompletionTask task, String expectedAssessmentVersion) {
+        String taskAssessmentVersion = task.getSubject() == null
+                ? null : task.getSubject().getAssessmentVersion();
+        if (taskAssessmentVersion == null || taskAssessmentVersion.isBlank()) {
+            return;
+        }
+        if (!Objects.equals(taskAssessmentVersion, expectedAssessmentVersion)) {
+            throw failure(WorkItemOperationException.Code.REVISION_CONFLICT,
+                    "Decision assessment changed before completion; refresh the work item and review the current evidence");
+        }
+    }
+
+    private void requireOwnedAndLive(CompletionTask task, String actorRef) {
+        TaskAssignment assignment = task.getAssignment();
+        if (assignment == null || !Objects.equals(actorRef, assignment.getClaimedBy())) {
+            throw failure(WorkItemOperationException.Code.NOT_ASSIGNED,
+                    "Work item is not assigned to actor " + actorRef);
+        }
+        if (assignment.getLeaseUntil() != null && assignment.getLeaseUntil().before(new Date())) {
+            throw failure(WorkItemOperationException.Code.LEASE_EXPIRED,
+                    "Work item lease has expired and must be reclaimed");
+        }
+    }
+
+    private boolean isEligible(CompletionTask task,
+                               WorkerType workerType,
+                               Set<String> roles,
+                               Set<String> profiles,
+                               Set<String> capabilities) {
+        TaskEligibility eligibility = task.getEligibility();
+        if (eligibility == null) {
+            return workerType == null || workerType == WorkerType.HUMAN;
+        }
+        return eligibility.permits(workerType, safeSet(roles), safeSet(profiles), safeSet(capabilities));
+    }
+
+    private Set<String> safeSet(Set<String> values) {
+        return values == null ? Set.of() : values;
+    }
+
+    private void validateNewWorkItem(CompletionTask task) {
+        if (task == null) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST, "Work item body is required");
+        }
+        if (task.getTaskType() == null || task.getTaskType().isBlank()) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST, "taskType is required");
+        }
+        if (task.getSummary() == null || task.getSummary().isBlank()) {
+            throw failure(WorkItemOperationException.Code.INVALID_REQUEST, "summary is required");
+        }
+    }
+
+    private void requireActionAllowed(CompletionTask task, String action) {
+        if (task.getContract() == null || task.getContract().getAllowedActions() == null
+                || task.getContract().getAllowedActions().isEmpty()) {
+            return;
+        }
+        boolean allowed = task.getContract().getAllowedActions().stream()
+                .anyMatch(configured -> action.equalsIgnoreCase(configured));
+        if (!allowed) {
+            throw failure(WorkItemOperationException.Code.INVALID_TRANSITION,
+                    "Action " + action + " is not enabled for work item " + task.getId());
+        }
+    }
+
+    private TaskPayload validateAndAttributeResult(CompletionTask task,
+                                                   TaskPayload payload,
+                                                   String actorRef) {
+        String requiredSchema = task.getContract() == null
+                ? null : task.getContract().getResultSchemaRef();
+        if (requiredSchema != null && !requiredSchema.isBlank()) {
+            if (payload == null || payload.getSchemaRef() == null) {
+                throw failure(WorkItemOperationException.Code.INVALID_REQUEST,
+                        "A result payload using schema " + requiredSchema + " is required");
+            }
+            if (!requiredSchema.equals(payload.getSchemaRef())) {
+                throw failure(WorkItemOperationException.Code.INVALID_REQUEST,
+                        "Result payload schema " + payload.getSchemaRef()
+                                + " does not match required schema " + requiredSchema);
+            }
+        }
+        if (payload != null) {
+            payload.setCapturedAt(new Date());
+            payload.setCapturedBy(actorRef);
+        }
+        return payload;
+    }
+
+    private WorkItemOperationException invalidTransition(CompletionTask current,
+                                                         CompletionTask.Status targetStatus) {
+        return failure(WorkItemOperationException.Code.INVALID_TRANSITION,
+                "Cannot transition work item from " + current.getStatus() + " to " + targetStatus);
+    }
+
+    private WorkItemOperationException failure(WorkItemOperationException.Code code, String message) {
+        return new WorkItemOperationException(code, message);
+    }
+
+    private void attachGroup(String realm, CompletionTask task, String groupId) {
+        if (groupId != null && !groupId.isBlank()) {
+            Optional<CompletionTaskGroup> group = groupRepo.findById(new ObjectId(groupId), realm, true);
+            group.ifPresent(task::setGroup);
+        }
+    }
+
+    private void markGroupRunning(String realm, String groupId) {
+        if (groupId != null && !groupId.isBlank()) {
+            groupRepo.updateStatus(realm, groupId, CompletionTaskGroup.Status.RUNNING);
+        }
+    }
+
+    private void notifyGroup(CompletionTask task) {
+        notifyGroup(getSecurityContextRealmId(), task);
+    }
+
+    private void notifyGroup(String realm, CompletionTask task) {
+        if (task.getGroup() != null) {
+            String groupId = task.getGroup().getId().toString();
+            groupRepo.notifyGroup(groupId, "task:" + task.getId() + ":" + task.getStatus());
+            refreshGroupStatus(realm, groupId);
+        }
+    }
+
     private void refreshGroupStatus(String realm, String groupId) {
         List<CompletionTask> tasks = listByGroup(realm, groupId);
         if (tasks.isEmpty()) {
             return;
         }
-
-        boolean allTerminal = tasks.stream().allMatch(task ->
-                task.getStatus() == CompletionTask.Status.SUCCESS || task.getStatus() == CompletionTask.Status.FAILED
-        );
-
-        groupRepo.updateStatus(
-                realm,
-                groupId,
-                allTerminal ? CompletionTaskGroup.Status.COMPLETE : CompletionTaskGroup.Status.RUNNING
-        );
+        boolean allTerminal = tasks.stream().allMatch(task -> task.getStatus() != null && task.getStatus().isTerminal());
+        groupRepo.updateStatus(realm, groupId,
+                allTerminal ? CompletionTaskGroup.Status.COMPLETE : CompletionTaskGroup.Status.RUNNING);
     }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
@@ -825,12 +825,14 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
             StateGraph stateGraph = field.getAnnotation(StateGraph.class);
             if (stateGraph != null) {
                field.setAccessible(true);
-               String newState = (String) field.get(newEntity);
-               String currentState = (String) field.get(existingEntity);
-               if (newState != null) {
+               Object newValue = field.get(newEntity);
+               Object currentValue = field.get(existingEntity);
+               String newState = StateGraphManager.stateName(newValue);
+               String currentState = StateGraphManager.stateName(currentValue);
+               if (newValue != null && !Objects.equals(currentState, newState)) {
                   stateGraphManager.validateTransition(
                      stateGraph.graphName(),
-                     currentState != null ? currentState : "",
+                     currentState,
                      newState
                   );
                }
@@ -845,8 +847,9 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
             StateGraph stateGraph = field.getAnnotation(StateGraph.class);
             if (stateGraph != null) {
                field.setAccessible(true);
-               String newState = (String) field.get(entity);
-               if (newState != null) {
+               Object newValue = field.get(entity);
+               String newState = StateGraphManager.stateName(newValue);
+               if (newValue != null) {
                   // Check if the state exists in the graph
                   StringState graph = stateGraphManager.getStateGraphs().get(stateGraph.graphName());
                   if (graph == null) {
@@ -1324,10 +1327,10 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
              StateGraph stateGraph = field.getAnnotation(StateGraph.class);
              if (stateGraph != null && pair.getValue() instanceof String) {
                 field.setAccessible(true);
-                String currentState = (String) field.get(currentEntity);
+                String currentState = StateGraphManager.stateName(field.get(currentEntity));
                 stateGraphManager.validateTransition(
                    stateGraph.graphName(),
-                   currentState != null ? currentState : "",
+                   currentState,
                    (String) pair.getValue()
                 );
              }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserRealmRoleRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserRealmRoleRepo.java
@@ -18,16 +18,32 @@ public class UserRealmRoleRepo extends MorphiaRepo<UserRealmRole> {
      * Assignments live in the system realm next to credentials.
      */
     public List<String> findActiveRolesForRealmWithIgnoreRules(String userId, String realmRefName, String systemRealmId) {
+        return findActiveAssignmentForRealmWithIgnoreRules(userId, realmRefName, systemRealmId)
+            .map(UserRealmRole::getRoles)
+            .orElse(List.of());
+    }
+
+    /**
+     * The user's active (non-suspended) membership assignment for a realm, bypassing
+     * security rules — same unauthenticated login path as {@link #findActiveRolesForRealmWithIgnoreRules}.
+     * Used at token issuance to read both the realm roles and the application grant.
+     */
+    public Optional<UserRealmRole> findActiveAssignmentForRealmWithIgnoreRules(String userId, String realmRefName, String systemRealmId) {
+        return findAssignmentForRealmWithIgnoreRules(userId, realmRefName, systemRealmId)
+            .filter(a -> !UserRealmRole.STATUS_SUSPENDED.equals(a.getStatus()));
+    }
+
+    /**
+     * The user's membership assignment for a realm regardless of status, bypassing
+     * security rules. Used by the admin surface to read/mutate the application grant
+     * (which must live in — and be read back from — the system realm the login path uses).
+     */
+    public Optional<UserRealmRole> findAssignmentForRealmWithIgnoreRules(String userId, String realmRefName, String systemRealmId) {
         MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(systemRealmId);
-        Optional<UserRealmRole> assignment;
         try (var cursor = ds.find(UserRealmRole.class)
                 .filter(Filters.eq("userId", userId), Filters.eq("realmRefName", realmRefName))
                 .iterator()) {
-            assignment = cursor.hasNext() ? Optional.of(cursor.next()) : Optional.empty();
+            return cursor.hasNext() ? Optional.of(cursor.next()) : Optional.empty();
         }
-        return assignment
-            .filter(a -> !UserRealmRole.STATUS_SUSPENDED.equals(a.getStatus()))
-            .map(UserRealmRole::getRoles)
-            .orElse(List.of());
     }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTask.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTask.java
@@ -1,9 +1,14 @@
 package com.e2eq.framework.model.persistent.tasks;
 
+import com.e2eq.framework.annotations.StateGraph;
+import com.e2eq.framework.annotations.Stateful;
 import com.e2eq.framework.model.persistent.base.BaseModel;
 import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Index;
+import dev.morphia.annotations.Indexes;
 import dev.morphia.annotations.Reference;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -11,12 +16,23 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Date;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Simple task entity that can be tracked until completion.
  */
 @Entity("completionTask")
+@Indexes({
+        @Index(fields = {@dev.morphia.annotations.Field("status"), @dev.morphia.annotations.Field("assignment.queueRef")}),
+        @Index(fields = {@dev.morphia.annotations.Field("assignment.claimedBy"), @dev.morphia.annotations.Field("status")}),
+        @Index(fields = {@dev.morphia.annotations.Field("kind"), @dev.morphia.annotations.Field("access.ownerRef"), @dev.morphia.annotations.Field("status")}),
+        @Index(fields = {@dev.morphia.annotations.Field("kind"), @dev.morphia.annotations.Field("assignment.assigneeRef"), @dev.morphia.annotations.Field("status")}),
+        @Index(fields = {@dev.morphia.annotations.Field("kind"), @dev.morphia.annotations.Field("access.grants.principalRef"), @dev.morphia.annotations.Field("status")}),
+        @Index(fields = {@dev.morphia.annotations.Field("provenance.executionRef"), @dev.morphia.annotations.Field("provenance.stepKey")})
+})
 @RegisterForReflection
+@Stateful
 @Data
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
@@ -25,10 +41,23 @@ import java.util.Date;
 public class CompletionTask extends BaseModel {
 
     public enum Status {
+        /** Legacy aliases retained for stored records and existing clients. */
         PENDING,
         RUNNING,
         SUCCESS,
-        FAILED
+        FAILED,
+
+        OPEN,
+        CLAIMED,
+        IN_PROGRESS,
+        COMPLETED,
+        CANCELLED,
+        EXPIRED;
+
+        public boolean isTerminal() {
+            return this == SUCCESS || this == FAILED || this == COMPLETED
+                    || this == CANCELLED || this == EXPIRED;
+        }
     }
 
     @Reference
@@ -36,10 +65,33 @@ public class CompletionTask extends BaseModel {
 
     protected String details;
 
+    @StateGraph(graphName = CompletionTaskStateGraph.GRAPH_NAME)
     protected Status status;
 
+    protected String taskType;
+    protected WorkItemKind kind;
+    protected String summary;
+    protected Integer priority;
+    protected TaskSubject subject;
+    protected TaskEligibility eligibility;
+    protected TaskAssignment assignment;
+    protected TaskContract contract;
+    protected TaskProvenance provenance;
+    protected TaskSla sla;
+    protected TaskInteraction interaction;
+    protected TaskAccess access;
+    @Builder.Default
+    protected List<TaskReminder> reminders = new ArrayList<>();
+    @Builder.Default
+    protected List<TaskActivity> activity = new ArrayList<>();
+    protected TaskPayload inputPayload;
+    protected TaskPayload resultPayload;
+
     protected Date createdDate;
+    protected Date updatedDate;
+    protected Date startedDate;
     protected Date completedDate;
+    protected Date dueDate;
 
     protected String result;
 

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTaskStateGraph.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/CompletionTaskStateGraph.java
@@ -1,0 +1,93 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import com.e2eq.framework.model.persistent.StateNode;
+import com.e2eq.framework.model.persistent.base.StateGraphManager;
+import com.e2eq.framework.model.persistent.base.StringState;
+import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Registers the governed work-item lifecycle while retaining transitions used
+ * by legacy completion-task clients.
+ */
+@Startup
+@ApplicationScoped
+public class CompletionTaskStateGraph {
+    public static final String GRAPH_NAME = "completionTaskLifecycle";
+
+    @Inject
+    StateGraphManager stateGraphManager;
+
+    @PostConstruct
+    void register() {
+        Map<String, StateNode> states = new LinkedHashMap<>();
+        state(states, CompletionTask.Status.PENDING, true, false);
+        state(states, CompletionTask.Status.RUNNING, false, false);
+        state(states, CompletionTask.Status.SUCCESS, false, true);
+        state(states, CompletionTask.Status.FAILED, false, true);
+        state(states, CompletionTask.Status.OPEN, true, false);
+        state(states, CompletionTask.Status.CLAIMED, false, false);
+        state(states, CompletionTask.Status.IN_PROGRESS, false, false);
+        state(states, CompletionTask.Status.COMPLETED, false, true);
+        state(states, CompletionTask.Status.CANCELLED, false, true);
+        state(states, CompletionTask.Status.EXPIRED, false, true);
+
+        Map<String, List<StateNode>> transitions = new LinkedHashMap<>();
+        transitions.put(name(CompletionTask.Status.PENDING), nodes(states,
+                CompletionTask.Status.CLAIMED, CompletionTask.Status.RUNNING,
+                CompletionTask.Status.SUCCESS, CompletionTask.Status.FAILED));
+        transitions.put(name(CompletionTask.Status.RUNNING), nodes(states,
+                CompletionTask.Status.SUCCESS, CompletionTask.Status.FAILED));
+        transitions.put(name(CompletionTask.Status.OPEN), nodes(states,
+                CompletionTask.Status.CLAIMED, CompletionTask.Status.SUCCESS,
+                CompletionTask.Status.COMPLETED, CompletionTask.Status.FAILED, CompletionTask.Status.CANCELLED,
+                CompletionTask.Status.EXPIRED));
+        transitions.put(name(CompletionTask.Status.CLAIMED), nodes(states,
+                CompletionTask.Status.OPEN, CompletionTask.Status.IN_PROGRESS,
+                CompletionTask.Status.SUCCESS, CompletionTask.Status.COMPLETED,
+                CompletionTask.Status.FAILED, CompletionTask.Status.CANCELLED,
+                CompletionTask.Status.EXPIRED));
+        transitions.put(name(CompletionTask.Status.IN_PROGRESS), nodes(states,
+                CompletionTask.Status.OPEN, CompletionTask.Status.SUCCESS,
+                CompletionTask.Status.COMPLETED, CompletionTask.Status.FAILED,
+                CompletionTask.Status.CANCELLED, CompletionTask.Status.EXPIRED));
+        transitions.put(name(CompletionTask.Status.SUCCESS), List.of());
+        transitions.put(name(CompletionTask.Status.FAILED), List.of());
+        // Participant TODOs may be reopened. Process-task completion remains terminal
+        // because its repository path never exposes REOPEN.
+        transitions.put(name(CompletionTask.Status.COMPLETED), nodes(states, CompletionTask.Status.OPEN));
+        transitions.put(name(CompletionTask.Status.CANCELLED), List.of());
+        transitions.put(name(CompletionTask.Status.EXPIRED), List.of());
+
+        stateGraphManager.defineStateGraph(StringState.builder()
+                .fieldName(GRAPH_NAME)
+                .states(states)
+                .transitions(transitions)
+                .build());
+    }
+
+    private static void state(Map<String, StateNode> states,
+                              CompletionTask.Status status,
+                              boolean initial,
+                              boolean terminal) {
+        states.put(name(status), StateNode.builder()
+                .state(name(status))
+                .initialState(initial)
+                .finalState(terminal)
+                .build());
+    }
+
+    private static List<StateNode> nodes(Map<String, StateNode> states, CompletionTask.Status... statuses) {
+        return java.util.Arrays.stream(statuses).map(status -> states.get(name(status))).toList();
+    }
+
+    private static String name(CompletionTask.Status status) {
+        return status.name();
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/ReminderStatus.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/ReminderStatus.java
@@ -1,0 +1,7 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+public enum ReminderStatus {
+    SCHEDULED,
+    DELIVERED,
+    CANCELLED
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskAccess.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskAccess.java
@@ -1,0 +1,45 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Owner and explicit audience for participant-created work. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@RegisterForReflection
+public class TaskAccess {
+    private String ownerRef;
+
+    @Builder.Default
+    private WorkItemVisibility visibility = WorkItemVisibility.PRIVATE;
+
+    @Builder.Default
+    private List<TaskGrant> grants = new ArrayList<>();
+
+    public boolean isOwner(String actorRef) {
+        return actorRef != null && Objects.equals(ownerRef, actorRef);
+    }
+
+    public boolean permits(String actorRef, WorkItemPermission permission) {
+        if (isOwner(actorRef)) return true;
+        if (visibility != WorkItemVisibility.RESTRICTED || grants == null) return false;
+        return grants.stream()
+                .filter(grant -> grant != null && Objects.equals(actorRef, grant.getPrincipalRef()))
+                .anyMatch(grant -> grant.getPermissions() != null
+                        && (grant.getPermissions().contains(permission)
+                        || (permission == WorkItemPermission.VIEW
+                        && (grant.getPermissions().contains(WorkItemPermission.COMMENT)
+                        || grant.getPermissions().contains(WorkItemPermission.EDIT)))));
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskActivity.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskActivity.java
@@ -1,0 +1,24 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/** Attributable lifecycle entry for participant work. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@RegisterForReflection
+public class TaskActivity {
+    private String action;
+    private String actorRef;
+    private String detail;
+    private Date occurredAt;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskAssignment.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskAssignment.java
@@ -1,0 +1,32 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * Current queue and claim ownership for a work item.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@RegisterForReflection
+public class TaskAssignment {
+    private String queueRef;
+    /** Business responsibility; independent of transient queue claiming. */
+    private String assigneeRef;
+    private String assignedBy;
+    private Date assignedAt;
+    private String claimedBy;
+    private WorkerType claimedWorkerType;
+    private Date claimedAt;
+    private Date heartbeatAt;
+    private Date leaseUntil;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskContract.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskContract.java
@@ -1,0 +1,27 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The governed input, result, rule, and action contract for a work item.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RegisterForReflection
+public class TaskContract {
+    private String inputSchemaRef;
+    private String resultSchemaRef;
+    private String ruleSetRef;
+
+    @Builder.Default
+    private List<String> allowedActions = new ArrayList<>();
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskEligibility.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskEligibility.java
@@ -1,0 +1,58 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Describes who may see and claim a work item. Empty role/profile/capability
+ * sets mean that dimension does not further restrict eligibility.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RegisterForReflection
+public class TaskEligibility {
+    @Builder.Default
+    private Set<WorkerType> workerTypes = new LinkedHashSet<>();
+
+    @Builder.Default
+    private Set<String> roleRefs = new LinkedHashSet<>();
+
+    @Builder.Default
+    private Set<String> profileRefs = new LinkedHashSet<>();
+
+    @Builder.Default
+    private Set<String> capabilityRefs = new LinkedHashSet<>();
+
+    public boolean permits(WorkerType workerType,
+                           Set<String> roles,
+                           Set<String> profiles,
+                           Set<String> capabilities) {
+        WorkerType effectiveWorkerType = workerType == null ? WorkerType.HUMAN : workerType;
+        if (workerTypes == null || workerTypes.isEmpty()) {
+            if (effectiveWorkerType != WorkerType.HUMAN) {
+                return false;
+            }
+        } else if (!workerTypes.contains(effectiveWorkerType)) {
+            return false;
+        }
+
+        return intersectsOrUnrestricted(roleRefs, roles)
+                && intersectsOrUnrestricted(profileRefs, profiles)
+                && intersectsOrUnrestricted(capabilityRefs, capabilities);
+    }
+
+    private static boolean intersectsOrUnrestricted(Set<String> required, Set<String> actual) {
+        if (required == null || required.isEmpty()) {
+            return true;
+        }
+        return actual != null && required.stream().anyMatch(actual::contains);
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskGrant.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskGrant.java
@@ -1,0 +1,25 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** Explicit participant access to a TODO. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@RegisterForReflection
+public class TaskGrant {
+    private String principalRef;
+
+    @Builder.Default
+    private Set<WorkItemPermission> permissions = new LinkedHashSet<>();
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskInteraction.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskInteraction.java
@@ -1,0 +1,23 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Declares which UI or external experience captures the task result and where
+ * the validated response is integrated in the decision context.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RegisterForReflection
+public class TaskInteraction {
+    private TaskInteractionType type;
+    private String experienceRef;
+    private String responseMappingRef;
+    private String targetContextPath;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskInteractionType.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskInteractionType.java
@@ -1,0 +1,13 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+/**
+ * The experience used to execute a task; the lifecycle remains the same.
+ */
+public enum TaskInteractionType {
+    WORKBOOK,
+    SURVEY,
+    FORM,
+    APPROVAL,
+    MESSAGE,
+    EXTERNAL_SYSTEM
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskPayload.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskPayload.java
@@ -1,0 +1,30 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Schema-identified payload envelope used at task/orchestration boundaries.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RegisterForReflection
+public class TaskPayload {
+    private String schemaRef;
+
+    @Builder.Default
+    private Map<String, Object> data = new LinkedHashMap<>();
+
+    private Date capturedAt;
+    private String capturedBy;
+    private String evidenceRef;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskProvenance.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskProvenance.java
@@ -1,0 +1,28 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Workflow coordinates needed to resume the business process after completion.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@RegisterForReflection
+public class TaskProvenance {
+    private String executionRef;
+    private String definitionRef;
+    private String stepKey;
+    /** Revision of the workflow-runtime task at dispatch time, used for completion CAS. */
+    private Long workflowTaskRevision;
+    private String signalType;
+    private String signalOnComplete;
+    private String createdBy;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskReminder.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskReminder.java
@@ -1,0 +1,37 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/** A governed in-app trigger attached to, but distinct from, a work item. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@RegisterForReflection
+public class TaskReminder {
+    private String reminderId;
+    private Date triggerAt;
+    private String createdBy;
+
+    @Builder.Default
+    private List<String> recipientRefs = new ArrayList<>();
+
+    @Builder.Default
+    private String channel = "IN_APP";
+
+    @Builder.Default
+    private ReminderStatus status = ReminderStatus.SCHEDULED;
+
+    private Date deliveredAt;
+    private Date cancelledAt;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskSla.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskSla.java
@@ -1,0 +1,24 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * Measurable service-level targets attached to a work item.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RegisterForReflection
+public class TaskSla {
+    private String policyRef;
+    private Date warningAt;
+    private Date targetAt;
+    private Date breachedAt;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskSubject.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/TaskSubject.java
@@ -1,0 +1,25 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Stable business references and UI deep link for the decision context a task advances.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@RegisterForReflection
+public class TaskSubject {
+    private String workbookRef;
+    private String decisionTypeRef;
+    private String decisionCaseRef;
+    private String assessmentVersion;
+    private String navigationRoute;
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemKind.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemKind.java
@@ -1,0 +1,7 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+/** Distinguishes participant-created work from orchestrated queue work. */
+public enum WorkItemKind {
+    PROCESS_TASK,
+    TODO
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemOperationException.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemOperationException.java
@@ -1,0 +1,33 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+/**
+ * Typed, client-safe failure for a governed work-item operation.
+ */
+public class WorkItemOperationException extends RuntimeException {
+    public enum Code {
+        INVALID_REQUEST,
+        NOT_FOUND,
+        NOT_ELIGIBLE,
+        NOT_ASSIGNED,
+        LEASE_EXPIRED,
+        INVALID_TRANSITION,
+        REVISION_CONFLICT,
+        INTERNAL_ERROR
+    }
+
+    private final Code code;
+
+    public WorkItemOperationException(Code code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public WorkItemOperationException(Code code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+
+    public Code getCode() {
+        return code;
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemPermission.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemPermission.java
@@ -1,0 +1,8 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+/** Capabilities that an explicit work-item grant may convey. */
+public enum WorkItemPermission {
+    VIEW,
+    COMMENT,
+    EDIT
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemVisibility.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkItemVisibility.java
@@ -1,0 +1,7 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+/** Audience mode for participant-owned work. */
+public enum WorkItemVisibility {
+    PRIVATE,
+    RESTRICTED
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkerType.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/tasks/WorkerType.java
@@ -1,0 +1,10 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+/**
+ * The class of worker permitted to execute a governed work item.
+ */
+public enum WorkerType {
+    HUMAN,
+    AGENT,
+    SERVICE
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/tasks/CompletionTaskMorphiaMappingTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/tasks/CompletionTaskMorphiaMappingTest.java
@@ -1,0 +1,27 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import dev.morphia.annotations.Entity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CompletionTaskMorphiaMappingTest {
+
+    @Test
+    void nestedDocumentsUsedByQueriesAndIndexesAreMappedEntities() {
+        assertNotNull(TaskSubject.class.getAnnotation(Entity.class),
+                "subject must be mapped so subject.workbookRef is a valid path");
+        assertNotNull(TaskAssignment.class.getAnnotation(Entity.class),
+                "assignment must be mapped so assignment.queueRef and assignment.claimedBy are valid paths");
+        assertNotNull(TaskProvenance.class.getAnnotation(Entity.class),
+                "provenance must be mapped so provenance.executionRef and provenance.stepKey are valid paths");
+        assertNotNull(TaskAccess.class.getAnnotation(Entity.class),
+                "access must be mapped so owner and participant indexes are valid paths");
+        assertNotNull(TaskGrant.class.getAnnotation(Entity.class),
+                "grants must be mapped so access.grants.principalRef is queryable");
+        assertNotNull(TaskReminder.class.getAnnotation(Entity.class),
+                "reminders must be mapped as governed embedded triggers");
+        assertNotNull(TaskActivity.class.getAnnotation(Entity.class),
+                "activity must be mapped as attributable embedded history");
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/tasks/TaskAccessTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/tasks/TaskAccessTest.java
@@ -1,0 +1,42 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TaskAccessTest {
+
+    @Test
+    void privateWorkIsVisibleOnlyToOwner() {
+        TaskAccess access = TaskAccess.builder()
+                .ownerRef("owner@example.com")
+                .visibility(WorkItemVisibility.PRIVATE)
+                .build();
+
+        assertTrue(access.permits("owner@example.com", WorkItemPermission.EDIT));
+        assertFalse(access.permits("other@example.com", WorkItemPermission.VIEW));
+    }
+
+    @Test
+    void editAndCommentGrantsImplyViewWithoutTransferringOwnership() {
+        TaskAccess access = TaskAccess.builder()
+                .ownerRef("owner@example.com")
+                .visibility(WorkItemVisibility.RESTRICTED)
+                .grants(List.of(
+                        TaskGrant.builder().principalRef("editor@example.com")
+                                .permissions(Set.of(WorkItemPermission.EDIT)).build(),
+                        TaskGrant.builder().principalRef("commenter@example.com")
+                                .permissions(Set.of(WorkItemPermission.COMMENT)).build()))
+                .build();
+
+        assertTrue(access.permits("editor@example.com", WorkItemPermission.VIEW));
+        assertTrue(access.permits("editor@example.com", WorkItemPermission.EDIT));
+        assertTrue(access.permits("commenter@example.com", WorkItemPermission.VIEW));
+        assertFalse(access.permits("commenter@example.com", WorkItemPermission.EDIT));
+        assertFalse(access.isOwner("editor@example.com"));
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/tasks/TaskEligibilityTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/tasks/TaskEligibilityTest.java
@@ -1,0 +1,36 @@
+package com.e2eq.framework.model.persistent.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TaskEligibilityTest {
+
+    @Test
+    void unrestrictedLegacyTaskIsHumanOnly() {
+        TaskEligibility eligibility = new TaskEligibility();
+
+        assertTrue(eligibility.permits(WorkerType.HUMAN, Set.of(), Set.of(), Set.of()));
+        assertFalse(eligibility.permits(WorkerType.AGENT, Set.of(), Set.of(), Set.of()));
+    }
+
+    @Test
+    void requiresEveryConfiguredEligibilityDimension() {
+        TaskEligibility eligibility = TaskEligibility.builder()
+                .workerTypes(Set.of(WorkerType.HUMAN, WorkerType.AGENT))
+                .roleRefs(Set.of("planner"))
+                .profileRefs(Set.of("asia-origin-team"))
+                .capabilityRefs(Set.of("consolidation-approval"))
+                .build();
+
+        assertTrue(eligibility.permits(WorkerType.HUMAN,
+                Set.of("planner"), Set.of("asia-origin-team"), Set.of("consolidation-approval")));
+        assertFalse(eligibility.permits(WorkerType.HUMAN,
+                Set.of("planner"), Set.of("europe-team"), Set.of("consolidation-approval")));
+        assertFalse(eligibility.permits(WorkerType.SERVICE,
+                Set.of("planner"), Set.of("asia-origin-team"), Set.of("consolidation-approval")));
+    }
+}


### PR DESCRIPTION
## What changed

Publishes the full authorized Quantum Framework worktree. It adds application-scoped authorization and token handling, realm-role support, shared work-item queue contracts, and the participant-owned TODO extension with explicit grants, assignment, reminders, attributable activity, revision-safe transitions, and typed error responses.

The participant work model extends the existing CompletionTask persistence rather than introducing a CRM-specific task store. Queue claiming remains compatible and distinct from personal ownership and assignment.

## Root cause and impact

Participant-created reminders and shared to-dos previously lacked durable ownership, audience, and audit semantics. During live validation, the embedded task subject was also found to be unmapped for Morphia nested queries; the mapping and a typed INTERNAL_ERROR path now prevent schema-invalid generic failures.

## Validation

- Focused `TaskAccessTest` and `CompletionTaskMorphiaMappingTest`
- Maven install for `quantum-morphia-repos` and `quantum-framework`
- Helixor DI tenant package using the installed snapshot
- Live signed-in participant-work smoke test
- `git diff --cached --check`
