### PR TITLE
Application auth, governed work items, realm-scoped BaseResource hardening

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -1254,12 +1254,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
                 requestContext.abortWith(
                     Response.status(Response.Status.FORBIDDEN)
-                        .entity(Map.of(
-                            "error", "Access Denied",
-                            "message", message,
-                            "decision", response.getDecision() != null ? response.getDecision() : "DENY",
-                            "scope", response.getDecisionScope() != null ? response.getDecisionScope() : "DEFAULT"
-                        ))
+                        .entity(apiError("ACCESS_DENIED", message))
                         .build()
                 );
                 return;
@@ -1300,10 +1295,21 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                 principalContext.getUserId(), requestContext.getUriInfo().getPath());
             requestContext.abortWith(
                 Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(Map.of("error", "Authorization check failed"))
+                    .entity(apiError(
+                        "AUTHORIZATION_CHECK_FAILED",
+                        "Authorization check failed. See server diagnostics for details."
+                    ))
                     .build()
             );
         }
+    }
+
+    /**
+     * Stable error contract consumed by generated SDKs. Authorization diagnostics stay in server
+     * logs; response bodies deliberately contain only the public, versioned API error fields.
+     */
+    static Map<String, String> apiError(String code, String message) {
+        return Map.of("code", code, "message", message);
     }
 
     /**

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/BaseResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/BaseResource.java
@@ -1140,7 +1140,7 @@ public class BaseResource<T extends UnversionedBaseModel, R extends BaseMorphiaR
          String actualRealmId = getRealmIdFromModel(model);
          return deleteEntity(actualRealmId, model);
       } else {
-         Optional<T> model = repo.findByRefName(realmId, refName);
+         Optional<T> model = repo.findByRefName(refName, realmId);
          return deleteEntity(realmId, model);
       }
    }
@@ -1177,7 +1177,7 @@ public class BaseResource<T extends UnversionedBaseModel, R extends BaseMorphiaR
         String actualRealmId = getRealmIdFromModel(model);
         return deleteEntity(actualRealmId, id, model);
      } else {
-        Optional<T> model = repo.findById(realmId, id);
+        Optional<T> model = repo.findById(id, realmId);
         return deleteEntity(realmId, id, model);
      }
    }

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterPreAuthTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterPreAuthTest.java
@@ -3,6 +3,8 @@ package com.e2eq.framework.rest.filters;
 import com.e2eq.framework.model.securityrules.RuleEffect;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -59,5 +61,22 @@ public class SecurityFilterPreAuthTest {
         // Pre-auth should not run when isPermitAll is true
         boolean shouldEnforce = !isPermitAll && enforcePreAuth;
         assertFalse(shouldEnforce, "@PermitAll should bypass pre-auth");
+    }
+
+    @Test
+    public void testAuthorizationErrorsUseGeneratedSdkContract() {
+        Map<String, String> error = SecurityFilter.apiError(
+            "ACCESS_DENIED",
+            "Access denied: user=local-test, area=DI, domain=ONTOLOGY_AGENT, action=VIEW"
+        );
+
+        assertEquals(
+            Map.of(
+                "code", "ACCESS_DENIED",
+                "message", "Access denied: user=local-test, area=DI, domain=ONTOLOGY_AGENT, action=VIEW"
+            ),
+            error
+        );
+        assertEquals(2, error.size(), "Generated SDK error schemas reject undeclared fields");
     }
 }

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/resources/BaseResourceRealmDeleteTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/resources/BaseResourceRealmDeleteTest.java
@@ -1,0 +1,88 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
+import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import com.e2eq.framework.model.persistent.morphia.MorphiaRepo;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BaseResourceRealmDeleteTest {
+    private static final String REALM = "century-logistics";
+    private static final String REF_NAME = "WRKBK-SALES-DEMO";
+    private static final String ID = "6a551ff9e72a57b17de69508";
+
+    @Test
+    void realmScopedDeleteByRefNameKeepsIdentifierAndRealmInRepositoryOrder() throws Exception {
+        TrackingRepo repo = new TrackingRepo();
+        TestResource resource = new TestResource(repo);
+
+        assertEquals(200, resource.deleteByRefName(headers(), REF_NAME).getStatus());
+        assertEquals(REF_NAME, repo.requestedRefName);
+        assertEquals(REALM, repo.requestedRealm);
+    }
+
+    @Test
+    void realmScopedDeleteByIdKeepsIdentifierAndRealmInRepositoryOrder() throws Exception {
+        TrackingRepo repo = new TrackingRepo();
+        TestResource resource = new TestResource(repo);
+
+        assertEquals(200, resource.delete(headers(), ID).getStatus());
+        assertEquals(ID, repo.requestedId);
+        assertEquals(REALM, repo.requestedRealm);
+    }
+
+    private static HttpHeaders headers() {
+        return (HttpHeaders) Proxy.newProxyInstance(
+                HttpHeaders.class.getClassLoader(),
+                new Class<?>[]{HttpHeaders.class},
+                (proxy, method, args) -> "getHeaderString".equals(method.getName())
+                        && args != null && args.length == 1 && "X-Realm".equals(args[0])
+                        ? REALM
+                        : null);
+    }
+
+    private static final class TestResource extends BaseResource<TestEntity, TrackingRepo> {
+        private TestResource(TrackingRepo repo) { super(repo); }
+    }
+
+    private static final class TestEntity extends UnversionedBaseModel { }
+
+    private static final class TrackingRepo extends MorphiaRepo<TestEntity> {
+        private String requestedRefName;
+        private String requestedId;
+        private String requestedRealm;
+
+        @Override
+        public Optional<TestEntity> findByRefName(String refName, String realmId) {
+            requestedRefName = refName;
+            requestedRealm = realmId;
+            return Optional.of(entity());
+        }
+
+        @Override
+        public Optional<TestEntity> findById(String id, String realmId) {
+            requestedId = id;
+            requestedRealm = realmId;
+            return Optional.of(entity());
+        }
+
+        @Override
+        public long delete(String realmId, TestEntity value) throws ReferentialIntegrityViolationException {
+            requestedRealm = realmId;
+            return 1;
+        }
+
+        private TestEntity entity() {
+            TestEntity value = new TestEntity();
+            value.setId(new ObjectId(ID));
+            value.setRefName(REF_NAME);
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Lands the scheduler-associated framework work on 1.4.0-SNAPSHOT:

- Application-scoped auth + governed work items (1f7249af)
- SecurityFilter/BaseResource realm handling refinements + BaseResourceRealmDeleteTest (WIP snapshot committed as-is per batch-land directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)