### PR TITLE
feat: consolidate sort collation and documentation dependency updates

### DIFF
--- a/quantum-docs/package-lock.json
+++ b/quantum-docs/package-lock.json
@@ -499,9 +499,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",

--- a/quantum-docs/package-lock.json
+++ b/quantum-docs/package-lock.json
@@ -222,9 +222,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/quantum-docs/package-lock.json
+++ b/quantum-docs/package-lock.json
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/BaseMorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/BaseMorphiaRepo.java
@@ -49,6 +49,25 @@ public interface BaseMorphiaRepo<T extends UnversionedBaseModel> {
    MorphiaDatastore getMorphiaDataStore ();
 
    /**
+    * Extension point returning the MongoDB {@link com.mongodb.client.model.Collation}
+    * applied to server-side sorts (both {@code find().sort(...)} and aggregation
+    * {@code $sort} pipelines), or {@code null} to preserve upstream binary-order
+    * behavior.
+    *
+    * <p>Default returns {@code null} so upstream and existing implementers are
+    * unaffected. Downstream implementations (see
+    * {@link MorphiaRepo#getSortCollation()}) may source this from config or
+    * override with a fixed policy.
+    *
+    * <p>Callers on the aggregation side (e.g. {@code OntologyAwareResource})
+    * MUST delegate to this method rather than reading collation config directly,
+    * so an override picked up by the find path also applies to expand queries.
+    */
+   default com.mongodb.client.model.Collation getSortCollation() {
+      return null;
+   }
+
+   /**
     * Returns the logical database name backing this repository.
     *
     * @return the database name

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
@@ -14,6 +14,8 @@ import com.e2eq.framework.rest.models.Collection;
 import com.e2eq.framework.security.runtime.RuleContext;
 import com.fasterxml.jackson.module.jsonSchema.jakarta.JsonSchema;
 import com.google.common.reflect.TypeToken;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CollationStrength;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import dev.morphia.Datastore;
@@ -71,6 +73,19 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @ConfigProperty(name = "ontology.auto-materialize", defaultValue = "true")
     protected boolean autoMaterialize;
+
+    // Opt-in MongoDB collation applied to server-side list/aggregation sorts.
+    // Empty locale disables collation and preserves upstream binary-order behavior.
+    // Downstreams (e.g. Movista, MOV-12188) set locale=en, strength=2 (SECONDARY)
+    // to get case-insensitive text sorting for AG Grid list grids.
+    @ConfigProperty(name = "quantum.sort.collation.locale", defaultValue = "")
+    protected String sortCollationLocale;
+
+    @ConfigProperty(name = "quantum.sort.collation.strength", defaultValue = "2")
+    protected int sortCollationStrength;
+
+    private volatile Collation cachedSortCollation;
+    private volatile boolean sortCollationResolved;
 
     private void callPostPersistHooks(String realmId, Object entity) {
         lifecycleHooks().callPostPersistHooks(realmId, entity);
@@ -456,6 +471,10 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
         if (sortFields != null && !sortFields.isEmpty()) {
             List<Sort> sorts = convertToSort(sortFields);
             findOptions.sort(sorts.toArray(new Sort[sorts.size()]));
+            Collation sortCollation = getSortCollation();
+            if (sortCollation != null) {
+                findOptions.collation(sortCollation);
+            }
         }
 
         // Field-level policy (deny-wins): excluded paths are removed at the
@@ -492,6 +511,38 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
         }
 
         return findOptions;
+    }
+
+    /**
+     * Extension point returning the MongoDB {@link Collation} applied to
+     * server-side list sorts, or {@code null} to preserve upstream binary-order
+     * behavior.
+     *
+     * <p>Default implementation reads {@code quantum.sort.collation.locale}
+     * and {@code quantum.sort.collation.strength} config properties; a blank
+     * locale disables collation (upstream default). Subclasses may override
+     * to supply a fixed policy independent of configuration.
+     *
+     * <p>Applied by {@link #buildFindOptions(int, int, List, List)} for
+     * {@code find().sort(...)} queries. Aggregation/expand pipelines pass the
+     * same collation at execution time via {@code AggregationOptions} /
+     * {@code MongoCollection.aggregate(...).collation(...)}.
+     */
+    protected Collation getSortCollation() {
+        if (!sortCollationResolved) {
+            synchronized (this) {
+                if (!sortCollationResolved) {
+                    if (sortCollationLocale != null && !sortCollationLocale.isBlank()) {
+                        cachedSortCollation = Collation.builder()
+                                .locale(sortCollationLocale)
+                                .collationStrength(CollationStrength.fromInt(sortCollationStrength))
+                                .build();
+                    }
+                    sortCollationResolved = true;
+                }
+            }
+        }
+        return cachedSortCollation;
     }
 
     @Override

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
@@ -514,35 +514,45 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     }
 
     /**
-     * Extension point returning the MongoDB {@link Collation} applied to
-     * server-side list sorts, or {@code null} to preserve upstream binary-order
-     * behavior.
+     * Default {@link BaseMorphiaRepo#getSortCollation()} implementation
+     * that reads {@code quantum.sort.collation.locale} and
+     * {@code quantum.sort.collation.strength} config properties; a blank
+     * locale disables collation (upstream default). An out-of-range strength
+     * value is logged at WARN and treated as disabled rather than throwing.
      *
-     * <p>Default implementation reads {@code quantum.sort.collation.locale}
-     * and {@code quantum.sort.collation.strength} config properties; a blank
-     * locale disables collation (upstream default). Subclasses may override
-     * to supply a fixed policy independent of configuration.
-     *
-     * <p>Applied by {@link #buildFindOptions(int, int, List, List)} for
-     * {@code find().sort(...)} queries. Aggregation/expand pipelines pass the
-     * same collation at execution time via {@code AggregationOptions} /
-     * {@code MongoCollection.aggregate(...).collation(...)}.
+     * <p>Subclasses may override to supply a fixed policy independent of
+     * configuration; the aggregation/expand path in
+     * {@code OntologyAwareResource} delegates to this method so an override
+     * applies to both {@code find().sort(...)} and aggregation sorts.
      */
-    protected Collation getSortCollation() {
+    @Override
+    public Collation getSortCollation() {
         if (!sortCollationResolved) {
             synchronized (this) {
                 if (!sortCollationResolved) {
-                    if (sortCollationLocale != null && !sortCollationLocale.isBlank()) {
-                        cachedSortCollation = Collation.builder()
-                                .locale(sortCollationLocale)
-                                .collationStrength(CollationStrength.fromInt(sortCollationStrength))
-                                .build();
-                    }
+                    cachedSortCollation = buildSortCollation();
                     sortCollationResolved = true;
                 }
             }
         }
         return cachedSortCollation;
+    }
+
+    private Collation buildSortCollation() {
+        if (sortCollationLocale == null || sortCollationLocale.isBlank()) {
+            return null;
+        }
+        try {
+            return Collation.builder()
+                    .locale(sortCollationLocale)
+                    .collationStrength(CollationStrength.fromInt(sortCollationStrength))
+                    .build();
+        } catch (IllegalArgumentException ex) {
+            Log.warnf(
+                    "Invalid quantum.sort.collation.strength=%d for locale=%s; disabling sort collation. Valid range is 1-5 (PRIMARY..IDENTICAL).",
+                    sortCollationStrength, sortCollationLocale);
+            return null;
+        }
     }
 
     @Override

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepoSortCollationTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepoSortCollationTest.java
@@ -1,0 +1,144 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.persistent.base.SortField;
+import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CollationStrength;
+import dev.morphia.query.FindOptions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Unit tests for {@link MorphiaRepo#getSortCollation()} and the collation
+ * portion of {@link MorphiaRepo#buildFindOptions(int, int, List, List)}.
+ *
+ * <p>These are plain JUnit tests (no {@code @QuarkusTest}) that exercise the
+ * config-driven collation hook directly, so no Mongo or CDI container is
+ * required. See {@link RepoSecurityContextResolverTest} for the same pattern.
+ */
+class MorphiaRepoSortCollationTest {
+
+    /** Minimal concrete entity so {@link MorphiaRepo} can be parameterized. */
+    public static class SortCollationTestModel extends UnversionedBaseModel {
+        @Override
+        public String bmFunctionalArea() { return "test-area"; }
+
+        @Override
+        public String bmFunctionalDomain() { return "test-domain"; }
+    }
+
+    /**
+     * Test subclass that exposes the protected {@code buildFindOptions} and
+     * lets tests set the two collation config fields directly, bypassing
+     * Quarkus @ConfigProperty injection.
+     */
+    static class TestRepo extends MorphiaRepo<SortCollationTestModel> {
+        TestRepo(String locale, int strength) {
+            this.sortCollationLocale = locale;
+            this.sortCollationStrength = strength;
+        }
+
+        FindOptions callBuildFindOptions(List<SortField> sortFields) {
+            return buildFindOptions(0, 0, sortFields, null);
+        }
+    }
+
+    /** Test subclass that overrides the hook to return a fixed value. */
+    static class HookOverrideRepo extends MorphiaRepo<SortCollationTestModel> {
+        private final Collation override;
+
+        HookOverrideRepo(Collation override) {
+            this.override = override;
+        }
+
+        @Override
+        public Collation getSortCollation() {
+            return override;
+        }
+
+        FindOptions callBuildFindOptions(List<SortField> sortFields) {
+            return buildFindOptions(0, 0, sortFields, null);
+        }
+    }
+
+    private static Collation extractCollation(FindOptions options) throws ReflectiveOperationException {
+        Field field = FindOptions.class.getDeclaredField("collation");
+        field.setAccessible(true);
+        return (Collation) field.get(options);
+    }
+
+    @Test
+    void getSortCollation_returnsNull_whenLocaleBlank() {
+        TestRepo repo = new TestRepo("", 2);
+
+        assertNull(repo.getSortCollation(), "Blank locale should disable sort collation (upstream default)");
+    }
+
+    @Test
+    void getSortCollation_returnsConfiguredCollation() {
+        TestRepo repo = new TestRepo("en", 2);
+
+        Collation collation = repo.getSortCollation();
+
+        assertNotNull(collation, "Configured locale should produce a Collation");
+        assertEquals("en", collation.getLocale());
+        assertEquals(CollationStrength.SECONDARY, collation.getStrength());
+    }
+
+    @Test
+    void getSortCollation_returnsNull_whenStrengthOutOfRange() {
+        TestRepo repo = new TestRepo("en", 99);
+
+        assertNull(
+                repo.getSortCollation(),
+                "Invalid strength should be swallowed by the try/catch and disable collation (not throw)");
+    }
+
+    @Test
+    void buildFindOptions_appliesCollation_whenHookNonNullAndSortPresent() throws Exception {
+        Collation fixed = Collation.builder()
+                .locale("en")
+                .collationStrength(CollationStrength.SECONDARY)
+                .build();
+        HookOverrideRepo repo = new HookOverrideRepo(fixed);
+
+        FindOptions options = repo.callBuildFindOptions(
+                List.of(new SortField("displayName", SortField.SortDirection.ASC)));
+
+        assertSame(fixed, extractCollation(options), "Collation from hook should be forwarded to FindOptions");
+    }
+
+    @Test
+    void buildFindOptions_noCollation_whenSortEmpty() throws Exception {
+        Collation fixed = Collation.builder()
+                .locale("en")
+                .collationStrength(CollationStrength.SECONDARY)
+                .build();
+        HookOverrideRepo repo = new HookOverrideRepo(fixed);
+
+        FindOptions options = repo.callBuildFindOptions(List.of());
+
+        assertNull(
+                extractCollation(options),
+                "Collation must not be applied when no sort is requested (avoids unnecessary in-memory sort)");
+    }
+
+    @Test
+    void buildFindOptions_noCollation_whenHookReturnsNull() throws Exception {
+        HookOverrideRepo repo = new HookOverrideRepo(null);
+
+        FindOptions options = repo.callBuildFindOptions(
+                List.of(new SortField("displayName", SortField.SortDirection.ASC)));
+
+        assertNull(
+                extractCollation(options),
+                "Null from hook must preserve upstream binary-order sort");
+    }
+}

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
@@ -12,6 +12,8 @@ import com.e2eq.framework.rest.models.Collection;
 import com.e2eq.framework.rest.resources.BaseResource;
 import com.e2eq.ontology.mongo.OntologyContextEnricherMongo;
 import com.e2eq.ontology.policy.ListQueryRewriter;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CollationStrength;
 import dev.morphia.Datastore;
 import dev.morphia.annotations.Entity;
 import io.quarkus.logging.Log;
@@ -61,8 +63,44 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
     @ConfigProperty(name = "feature.ontologyList.aggregation.enabled", defaultValue = "false")
     boolean ontologyListAggregationEnabled;
 
+    // Mirrors MorphiaRepo's sort-collation config so aggregation/expand sorts
+    // stay consistent with find().sort() behavior. Blank locale = upstream binary order.
+    @ConfigProperty(name = "quantum.sort.collation.locale", defaultValue = "")
+    String sortCollationLocale;
+
+    @ConfigProperty(name = "quantum.sort.collation.strength", defaultValue = "2")
+    int sortCollationStrength;
+
+    private volatile Collation cachedSortCollation;
+    private volatile boolean sortCollationResolved;
+
     protected OntologyAwareResource(R repo) {
         super(repo);
+    }
+
+    /**
+     * Extension point returning the MongoDB {@link Collation} applied to
+     * aggregation/expand sorts, or {@code null} for upstream binary order.
+     *
+     * <p>Mirrors {@code MorphiaRepo#getSortCollation()} so aggregation results
+     * order identically to standard {@code find().sort()} results when both
+     * paths are configured with the same collation.
+     */
+    protected Collation getSortCollation() {
+        if (!sortCollationResolved) {
+            synchronized (this) {
+                if (!sortCollationResolved) {
+                    if (sortCollationLocale != null && !sortCollationLocale.isBlank()) {
+                        cachedSortCollation = Collation.builder()
+                                .locale(sortCollationLocale)
+                                .collationStrength(CollationStrength.fromInt(sortCollationStrength))
+                                .build();
+                    }
+                    sortCollationResolved = true;
+                }
+            }
+        }
+        return cachedSortCollation;
     }
 
     /**
@@ -171,10 +209,16 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
         }
         int effLimit = limit > 0 ? limit : 50;
         int effSkip = Math.max(0, skip);
-        List<org.bson.Document> rows = ds.getDatabase()
+        com.mongodb.client.AggregateIterable<org.bson.Document> aggregate = ds.getDatabase()
                 .getCollection(rootCollection)
-                .aggregate(clean, org.bson.Document.class)
-                .into(new ArrayList<>());
+                .aggregate(clean, org.bson.Document.class);
+        if (sortFields != null && !sortFields.isEmpty()) {
+            Collation sortCollation = getSortCollation();
+            if (sortCollation != null) {
+                aggregate = aggregate.collation(sortCollation);
+            }
+        }
+        List<org.bson.Document> rows = aggregate.into(new ArrayList<>());
         Collection<org.bson.Document> col = new Collection<>(rows, effSkip, effLimit, query, (long) rows.size());
         String realmId = headers.getHeaderString("X-Realm");
         col.setRealm(realmId == null ? repo.getDatabaseName() : realmId);

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
@@ -13,7 +13,6 @@ import com.e2eq.framework.rest.resources.BaseResource;
 import com.e2eq.ontology.mongo.OntologyContextEnricherMongo;
 import com.e2eq.ontology.policy.ListQueryRewriter;
 import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.CollationStrength;
 import dev.morphia.Datastore;
 import dev.morphia.annotations.Entity;
 import io.quarkus.logging.Log;
@@ -63,44 +62,27 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
     @ConfigProperty(name = "feature.ontologyList.aggregation.enabled", defaultValue = "false")
     boolean ontologyListAggregationEnabled;
 
-    // Mirrors MorphiaRepo's sort-collation config so aggregation/expand sorts
-    // stay consistent with find().sort() behavior. Blank locale = upstream binary order.
-    @ConfigProperty(name = "quantum.sort.collation.locale", defaultValue = "")
-    String sortCollationLocale;
-
-    @ConfigProperty(name = "quantum.sort.collation.strength", defaultValue = "2")
-    int sortCollationStrength;
-
-    private volatile Collation cachedSortCollation;
-    private volatile boolean sortCollationResolved;
-
     protected OntologyAwareResource(R repo) {
         super(repo);
     }
 
     /**
-     * Extension point returning the MongoDB {@link Collation} applied to
-     * aggregation/expand sorts, or {@code null} for upstream binary order.
+     * Resolves the collation to attach to the aggregation pipeline, delegating
+     * to {@link BaseMorphiaRepo#getSortCollation()} so the aggregation/expand
+     * path stays consistent with {@code find().sort(...)} in
+     * {@link com.e2eq.framework.model.persistent.morphia.MorphiaRepo#buildFindOptions}.
      *
-     * <p>Mirrors {@code MorphiaRepo#getSortCollation()} so aggregation results
-     * order identically to standard {@code find().sort()} results when both
-     * paths are configured with the same collation.
+     * <p>Returns {@code null} when no sort is requested (so no-sort aggregations
+     * don't incur the in-memory collation sort) or when the repo hook opts out.
+     *
+     * <p>Package-private to support unit testing of the delegation contract
+     * without spinning up a full aggregation pipeline.
      */
-    protected Collation getSortCollation() {
-        if (!sortCollationResolved) {
-            synchronized (this) {
-                if (!sortCollationResolved) {
-                    if (sortCollationLocale != null && !sortCollationLocale.isBlank()) {
-                        cachedSortCollation = Collation.builder()
-                                .locale(sortCollationLocale)
-                                .collationStrength(CollationStrength.fromInt(sortCollationStrength))
-                                .build();
-                    }
-                    sortCollationResolved = true;
-                }
-            }
+    Collation resolveAggregationSortCollation(List<?> sortFields) {
+        if (sortFields == null || sortFields.isEmpty()) {
+            return null;
         }
-        return cachedSortCollation;
+        return repo.getSortCollation();
     }
 
     /**
@@ -212,11 +194,9 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
         com.mongodb.client.AggregateIterable<org.bson.Document> aggregate = ds.getDatabase()
                 .getCollection(rootCollection)
                 .aggregate(clean, org.bson.Document.class);
-        if (sortFields != null && !sortFields.isEmpty()) {
-            Collation sortCollation = getSortCollation();
-            if (sortCollation != null) {
-                aggregate = aggregate.collation(sortCollation);
-            }
+        Collation sortCollation = resolveAggregationSortCollation(sortFields);
+        if (sortCollation != null) {
+            aggregate = aggregate.collation(sortCollation);
         }
         List<org.bson.Document> rows = aggregate.into(new ArrayList<>());
         Collection<org.bson.Document> col = new Collection<>(rows, effSkip, effLimit, query, (long) rows.size());

--- a/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/rest/OntologyAwareResourceSortCollationTest.java
+++ b/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/rest/OntologyAwareResourceSortCollationTest.java
@@ -1,0 +1,114 @@
+package com.e2eq.ontology.policy.rest;
+
+import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import com.e2eq.framework.model.persistent.morphia.BaseMorphiaRepo;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CollationStrength;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Verifies that {@link OntologyAwareResource#resolveAggregationSortCollation}
+ * — the collation source used by {@code tryAggregationList} — delegates to
+ * {@link BaseMorphiaRepo#getSortCollation()} rather than reading collation
+ * config independently.
+ *
+ * <p>Fixes Greptile P1 on PR #21: previously this class carried its own copy
+ * of {@code quantum.sort.collation.*} @ConfigProperty fields, so an
+ * override of {@link com.e2eq.framework.model.persistent.morphia.MorphiaRepo#getSortCollation()}
+ * on a downstream repo would apply to {@code find().sort(...)} but not to
+ * aggregation/expand queries. These tests lock in the delegation contract.
+ *
+ * <p>Uses a JDK dynamic proxy for {@link BaseMorphiaRepo} so no Mockito
+ * dependency is required.
+ */
+class OntologyAwareResourceSortCollationTest {
+
+    public static class SortCollationTestModel extends UnversionedBaseModel {
+        @Override
+        public String bmFunctionalArea() { return "test-area"; }
+
+        @Override
+        public String bmFunctionalDomain() { return "test-domain"; }
+    }
+
+    static class TestOntologyResource
+            extends OntologyAwareResource<SortCollationTestModel, BaseMorphiaRepo<SortCollationTestModel>> {
+        TestOntologyResource(BaseMorphiaRepo<SortCollationTestModel> repo) {
+            super(repo);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BaseMorphiaRepo<SortCollationTestModel> stubRepoReturning(
+            Collation collation, AtomicInteger callCount) {
+        return (BaseMorphiaRepo<SortCollationTestModel>) Proxy.newProxyInstance(
+                BaseMorphiaRepo.class.getClassLoader(),
+                new Class<?>[]{BaseMorphiaRepo.class},
+                (proxy, method, args) -> {
+                    if ("getSortCollation".equals(method.getName())) {
+                        callCount.incrementAndGet();
+                        return collation;
+                    }
+                    throw new UnsupportedOperationException("Not stubbed: " + method);
+                });
+    }
+
+    @Test
+    void delegatesToRepoGetSortCollation_whenSortPresent() {
+        Collation configured = Collation.builder()
+                .locale("en")
+                .collationStrength(CollationStrength.SECONDARY)
+                .build();
+        AtomicInteger repoCalls = new AtomicInteger();
+        TestOntologyResource resource = new TestOntologyResource(stubRepoReturning(configured, repoCalls));
+
+        Collation result = resource.resolveAggregationSortCollation(List.of("displayName"));
+
+        assertSame(configured, result, "Aggregation path must return the repo's collation, not build its own");
+        assertEquals(1, repoCalls.get(), "Repo hook should be consulted exactly once per resolve call");
+    }
+
+    @Test
+    void returnsNull_andSkipsRepoLookup_whenSortEmpty() {
+        AtomicInteger repoCalls = new AtomicInteger();
+        TestOntologyResource resource = new TestOntologyResource(
+                stubRepoReturning(Collation.builder().locale("en").build(), repoCalls));
+
+        Collation result = resource.resolveAggregationSortCollation(List.of());
+
+        assertNull(result, "Empty sort must skip collation to avoid unnecessary in-memory sort");
+        assertEquals(0, repoCalls.get(),
+                "Repo hook should not be invoked when there is nothing to sort");
+    }
+
+    @Test
+    void returnsNull_whenSortNull() {
+        AtomicInteger repoCalls = new AtomicInteger();
+        TestOntologyResource resource = new TestOntologyResource(
+                stubRepoReturning(Collation.builder().locale("en").build(), repoCalls));
+
+        Collation result = resource.resolveAggregationSortCollation(null);
+
+        assertNull(result);
+        assertEquals(0, repoCalls.get());
+    }
+
+    @Test
+    void returnsNull_whenRepoHookReturnsNull() {
+        AtomicInteger repoCalls = new AtomicInteger();
+        TestOntologyResource resource = new TestOntologyResource(stubRepoReturning(null, repoCalls));
+
+        Collation result = resource.resolveAggregationSortCollation(List.of("displayName"));
+
+        assertNull(result, "Null from repo hook must preserve upstream binary-order aggregation sort");
+        assertEquals(1, repoCalls.get());
+    }
+}


### PR DESCRIPTION
Carries the generic Quantum Framework patches from the MoVista fork into the supported 1.4.0-SNAPSHOT line without importing fork-specific group IDs or release configuration.