### PR TITLE
Harden tenant-aware authorization and lifecycle contracts

### DIFF
--- a/quantum-docs/src/docs/asciidoc/user-guide/auth.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/auth.adoc
@@ -104,7 +104,7 @@ When you extend BaseAuthProvider, you inherit ready-to-use capabilities that red
 
 Best practices when deriving:
 
-- Always set the auth provider name in stored credentials so records can be traced to the correct provider.
+- Record the auth provider name in stored credentials as informational provenance. It tells callers which provider resolved the credential or token; it is not an authentication routing or authorization binding.
 - Reuse the role merge/remove patterns to avoid accidental role loss.
 - Prefer emitting precise exceptions (e.g., NotFound for missing users, SecurityException for access violations).
 
@@ -152,7 +152,7 @@ lastUpdate:: Timestamp for auditing and token invalidation strategies.
 area2RealmOverrides:: Optional map to route specific functional areas to different realms than the default (e.g., “Reporting” → analytics-realm).
 realmRegEx:: Optional regex to limit or override which realms this identity may act in; also used by impersonation/override flows.
 impersonateFilterScript:: Optional script indicating the filter/scope applied during impersonation so actions are constrained.
-authProviderName:: The name of the provider that owns this credential (e.g., “custom”, “oidc”), enabling multi-provider operations and audits.
+authProviderName:: Informational provenance naming the provider that resolved this credential or token (e.g., “custom”, “oidc”). Provider selection comes from an explicit request override or the ordered `auth.provider` configuration, never from this field.
 
 How DomainContext selects the realm for REST calls
 

--- a/quantum-docs/src/docs/asciidoc/user-guide/multiple-auth-providers.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/multiple-auth-providers.adoc
@@ -26,7 +26,9 @@ When a request arrives with a JWT, the framework resolves which provider should 
 The first provider whose issuer matches the JWT `iss` claim wins.
 2. **By name** -- `AuthProviderFactory.getProviderByName(String name)` performs a case-insensitive lookup (for example `"custom"` or `"oidc"`).
 3. **Default** -- `AuthProviderFactory.getAuthProvider()` returns the first configured provider.
-If issuer-based lookup finds no match, the default provider is used as a fallback.
+Unknown or missing issuer routing fails closed; callers that intentionally want the default provider must request it explicitly.
+
+For user-facing login, an explicit `provider` request may contain a comma-separated ordered list. When omitted, the ordered `auth.provider` configuration is used. Every provider named by either list must be available; configuration errors are not silently skipped.
 
 === Canonical Identity Service
 
@@ -159,7 +161,7 @@ AuthProviderFactory.getProviderForIssuer(issuer)
     |       -> yes: use this provider
     |       -> no: try next
     |
-    +-- No match: fall back to default provider
+    +-- No match: fail provider resolution
     |
     v
 Provider validates token and returns ProviderClaims or SecurityIdentity

--- a/quantum-docs/src/docs/asciidoc/user-guide/rest-crud.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/rest-crud.adoc
@@ -707,7 +707,7 @@ When you extend BaseAuthProvider, you inherit ready-to-use capabilities that red
 
 Best practices when deriving:
 
-* Always set the auth provider name in stored credentials so records can be traced to the correct provider.
+* Record the auth provider name in stored credentials as informational provenance. It tells callers which provider resolved the credential or token; it is not an authentication routing or authorization binding.
 * Reuse the role merge/remove patterns to avoid accidental role loss.
 * Prefer emitting precise exceptions (e.g., NotFound for missing users, SecurityException for access violations).
 
@@ -756,7 +756,7 @@ lastUpdate:: Timestamp for auditing and token invalidation strategies.
 area2RealmOverrides:: Optional map to route specific functional areas to different realms than the default (e.g., “Reporting” → analytics-realm).
 realmRegEx:: Optional regex to limit or override which realms this identity may act in; also used by impersonation/override flows.
 impersonateFilterScript:: Optional script indicating the filter/scope applied during impersonation so actions are constrained.
-authProviderName:: The name of the provider that owns this credential (e.g., “custom”, “oidc”), enabling multi-provider operations and audits.
+authProviderName:: Informational provenance naming the provider that resolved this credential or token (e.g., “custom”, “oidc”). Provider selection comes from an explicit request override or the ordered `auth.provider` configuration, never from this field.
 
 How DomainContext selects the realm for REST calls
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/api/query/QueryGatewayResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/api/query/QueryGatewayResource.java
@@ -18,6 +18,7 @@ import com.e2eq.framework.model.persistent.imports.ImportSessionRow;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
 import com.e2eq.framework.model.securityrules.SecurityContext;
+import com.e2eq.framework.model.securityrules.FieldPolicyEnforcer;
 import com.e2eq.framework.security.runtime.RuleContext;
 import com.e2eq.framework.rest.models.Collection;
 import com.e2eq.framework.csv.CSVExportHelper;
@@ -56,6 +57,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 
 /**
@@ -169,8 +171,9 @@ public class QueryGatewayResource {
     @GET
     @Path("/rootTypes")
     @FunctionalAction("listRootTypes")
-    public RootTypesResponse listRootTypes() {
-        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(defaultRealm);
+    public RootTypesResponse listRootTypes(@QueryParam("realm") String requestRealm) {
+        String realm = resolveRealm(requestRealm);
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realm);
         Mapper mapper = ds.getMapper();
 
         List<RootTypeInfo> rootTypes = new ArrayList<>();
@@ -392,9 +395,22 @@ public class QueryGatewayResource {
         try {
             // Convert the Map to the target entity type
             UnversionedBaseModel entity = objectMapper.convertValue(req.entity, root);
+            @SuppressWarnings("unchecked")
+            BaseMorphiaRepo<UnversionedBaseModel> repo =
+                    resolveRepo((Class<UnversionedBaseModel>) root);
 
-            // Save (insert or update)
-            UnversionedBaseModel saved = ds.save(entity);
+            governEntityForSave(ds, root, entity);
+
+            // Morphia save is insert-only; updates must use merge. Reuse the registered
+            // repository in both cases so validation, policy-preservation, and
+            // state-transition checks remain centralized.
+            UnversionedBaseModel saved = entity.getId() == null
+                    ? repo.save(realm, entity)
+                    : repo.merge(ds, entity);
+
+            // The generic response is a DTO map, so the REST model interceptor cannot
+            // mask it. Apply the same policy before materializing the response payload.
+            FieldPolicyEnforcer.mask(saved, excludedFieldPaths());
 
             SaveResponse response = new SaveResponse();
             response.id = saved.getId() != null ? saved.getId().toHexString() : null;
@@ -402,6 +418,13 @@ public class QueryGatewayResource {
             response.rootType = root.getName();
 
             return Response.ok(response).build();
+        } catch (WebApplicationException e) {
+            throw e;
+        } catch (SecurityException e) {
+            // Repository policy denials are authorization failures.  Do not disguise them
+            // as generic save failures (500), since clients must be able to distinguish a
+            // forbidden field/row mutation from an infrastructure failure.
+            throw new ForbiddenException(e.getMessage(), e);
         } catch (IllegalArgumentException e) {
             Log.errorf(e, "Failed to convert entity to type %s", root.getName());
             Map<String, Object> error = new HashMap<>();
@@ -415,6 +438,71 @@ public class QueryGatewayResource {
             error.put("message", "Failed to save entity: " + e.getMessage());
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(error).build();
         }
+    }
+
+    /**
+     * Applies the same row/field governance expected by a typed Morphia resource before the
+     * generic save delegates to its registered repository.
+     *
+     * <p>Creates are stamped into the caller's effective DataDomain; a request body cannot choose
+     * another tenant placement. Updates must resolve the existing row through the secured filter,
+     * preserve its DataDomain, and restore fields excluded by policy before repository validation
+     * and persistence. An unknown id is treated as not-found rather than an upsert so a caller
+     * cannot manufacture a cross-domain record with a chosen identifier.</p>
+     */
+    private void governEntityForSave(
+            Datastore datastore,
+            Class<? extends UnversionedBaseModel> root,
+            UnversionedBaseModel entity) {
+        if (SecurityContext.isIgnoringRules()) {
+            return;
+        }
+
+        PrincipalContext principal = SecurityContext.getPrincipalContext()
+                .orElseThrow(() -> ungovernedMutation("PrincipalContext"));
+        SecurityContext.getResourceContext()
+                .orElseThrow(() -> ungovernedMutation("ResourceContext"));
+
+        if (entity.getId() == null) {
+            if (principal.getDataDomain() == null) {
+                throw ungovernedMutation("principal DataDomain");
+            }
+            entity.setDataDomain(principal.getDataDomain());
+            return;
+        }
+
+        List<Filter> idFilters = new ArrayList<>();
+        idFilters.add(Filters.eq("_id", entity.getId()));
+        UnversionedBaseModel stored = datastore.find(root)
+                .filter(securedFilterArray(idFilters, root))
+                .first();
+        if (stored == null) {
+            throw new NotFoundException("Entity was not found in the caller's governed data scope");
+        }
+
+        entity.setDataDomain(stored.getDataDomain());
+        for (String path : excludedFieldPaths()) {
+            try {
+                FieldPolicyEnforcer.copyPath(stored, entity, path);
+            } catch (ReflectiveOperationException e) {
+                throw new WebApplicationException(
+                        Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                                .entity(Map.of(
+                                        "error", "FieldPolicyEnforcementFailed",
+                                        "message", "A protected field could not be preserved; the save was rejected."))
+                                .build());
+            }
+        }
+    }
+
+    private WebApplicationException ungovernedMutation(String missingContext) {
+        Log.warnf("QueryGateway refusing ungoverned save: missing %s", missingContext);
+        return new WebApplicationException(
+                Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                        .entity(Map.of(
+                                "error", "SecurityContextMissing",
+                                "message", "Save cannot be governed: security context is not established for this request."))
+                        .build());
     }
 
     // ========================================================================
@@ -984,17 +1072,26 @@ public class QueryGatewayResource {
     /**
      * Field-level policy companion to {@link #securedFilterArray}: the deny-wins set of excluded
      * field paths for the current security context, mirroring
-     * {@code RepoSecurityFilterBuilder#buildExcludedFieldPaths}. Empty when rules are ignored or no
-     * principal is present (field exclusions are principal-relative).
+     * {@code RepoSecurityFilterBuilder#buildExcludedFieldPaths}. Empty only in an explicit
+     * ignore-rules scope; missing request security context fails closed.
      */
     private java.util.Set<String> excludedFieldPaths() {
         if (SecurityContext.isIgnoringRules()) {
             return java.util.Set.of();
         }
-        java.util.Optional<PrincipalContext> pc = SecurityContext.getPrincipalContext();
-        java.util.Optional<ResourceContext> rc = SecurityContext.getResourceContext();
+        Optional<PrincipalContext> pc = SecurityContext.getPrincipalContext();
+        Optional<ResourceContext> rc = SecurityContext.getResourceContext();
         if (pc.isEmpty() || rc.isEmpty()) {
-            return java.util.Set.of();
+            String missing = pc.isEmpty() && rc.isEmpty()
+                    ? "PrincipalContext and ResourceContext"
+                    : pc.isEmpty() ? "PrincipalContext" : "ResourceContext";
+            Log.warnf("QueryGateway refusing field-policy resolution: missing %s", missing);
+            throw new WebApplicationException(
+                    Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                            .entity(Map.of(
+                                    "error", "SecurityContextMissing",
+                                    "message", "Field policy cannot be resolved: security context is not established for this request."))
+                            .build());
         }
         return ruleContext.getExcludedFieldPaths(pc.get(), rc.get());
     }
@@ -1028,26 +1125,32 @@ public class QueryGatewayResource {
     }
 
     private String resolveRealm(String requestRealm) {
-        // 1. Explicit realm from request takes highest priority
+        Optional<PrincipalContext> principal = SecurityContext.getPrincipalContext();
+        if (principal.isPresent() && !SecurityContext.isIgnoringRules()) {
+            PrincipalContext pc = principal.get();
+            String effectiveRealm = pc.getDefaultRealm();
+            if (pc.getArea2RealmOverrides() != null) {
+                String areaOverride = pc.getArea2RealmOverrides().get(FUNCTIONAL_AREA);
+                if (areaOverride != null && !areaOverride.isBlank()) {
+                    effectiveRealm = areaOverride;
+                    Log.debugf("Using area2RealmOverride for area '%s': %s", FUNCTIONAL_AREA, areaOverride);
+                }
+            }
+            if (effectiveRealm == null || effectiveRealm.isBlank()) {
+                throw ungovernedMutation("effective realm");
+            }
+            if (requestRealm != null && !requestRealm.isBlank() && !requestRealm.equals(effectiveRealm)) {
+                throw new ForbiddenException("Requested realm does not match the authenticated operating realm");
+            }
+            return effectiveRealm;
+        }
+
+        // Bootstrap, migration, and explicitly rule-ignoring callers retain the existing explicit
+        // realm behavior. Authenticated governed requests are bound to the SecurityContext above.
         if (requestRealm != null && !requestRealm.isBlank()) {
             return requestRealm;
         }
-
-        // 2. Try to get from SecurityContext
-        return SecurityContext.getPrincipalContext()
-                .map(pc -> {
-                    // 2a. Check for area-specific realm override
-                    if (pc.getArea2RealmOverrides() != null) {
-                        String areaOverride = pc.getArea2RealmOverrides().get(FUNCTIONAL_AREA);
-                        if (areaOverride != null && !areaOverride.isBlank()) {
-                            Log.debugf("Using area2RealmOverride for area '%s': %s", FUNCTIONAL_AREA, areaOverride);
-                            return areaOverride;
-                        }
-                    }
-                    // 2b. Use principal's default realm (includes X-Realm override if applied)
-                    return pc.getDefaultRealm();
-                })
-                .orElse(defaultRealm);
+        return defaultRealm;
     }
 
     /**

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -14,6 +14,7 @@ import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
 import com.e2eq.framework.model.persistent.morphia.RealmRepo;
+import com.e2eq.framework.api.system.SystemDirectory;
 import com.e2eq.framework.util.EnvConfigUtils;
 import com.e2eq.framework.util.SecurityUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -68,6 +69,9 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     RealmRepo realmRepo;
 
     @Inject
+    SystemDirectory systemDirectory;
+
+    @Inject
     CredentialRepo credentialRepo;
 
     @Inject
@@ -111,15 +115,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     // database. Default false preserves the strict local-credential behavior.
     @ConfigProperty(name = "quantum.auth.trust-token-claims", defaultValue = "false")
     boolean trustTokenClaims;
-
-    // Delegated-identity data-domain scoping: when true, a delegated principal (trusted-issuer
-    // token, no local credential) adopts the DATA DOMAIN of the tenant realm it operates in —
-    // resolved from that realm's registered Realm.DomainContext — instead of the cross-tenant
-    // system data domain. If the realm is NOT a registered tenant, the request FAILS CLOSED
-    // (403) rather than silently granting the system domain. Default false preserves the prior
-    // behavior (system data domain) for services that have not opted in.
-    @ConfigProperty(name = "quantum.auth.delegated.realm-scoped-domain", defaultValue = "false")
-    boolean delegatedRealmScopedDomain;
 
     @Inject
     com.e2eq.framework.security.runtime.RuleContext ruleContext;
@@ -632,7 +627,8 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             DataDomain dataDomain = creds.getDomainContext().toDataDomain(creds.getUserId());
             Log.debugf("buildIdentityContextWithCredentials: resolving roles with roleLookupRealm=%s, subject=%s",
                 roleLookupRealm, creds.getSubject());
-            String[] roles = resolveEffectiveRoles(securityIdentity, creds, roleLookupRealm);
+            String[] roles = resolveEffectiveRoles(
+                    securityIdentity, creds, credentialRealm, roleLookupRealm);
 
             PrincipalContext context = new PrincipalContext.Builder()
                     .withDefaultRealm(credentialRealm)
@@ -644,19 +640,9 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                     .withDataDomainPolicy(creds.getDataDomainPolicy())
                     .build();
             return new ContextBuildResult(context, creds);
-        } else {
-            // No credential found - fall back to system realm or override
-            String contextRealm = (realmOverride != null) ? realmOverride : envConfigUtils.getSystemRealm();
-            String[] roles = resolveEffectiveRoles(securityIdentity, null, contextRealm);
-            PrincipalContext context = new PrincipalContext.Builder()
-                    .withDefaultRealm(contextRealm)
-                    .withDataDomain(securityUtils.getSystemDataDomain())
-                    .withUserId(principalName)
-                    .withRoles(roles)
-                    .withScope("AUTHENTICATED")
-                    .build();
-            return new ContextBuildResult(context, null);
         }
+        throw new jakarta.ws.rs.ForbiddenException(
+                "Authenticated identity is not mapped to a Quantum credential");
     }
 
     private ContextBuildResult buildJwtContextWithCredentials(String authHeader, String realmOverride) {
@@ -693,7 +679,9 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         // Keep the base context on the credential's home realm. X-Realm is applied later by
         // applyRealmOverride(), but we still need the target realm here for role resolution.
         String credentialRealm = creds.getDomainContext().getDefaultRealm();
-        String roleLookupRealm = credentialRealm;
+        String signedRealm = claimString("realm");
+        String authorityRealm = signedRealm == null ? credentialRealm : signedRealm;
+        String roleLookupRealm = authorityRealm;
         Log.debugf("buildJwtContextWithCredentials: credential found for userId=%s, domainContext.defaultRealm=%s",
             creds.getUserId(), credentialRealm);
 
@@ -705,11 +693,17 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
         Log.debugf("buildJwtContextWithCredentials: resolving roles with roleLookupRealm=%s, subject=%s",
             roleLookupRealm, creds.getSubject());
-        String[] roles = resolveEffectiveRoles(securityIdentity, creds, roleLookupRealm);
-        DataDomain dataDomain = creds.getDomainContext().toDataDomain(creds.getUserId());
+        String[] roles = resolveEffectiveRoles(
+                securityIdentity, creds, authorityRealm, roleLookupRealm);
+        // Build the base context from the realm already authorized by the signed token.
+        // The X-Realm target is applied below by applyRealmOverride(), which records the
+        // original data domain and marks the request as an auditable realm override.
+        com.e2eq.framework.model.security.DomainContext effectiveDomainContext =
+                resolveDomainContext(creds, authorityRealm);
+        DataDomain dataDomain = effectiveDomainContext.toDataDomain(creds.getUserId());
         PrincipalContext context = new PrincipalContext.Builder()
-                .withDefaultRealm(credentialRealm)
-                .withDomainContext(creds.getDomainContext())
+                .withDefaultRealm(authorityRealm)
+                .withDomainContext(effectiveDomainContext)
                 .withDataDomain(dataDomain)
                 .withUserId(creds.getUserId())
                 .withRoles(roles)
@@ -736,10 +730,19 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         if (userId == null) userId = sub;
 
         String systemRealm = envConfigUtils.getSystemRealm();
-        String contextRealm = (realmOverride != null && !realmOverride.isBlank())
-                ? realmOverride
-                : systemRealm;
-        String[] roles = resolveEffectiveRoles(securityIdentity, null, contextRealm);
+        String signedRealm = claimString("realm");
+        if (signedRealm == null) {
+            throw new jakarta.ws.rs.ForbiddenException(
+                    "Trusted-issuer token is missing the required realm claim");
+        }
+        if (realmOverride != null && !realmOverride.isBlank()
+                && !realmOverride.equalsIgnoreCase(signedRealm)) {
+            throw new jakarta.ws.rs.ForbiddenException(
+                    "X-Realm does not match the realm authorized by the token");
+        }
+        String contextRealm = signedRealm;
+        String[] roles = resolveEffectiveRoles(
+                securityIdentity, null, signedRealm, contextRealm);
 
         Log.infof("Delegated identity: principal from trusted-issuer token claims (iss=%s, sub=%s, userId=%s, realm=%s, roles=%s)",
                 jwt.getIssuer(), sub, userId, contextRealm, java.util.Arrays.toString(roles));
@@ -749,22 +752,32 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         // The system domain is reserved for the system realm / system admins — never a silent
         // fallback for an ordinary tenant user. Gated so services opt in explicitly.
         DataDomain dataDomain;
-        if (!delegatedRealmScopedDomain || contextRealm.equals(systemRealm)) {
+        if (contextRealm.equalsIgnoreCase(systemRealm)) {
+            boolean hasSystemAuthority = Arrays.stream(roles)
+                    .anyMatch(role -> "system".equalsIgnoreCase(role));
+            if (!hasSystemAuthority) {
+                throw new jakarta.ws.rs.ForbiddenException(
+                        "The system realm requires system authority in the signed token");
+            }
             dataDomain = securityUtils.getSystemDataDomain();
         } else {
-            Optional<Realm> realmOpt = realmRepo.findByRefName(contextRealm, true, systemRealm);
-            if (realmOpt.isEmpty()) {
-                realmOpt = realmRepo.findByDatabaseName(contextRealm, true, systemRealm);
+            String tenantId = claimString("tenantId");
+            String orgRefName = claimString("orgRefName");
+            String accountNum = claimString("accountNum");
+            if (tenantId != null && orgRefName != null && accountNum != null) {
+                dataDomain = new DataDomain(orgRefName, accountNum, tenantId, 0, userId);
+            } else {
+                // Older trusted tokens may not carry the full data-domain projection. Resolve
+                // it through the deployment-mode SystemDirectory, but never substitute the
+                // system domain when the tenant catalog is unavailable.
+                Optional<Realm> realmOpt = systemDirectory.findRealmByRefName(contextRealm);
+                if (realmOpt.isEmpty() || realmOpt.get().getDomainContext() == null) {
+                    throw new jakarta.ws.rs.ForbiddenException(
+                            "Trusted-issuer token is missing tenant data-domain claims for realm '"
+                                    + contextRealm + "'");
+                }
+                dataDomain = realmOpt.get().getDomainContext().toDataDomain(userId);
             }
-            if (realmOpt.isEmpty() || realmOpt.get().getDomainContext() == null) {
-                // Fail closed: the realm is not a registered tenant. Do NOT grant the
-                // cross-tenant system data domain to a delegated principal.
-                Log.warnf("Delegated principal denied: realm '%s' is not a registered tenant "
-                        + "(no system-domain fallback under quantum.auth.delegated.realm-scoped-domain)", contextRealm);
-                throw new jakarta.ws.rs.ForbiddenException(
-                        "Realm '" + contextRealm + "' is not a registered tenant.");
-            }
-            dataDomain = realmOpt.get().getDomainContext().toDataDomain(userId);
         }
 
         PrincipalContext context = new PrincipalContext.Builder()
@@ -830,8 +843,8 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                     }
                 }
             } catch (Exception e) {
-                Log.warnf(e, "PrincipalContextPropertiesResolver %s failed; skipping",
-                    resolver.getClass().getName());
+                throw new IllegalStateException(
+                        "Principal context resolver failed: " + resolver.getClass().getName(), e);
             }
         }
 
@@ -886,15 +899,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             if (Objects.equals(creds.getSubject(), sub)) {
                 return ocreds;
             }
-            if (!isKnownIssuer(jwt.getIssuer())) {
-                Log.warnf(
-                    "Resolved external token subject %s to local userId %s using claim alias lookup; stored subject=%s",
-                    sub,
-                    candidate,
-                    creds.getSubject());
-                return ocreds;
-            }
-
             String text = String.format(
                 "Found user with userId %s but subject is:%s but token has subject:%s in the database, roles in credential is %s",
                 candidate, creds.getSubject(), sub, Arrays.toString(creds.getRoles()));
@@ -902,29 +906,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             throw new IllegalStateException(text);
         }
         return Optional.empty();
-    }
-
-    /**
-     * Check whether the given issuer matches any configured auth provider.
-     * Used to distinguish tokens issued by a known provider (where subject
-     * mismatches are errors) from external/unknown tokens (where claim-based
-     * lookup with a different subject is expected).
-     */
-    private boolean isKnownIssuer(String issuer) {
-        if (issuer == null) {
-            return false;
-        }
-        for (String providerName : authProvider.split(",")) {
-            try {
-                AuthProvider provider = authProviderFactory.getProviderByName(providerName.trim());
-                if (issuer.equals(provider.getIssuer())) {
-                    return true;
-                }
-            } catch (IllegalArgumentException e) {
-                Log.debugf("Auth provider '%s' not found during issuer check", providerName.trim());
-            }
-        }
-        return false;
     }
 
     private void addClaimCandidate(List<String> candidates, Object rawValue) {
@@ -941,77 +922,59 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     IdentityRoleResolver identityRoleResolver;
 
     /**
-     * @deprecated Use {@link #resolveEffectiveRoles(SecurityIdentity, CredentialUserIdPassword, String)} with explicit realm
-     */
-    @Deprecated
-    private String[] resolveEffectiveRoles(SecurityIdentity identity, CredentialUserIdPassword credential) {
-        // Fallback: use credential's domain context realm if available
-        String realm = (credential != null && credential.getDomainContext() != null)
-            ? credential.getDomainContext().getDefaultRealm()
-            : null;
-        return resolveEffectiveRoles(identity, credential, realm);
-    }
-
-    /**
      * Resolve effective roles for a user within a specific realm.
      * @param identity the security identity from the token
      * @param credential the user's credential
      * @param realm the target realm for UserProfile/UserGroup lookups (e.g., from X-Realm header)
      */
     private String[] resolveEffectiveRoles(SecurityIdentity identity, CredentialUserIdPassword credential, String realm) {
-        // Delegate to centralized resolver to keep logic consistent across endpoints and filter
-        if (identityRoleResolver != null) {
-            return identityRoleResolver.resolveEffectiveRoles(identity, credential, realm);
+        String authorityRealm = credential != null && credential.getDomainContext() != null
+                ? credential.getDomainContext().getDefaultRealm()
+                : realm;
+        return resolveEffectiveRoles(identity, credential, authorityRealm, realm);
+    }
+
+    private String[] resolveEffectiveRoles(SecurityIdentity identity,
+                                           CredentialUserIdPassword credential,
+                                           String authorityRealm,
+                                           String effectiveRealm) {
+        if (identityRoleResolver == null) {
+            throw new IllegalStateException("IdentityRoleResolver is required to build an authenticated principal");
         }
-        // Fallback for unit tests that construct SecurityFilter without CDI injection
-        java.util.Set<String> rolesSet = new java.util.LinkedHashSet<>();
-        if (identity != null) {
-            for (String role : identity.getRoles()) {
-                if (role != null && !role.isEmpty()) {
-                    rolesSet.add(role);
-                }
-            }
-        }
-        if (credential != null && credential.getRoles() != null && credential.getRoles().length > 0) {
-            rolesSet.addAll(java.util.Arrays.asList(credential.getRoles()));
-        }
-        if (credential != null) {
-            // Use the provided realm, or fall back to credential's realm context
-            String effectiveRealm = (realm != null && !realm.isBlank())
-                ? realm
-                : (credential.getDomainContext() != null)
-                    ? credential.getDomainContext().getDefaultRealm()
-                    : envConfigUtils.getSystemRealm();
-            java.util.Optional<com.e2eq.framework.model.security.UserProfile> userProfile = userProfileRepo.getBySubject(effectiveRealm, credential.getSubject());
-            if (userProfile.isPresent()) {
-                java.util.List<com.e2eq.framework.model.security.UserGroup> userGroups = userGroupRepo.findByUserProfileRef(userProfile.get().createEntityReference());
-                if (!userGroups.isEmpty()) {
-                    userGroups.forEach(userGroup -> rolesSet.addAll(userGroup.getRoles().stream().toList()));
-                }
-            }
-        }
-        return rolesSet.isEmpty() ? new String[]{"ANONYMOUS"} : rolesSet.toArray(new String[0]);
+        return identityRoleResolver.resolveEffectiveRoles(
+                identity, credential, authorityRealm, effectiveRealm);
     }
 
     private void validateRealmAccess(CredentialUserIdPassword creds, String realm) {
         if (realm != null) {
-            List<Realm> realmsAvailable = realmRepo.getAllListWithIgnoreRules(envConfigUtils.getSystemRealm());
-            List<String> realmRefNamesAvailable = new java.util.ArrayList<>(realmsAvailable.stream().map(Realm::getRefName).toList());
-
-            if (!realmRefNamesAvailable.contains(realm)) {
-                if (Log.isDebugEnabled()) {
-                    Log.debugf("Available realms determined by realm Collection in database: %s,  values: %s", envConfigUtils.getSystemRealm(), realmRefNamesAvailable.stream().collect(Collectors.joining(", ") ));
-                }
-                throw new IllegalArgumentException(String.format(
-                    "The realm override %s is not a configured Realm RefName in the realm collection in the database:%s", realm, envConfigUtils.getSystemRealm()));
+            if (systemDirectory.findRealmByRefName(realm).isEmpty()) {
+                throw new jakarta.ws.rs.ForbiddenException(String.format(
+                    "The realm override %s is not registered", realm));
             }
 
-            List<String> realmsAuthorized = securityUtils.computeAllowedRealmRefNames(creds, realmRefNamesAvailable);
+            List<String> realmsAuthorized = securityUtils.computeAllowedRealmRefNames(creds, List.of(realm));
             if (!realmsAuthorized.contains(realm)) {
-                throw new IllegalArgumentException(String.format(
+                throw new jakarta.ws.rs.ForbiddenException(String.format(
                     "The user %s is not authorized to access realm %s", creds.getUserId(), realm));
             }
         }
+    }
+
+    private com.e2eq.framework.model.security.DomainContext resolveDomainContext(
+            CredentialUserIdPassword credential,
+            String realm) {
+        com.e2eq.framework.model.security.DomainContext home = credential.getDomainContext();
+        if (home != null && realm != null && realm.equalsIgnoreCase(home.getDefaultRealm())) {
+            return home;
+        }
+        Realm target = systemDirectory.findRealmByRefName(realm)
+                .orElseThrow(() -> new jakarta.ws.rs.ForbiddenException(
+                        "Realm '" + realm + "' is not registered"));
+        if (target.getDomainContext() == null) {
+            throw new jakarta.ws.rs.ForbiddenException(
+                    "Realm '" + realm + "' has no data-domain configuration");
+        }
+        return target.getDomainContext();
     }
 
     private PrincipalContext handleImpersonation(ContainerRequestContext requestContext, PrincipalContext baseContext) {
@@ -1137,29 +1100,19 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         // Look up the target realm to get its default DomainContext
         // Use system realm for the lookup since realms are typically stored there
         Optional<com.e2eq.framework.model.security.Realm> targetRealmOpt =
-            realmRepo.findByRefName(realm, true, envConfigUtils.getSystemRealm());
-
-        // If not found by refName, try by databaseName (they're often the same)
-        if (targetRealmOpt.isEmpty()) {
-            targetRealmOpt = realmRepo.findByDatabaseName(realm, true, envConfigUtils.getSystemRealm());
-        }
+                systemDirectory.findRealmByRefName(realm);
 
         if (targetRealmOpt.isEmpty()) {
-            // Realm not found - log warning and return original context
-            // The realm was already validated in validateRealmAccess(), so this shouldn't normally happen
-            Log.warnf("Realm '%s' not found during realm override for user %s - using original DataDomain",
-                realm, context.getUserId());
-            return context;
+            throw new jakarta.ws.rs.ForbiddenException(
+                    "Realm '" + realm + "' is not registered");
         }
 
         com.e2eq.framework.model.security.Realm targetRealm = targetRealmOpt.get();
         com.e2eq.framework.model.security.DomainContext targetDomainContext = targetRealm.getDomainContext();
 
         if (targetDomainContext == null) {
-            // Realm has no DomainContext configured
-            Log.warnf("Realm '%s' has no DomainContext configured - cannot apply realm override for user %s",
-                realm, context.getUserId());
-            return context;
+            throw new jakarta.ws.rs.ForbiddenException(
+                    "Realm '" + realm + "' has no data-domain configuration");
         }
 
         // Create the effective DataDomain using the target realm's context but keeping caller's userId as owner

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
@@ -1,6 +1,7 @@
 package com.e2eq.framework.rest.resources;
 
 
+import com.e2eq.framework.annotations.FunctionalMapping;
 import com.e2eq.framework.model.persistent.morphia.RealmRepo;
 import com.e2eq.framework.model.auth.AuthProviderFactory;
 import com.e2eq.framework.model.auth.UserManagement;
@@ -68,6 +69,7 @@ import java.util.*;
         )
 )
 @Path("/security")
+@FunctionalMapping(area = "SECURITY", domain = "CREDENTIAL_USERID_PASSWORD")
 @Tag(name = "security", description = "Operations related to security")
 @RequestScoped
 public class SecurityResource {
@@ -296,19 +298,20 @@ public class SecurityResource {
         if (Log.isInfoEnabled())
             Log.info("Authentication Attempt:" + authRequest.getUserId() + " Address:" + ((remoteAddress != null) ? remoteAddress : "unknown") + " UserAgent:" + ((userAgent != null) ? userAgent : "unknown"));
 
-        String qrealm = headers.getRequestHeaders().getFirst("X-Realm");
-        String realm= null;
-        if (qrealm != null ) {
-            Log.infof("Overriding to realm:%s ",  qrealm);
-            realm = qrealm;
+        String headerRealm = normalizeLoginRealm(headers.getRequestHeaders().getFirst("X-Realm"));
+        String bodyRealm = normalizeLoginRealm(authRequest.getRealm());
+        if (headerRealm != null && bodyRealm != null && !headerRealm.equalsIgnoreCase(bodyRealm)) {
+            throw new BadRequestException("Conflicting login realms were supplied in the request body and X-Realm header");
         }
+        String realm = bodyRealm != null ? bodyRealm : headerRealm;
 
         Log.infof("Logging in userid: %s realm: %s",authRequest.getUserId(), realm);
 
         try {
             String providerOverride = (provider == null || provider.isBlank()) ? null : provider;
             AuthLoginService.LoginResult loginResult = authLoginService.login(
-                    authRequest.getUserId(), authRequest.getPassword(), providerOverride, authRequest.getApplicationId());
+                    authRequest.getUserId(), authRequest.getPassword(), providerOverride,
+                    authRequest.getApplicationId(), realm);
             if (loginResult.authenticated()) {
                 Log.info("Login successful for userId:" + authRequest.getUserId() + " provider:" + loginResult.response().getAuthProvider());
                 return Response.ok(loginResult.response()).build();
@@ -369,8 +372,16 @@ public class SecurityResource {
          */
     }
 
+    private static String normalizeLoginRealm(String realm) {
+        if (realm == null || realm.isBlank()) {
+            return null;
+        }
+        return realm.trim();
+    }
+
     @POST
     @Path("/create-user")
+    @FunctionalMapping(area = "SECURITY", domain = "CREDENTIAL_USERID_PASSWORD")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({ "admin", "system"})
@@ -644,6 +655,29 @@ public class SecurityResource {
     public Response disableRealmOverride( @QueryParam("subject") String subject) {
         authProviderFactory.getUserManager().disableRealmOverrideWithSubject(subject);
         return Response.ok().build();
+    }
+
+    @PUT
+    @RolesAllowed({"admin", "system"})
+    @Path("/enableApplicationOverride")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response enableApplicationOverride(@QueryParam("subject") String subject,
+                                              @QueryParam("applicationRegEx") String applicationRegEx) {
+        try {
+            return Response.ok(credentialRepo.saveApplicationRegExBySubject(subject, applicationRegEx)).build();
+        } catch (IllegalArgumentException invalidPattern) {
+            throw new BadRequestException(invalidPattern.getMessage());
+        }
+    }
+
+    @PUT
+    @RolesAllowed({"admin", "system"})
+    @Path("/disableApplicationOverride")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response disableApplicationOverride(@QueryParam("subject") String subject) {
+        return Response.ok(credentialRepo.saveApplicationRegExBySubject(subject, null)).build();
     }
 
     @PUT

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/TenantProvisioningResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/TenantProvisioningResource.java
@@ -1,5 +1,6 @@
 package com.e2eq.framework.rest.resources;
 
+import com.e2eq.framework.annotations.FunctionalMapping;
 import com.e2eq.framework.rest.models.RestError;
 import com.e2eq.framework.rest.requests.TenantProvisioningRetryRequest;
 import com.e2eq.framework.rest.responses.TenantProvisioningRunResponse;
@@ -29,6 +30,7 @@ import io.quarkus.arc.properties.IfBuildProperty;
  * Minimal REST endpoint to provision a new tenant. Intended for admin use.
  */
 @Path("/admin/tenants")
+@FunctionalMapping(area = "SECURITY", domain = "REALM")
 @Tag(name = "security", description = "Operations related to tenant provisioning")
 @IfBuildProperty(name = "quantum.system-rest.enabled", stringValue = "true", enableIfMissing = true) // control-plane admin surface; one-switch opt-out (CONTROL_PLANE_SPLIT_DESIGN.md Phase B, wp3 tier 1)
 public class TenantProvisioningResource {
@@ -145,12 +147,28 @@ public class TenantProvisioningResource {
         try {
             TenantProvisioningService.DeleteResult r = provisioningService.deleteTenant(realmId);
             return Response.ok(new DeleteTenantResponse(r)).build();
-        } catch (IllegalStateException | IllegalArgumentException e) {
+        } catch (UnsupportedOperationException e) {
+            Log.warn("Direct tenant deletion is disabled: " + e.getMessage());
+            throw buildProvisioningException(
+                Response.Status.CONFLICT,
+                "Direct tenant deletion is disabled.",
+                e.getMessage(),
+                null
+            );
+        } catch (IllegalArgumentException e) {
             Log.warn("Tenant deletion rejected: " + e.getMessage());
-            return Response.status(Response.Status.CONFLICT).entity(e.getMessage()).build();
+            throw buildProvisioningException(Response.Status.BAD_REQUEST, e.getMessage(), e.getMessage(), null);
+        } catch (IllegalStateException e) {
+            Log.warn("Tenant deletion rejected: " + e.getMessage());
+            throw buildProvisioningException(Response.Status.CONFLICT, e.getMessage(), e.getMessage(), null);
         } catch (Exception e) {
             Log.error("Tenant deletion failed", e);
-            return Response.serverError().entity(e.getMessage()).build();
+            throw buildProvisioningException(
+                Response.Status.INTERNAL_SERVER_ERROR,
+                "Tenant deletion failed.",
+                e.getMessage(),
+                null
+            );
         }
     }
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthCredentialService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthCredentialService.java
@@ -44,7 +44,9 @@ public class AuthCredentialService {
         if (credentialOptional.isPresent()) {
             CredentialUserIdPassword credential = credentialOptional.get();
             if (credential.getCredentialType() != null && credential.getCredentialType() != CredentialType.PASSWORD) {
-                return authProviderFactory.getUserManager();
+                throw new IllegalArgumentException(String.format(
+                        "Credential type %s does not support password management",
+                        credential.getCredentialType()));
             }
 
             if (credential.getIssuer() != null && !credential.getIssuer().isBlank()) {
@@ -52,10 +54,9 @@ public class AuthCredentialService {
                 if (issuerProvider instanceof UserManagement userManagement) {
                     return userManagement;
                 }
-            }
-
-            if (credential.getAuthProviderName() != null && !credential.getAuthProviderName().isBlank()) {
-                return authProviderFactory.getUserManager(credential.getAuthProviderName());
+                throw new IllegalArgumentException(String.format(
+                        "Authentication provider for issuer '%s' does not support user management",
+                        credential.getIssuer()));
             }
         }
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
@@ -38,24 +38,29 @@ public class AuthLoginService {
     /** Application-authorization signals a provider may return as a negative login response. */
     private static final String APP_SELECTION_REQUIRED = "ApplicationSelectionRequired";
     private static final String APP_NOT_AUTHORIZED = "ApplicationNotAuthorized";
+    private static final String REALM_NOT_AUTHORIZED = "RealmNotAuthorized";
+    private static final String REALM_AUTHORIZATION_UNAVAILABLE = "RealmAuthorizationUnavailable";
 
     public LoginResult login(String userId, String password) {
-        return login(userId, password, null, null);
+        return login(userId, password, null, null, null);
     }
 
     public LoginResult login(String userId, String password, String providerOverride) {
-        return login(userId, password, providerOverride, null);
+        return login(userId, password, providerOverride, null, null);
     }
 
     public LoginResult login(String userId, String password, String providerOverride, String applicationId) {
-        Optional<CredentialUserIdPassword> credentialOptional = findLoginCredential(userId);
-        List<AuthProvider> authProviders = authProviderFactory.getLoginProviders(
-                providerOverride,
-                credentialOptional.map(CredentialUserIdPassword::getAuthProviderName).orElse(null));
+        return login(userId, password, providerOverride, applicationId, null);
+    }
+
+    public LoginResult login(String userId, String password, String providerOverride,
+                             String applicationId, String realmId) {
+        List<AuthProvider> authProviders = authProviderFactory.getLoginProviders(providerOverride);
 
         List<String> providerFailures = new ArrayList<>();
         for (AuthProvider authProvider : authProviders) {
-            AuthProvider.LoginResponse loginResponse = authProvider.login(userId, password, applicationId);
+            AuthProvider.LoginResponse loginResponse = dispatchLogin(
+                    authProvider, userId, password, applicationId, realmId);
             if (loginResponse.authenticated() && loginResponse.positiveResponse() != null) {
                 Optional<CredentialUserIdPassword> credentialOp = findCredential(
                         loginResponse.positiveResponse().identity() != null
@@ -79,9 +84,19 @@ public class AuthLoginService {
             if (negative != null && APP_NOT_AUTHORIZED.equals(negative.errorType())) {
                 return LoginResult.applicationDenied(negative.errorMessage());
             }
+            if (negative != null && (REALM_NOT_AUTHORIZED.equals(negative.errorType())
+                    || REALM_AUTHORIZATION_UNAVAILABLE.equals(negative.errorType()))) {
+                return LoginResult.realmDenied(negative.errorMessage());
+            }
             providerFailures.add(loginFailure(authProvider, loginResponse));
         }
         return LoginResult.failure(providerFailures);
+    }
+
+    static AuthProvider.LoginResponse dispatchLogin(AuthProvider provider, String userId,
+                                                     String password, String applicationId,
+                                                     String realmId) {
+        return provider.login(userId, password, applicationId, realmId);
     }
 
     public Optional<CredentialUserIdPassword> findCredential(String subject, String userId) {
@@ -105,23 +120,13 @@ public class AuthLoginService {
         if (userId == null || userId.isBlank()) {
             return Optional.empty();
         }
-        try {
-            Optional<CredentialUserIdPassword> byUserId = credentialRepo.findByUserId(
-                    userId,
-                    envConfigUtils.getSystemRealm(),
-                    true);
-            if (byUserId.isPresent()) {
-                return byUserId;
-            }
-        } catch (RuntimeException e) {
-            Log.debugf("Unable to resolve login credential in system realm for %s: %s", userId, e.getMessage());
-        }
-        try {
-            return credentialRepo.findByUserId(userId);
-        } catch (RuntimeException e) {
-            Log.debugf("Unable to resolve login credential for %s: %s", userId, e.getMessage());
-            return Optional.empty();
-        }
+        // Authentication semantics must not change when the credential store is
+        // unavailable. A lookup failure is an operational error, not evidence that
+        // the credential is absent and permission to try a different provider.
+        return credentialRepo.findByUserId(
+                userId,
+                envConfigUtils.getSystemRealm(),
+                true);
     }
 
     public List<AccessibleRealmInfo> resolveAccessibleRealms(CredentialUserIdPassword credential) {
@@ -185,6 +190,10 @@ public class AuthLoginService {
 
         /** Authenticated, but the requested application is not authorized for this user/realm. */
         public static LoginResult applicationDenied(String message) {
+            return new LoginResult(null, List.of(), Response.Status.FORBIDDEN.getStatusCode(), null, message);
+        }
+
+        public static LoginResult realmDenied(String message) {
             return new LoginResult(null, List.of(), Response.Status.FORBIDDEN.getStatusCode(), null, message);
         }
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
@@ -14,6 +14,7 @@ import com.e2eq.framework.model.persistent.morphia.RealmRepo;
 import com.e2eq.framework.model.persistent.morphia.RealmTenantMembershipRepo;
 import com.e2eq.framework.model.persistent.morphia.UserGroupRepo;
 import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
+import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.DomainContext;
 import com.e2eq.framework.model.security.Realm;
@@ -21,6 +22,7 @@ import com.e2eq.framework.model.security.RealmTenantMembership;
 import com.e2eq.framework.model.security.RealmSetupStatus;
 import com.e2eq.framework.model.security.UserGroup;
 import com.e2eq.framework.model.security.UserProfile;
+import com.e2eq.framework.model.security.UserRealmRole;
 import com.e2eq.framework.model.auth.AuthProviderFactory;
 import com.e2eq.framework.model.auth.UserManagement;
 import com.e2eq.framework.service.seed.*;
@@ -29,7 +31,6 @@ import com.e2eq.framework.model.securityrules.ResourceContext;
 import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.util.EnvConfigUtils;
 import com.mongodb.MongoCommandException;
-import com.mongodb.client.MongoClient;
 import dev.morphia.Datastore;
 import dev.morphia.query.filters.Filters;
 import io.quarkus.logging.Log;
@@ -68,8 +69,7 @@ public class TenantProvisioningService implements TenantLifecycle {
     @Inject RealmTenantMembershipRepo realmTenantMembershipRepo;
     @Inject UserProfileRepo userProfileRepo;
     @Inject UserGroupRepo userGroupRepo;
-    @Inject MongoClient mongoClient;
-
+    @Inject UserRealmRoleRepo userRealmRoleRepo;
     @Inject SeedLoaderService seedLoaderService;
 
     @Inject SeedDiscoveryService seedDiscoveryService;
@@ -285,9 +285,29 @@ public class TenantProvisioningService implements TenantLifecycle {
 
     public void ensureRealmCatalog(ProvisioningContext context) {
         Log.infof("  computed realmId: %s", context.getRealmId());
-        Optional<Realm> existingOpt = realmCatalog.findByEmailDomain(
+        Optional<Realm> existingByEmailDomain = realmCatalog.findByEmailDomain(
             context.getCommand().getTenantEmailDomain()
         );
+        Optional<Realm> existingByRefName = realmCatalog.findByRefName(context.getRealmId());
+
+        if (existingByEmailDomain.isPresent() && existingByRefName.isPresent()
+            && !Objects.equals(existingByEmailDomain.get().getRefName(), existingByRefName.get().getRefName())) {
+            throw new IllegalStateException(String.format(
+                "Realm catalog conflict: email domain '%s' resolves to realm '%s', but computed realm id '%s' "
+                    + "resolves to a different catalog entry",
+                context.getCommand().getTenantEmailDomain(),
+                existingByEmailDomain.get().getRefName(),
+                context.getRealmId()
+            ));
+        }
+
+        // A realm id is derived from the tenant domain. Distinct historical domain spellings can
+        // collapse to the same id (for example, dots and hyphens). Always inspect both keys so a
+        // provisioning retry fails with explicit differences instead of attempting a second
+        // registration against the same realm/database identity.
+        Optional<Realm> existingOpt = existingByEmailDomain.isPresent()
+            ? existingByEmailDomain
+            : existingByRefName;
 
         if (existingOpt.isPresent()) {
             Log.warnf("Realm %s already exists in the realm collection in realm %s", context.getRealmId(), context.getSystemRealm());
@@ -420,6 +440,13 @@ public class TenantProvisioningService implements TenantLifecycle {
             context.getDesiredRoles(),
             context.getDomainContext()
         );
+        ensureUserRealmRole(
+            context.getSystemRealm(),
+            context.getRealmId(),
+            context.getCommand().getAdminUserId(),
+            context.getDesiredRoles(),
+            context.getDomainContext()
+        );
 
         if (!context.getBaselineAdminUserId().equalsIgnoreCase(context.getCommand().getAdminUserId())) {
             ensureCredentialExists(
@@ -438,6 +465,13 @@ public class TenantProvisioningService implements TenantLifecycle {
                 context.getDesiredRoles(),
                 context.getDomainContext()
             );
+            ensureUserRealmRole(
+                context.getSystemRealm(),
+                context.getRealmId(),
+                context.getBaselineAdminUserId(),
+                context.getDesiredRoles(),
+                context.getDomainContext()
+            );
         }
 
         ensureCredentialExists(
@@ -452,6 +486,13 @@ public class TenantProvisioningService implements TenantLifecycle {
         ensureUserProfileInRealm(
             context.getRealmId(),
             context.getDemoUserId(),
+            context.getDemoUserId(),
+            Set.of("user"),
+            context.getDomainContext()
+        );
+        ensureUserRealmRole(
+            context.getSystemRealm(),
+            context.getRealmId(),
             context.getDemoUserId(),
             Set.of("user"),
             context.getDomainContext()
@@ -634,6 +675,47 @@ public class TenantProvisioningService implements TenantLifecycle {
         userGroupRepo.save(realmId, group);
     }
 
+    /**
+     * Reconciles the system-plane membership consumed by token issuance. Credentials are
+     * global identities; their flat roles describe only the compatibility/default realm.
+     * Every provisioned tenant therefore needs an explicit per-realm assignment or a login
+     * for that realm will correctly receive no tenant roles.
+     */
+    private void ensureUserRealmRole(String systemRealm,
+                                     String realmId,
+                                     String userId,
+                                     Set<String> roles,
+                                     DomainContext domainContext) {
+        CredentialUserIdPassword credential = systemDirectory.findCredentialByUserId(userId)
+            .orElseThrow(() -> new IllegalStateException(
+                "Credential was not found while creating realm membership for userId: " + userId
+            ));
+
+        UserRealmRole assignment = userRealmRoleRepo
+            .findAssignmentForRealmWithIgnoreRules(userId, realmId, systemRealm)
+            .orElseGet(() -> UserRealmRole.builder()
+                .refName("user-realm-role:" + userId + ":" + realmId)
+                .displayName(userId + " in " + realmId)
+                .userId(userId)
+                .realmRefName(realmId)
+                .build());
+
+        assignment.setUserId(userId);
+        assignment.setSubject(credential.getSubject());
+        assignment.setRealmRefName(realmId);
+        assignment.setRoles(roles.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList());
+        assignment.setSponsoringOrgRefName(domainContext.getOrgRefName());
+        assignment.setStatus(UserRealmRole.STATUS_ACTIVE);
+        assignment.setDataDomain(DataDomain.builder()
+            .orgRefName(domainContext.getOrgRefName())
+            .accountNum(domainContext.getAccountId())
+            .tenantId(domainContext.getTenantId())
+            .ownerId(userId)
+            .build());
+
+        userRealmRoleRepo.save(systemRealm, assignment);
+    }
+
     private void upsertUserProfileReference(List<EntityReference> members, String userId) {
         if (userId == null || userId.isBlank()) {
             return;
@@ -701,64 +783,11 @@ public class TenantProvisioningService implements TenantLifecycle {
         if (normalizedRealmId.isBlank()) {
             throw new IllegalArgumentException("realmId cannot be blank");
         }
-        if (realmCatalog.systemRealmId().equalsIgnoreCase(normalizedRealmId)) {
-            throw new IllegalStateException("Refusing to delete the configured system realm");
-        }
-
-        String systemRealm = realmCatalog.systemRealmId();
-        Realm realm = realmCatalog.findByRefName(normalizedRealmId)
-                .orElseThrow(() -> new IllegalStateException("Realm was not found in the system catalog: " + normalizedRealmId));
-
-        DeleteResult result = new DeleteResult();
-        result.realmId = normalizedRealmId;
-
-        Datastore systemDatastore = credentialRepo.getMorphiaDataStoreWrapper().getDataStore(systemRealm);
-        List<CredentialUserIdPassword> tenantCredentials = systemDatastore.find(CredentialUserIdPassword.class)
-                .filter(Filters.or(
-                        Filters.eq("domainContext.defaultRealm", normalizedRealmId),
-                        Filters.eq("domainContext.tenantId", realm.getEmailDomain()),
-                        Filters.eq("userId", realm.getDefaultAdminUserId())
-                ))
-                .iterator()
-                .toList();
-
-        for (CredentialUserIdPassword credential : tenantCredentials) {
-            try {
-                credentialRepo.delete(systemRealm, credential);
-                result.deletedCredentialCount++;
-            } catch (Exception e) {
-                String warning = String.format("Failed to delete credential %s: %s", credential.getUserId(), e.getMessage());
-                Log.warn(warning);
-                result.addWarning(warning);
-            }
-        }
-
-        try {
-            mongoClient.getDatabase(normalizedRealmId).drop();
-            result.databaseDropped = true;
-        } catch (Exception e) {
-            String warning = String.format("Failed to drop database %s: %s", normalizedRealmId, e.getMessage());
-            Log.warn(warning);
-            result.addWarning(warning);
-        }
-
-        try {
-            Datastore systemRealmDatastore = realmRepo.getMorphiaDataStoreWrapper().getDataStore(systemRealm);
-            long deletedCount = systemRealmDatastore.find(Realm.class)
-                    .filter(Filters.eq("_id", realm.getId()))
-                    .delete()
-                    .getDeletedCount();
-            result.realmCatalogDeleted = deletedCount > 0;
-            if (!result.realmCatalogDeleted) {
-                result.addWarning("Realm catalog entry was not deleted from the system catalog: " + normalizedRealmId);
-            }
-        } catch (Exception e) {
-            String warning = String.format("Failed to delete realm catalog entry %s: %s", normalizedRealmId, e.getMessage());
-            Log.warn(warning);
-            result.addWarning(warning);
-        }
-
-        return result;
+        throw new UnsupportedOperationException(
+            "Direct destructive tenant deletion is disabled. Use the governed realm lifecycle "
+                + "decommission workflow; hard archive-and-drop is available only through its "
+                + "separately authorized system-administrator workflow."
+        );
     }
 
     @FunctionalInterface

--- a/quantum-framework/src/test/java/com/e2eq/framework/api/grammar/TestGrammar.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/api/grammar/TestGrammar.java
@@ -75,7 +75,20 @@ public class TestGrammar {
 
    @Test
    public void testFilterGeneration() throws IOException {
-      try (FileInputStream fstream = new FileInputStream("src/test/resources/testQueryStrings.txt")) {
+       PrincipalContext principalContext = new PrincipalContext.Builder()
+               .withDataDomain(testUtils.getTestDataDomain())
+               .withDefaultRealm(testRealm)
+               .withUserId(testUtils.getTestUserId())
+               .withRoles(new String[]{"user"})
+               .withScope("test")
+               .build();
+       ResourceContext resourceContext = new ResourceContext.Builder()
+               .withRealm(testRealm)
+               .withArea("test")
+               .withFunctionalDomain("query")
+               .withAction("view")
+               .build();
+       try (FileInputStream fstream = new FileInputStream("src/test/resources/testQueryStrings.txt")) {
 
          try (BufferedReader reader = new BufferedReader(new InputStreamReader(fstream))) {
             String line;
@@ -89,9 +102,16 @@ public class TestGrammar {
                   continue;
                }
 
+               // Relationship predicates are integration-tested with a tenant ontology store.
+               // This legacy fixture only verifies context-free scalar filter lowering.
+               if (line.startsWith("hasEdge(")) {
+                  continue;
+               }
+
                Log.info("Processing query: " + line);
 
-               Filter f = MorphiaUtils.convertToFilter(line, UserProfile.class);
+               Filter f = MorphiaUtils.convertToFilterWContext(
+                       line, principalContext, resourceContext, UserProfile.class);
                Log.info("Filter:" + f.toString());
                lcount++;
             }

--- a/quantum-framework/src/test/java/com/e2eq/framework/api/query/QueryGatewayGovernanceIT.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/api/query/QueryGatewayGovernanceIT.java
@@ -2,7 +2,9 @@ package com.e2eq.framework.api.query;
 
 import com.e2eq.framework.model.persistent.base.CodeList;
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.persistent.base.ProjectionField;
 import com.e2eq.framework.model.persistent.morphia.MorphiaDataStoreWrapper;
+import com.e2eq.framework.model.persistent.morphia.CodeListRepo;
 import com.e2eq.framework.model.security.Rule;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
@@ -10,6 +12,7 @@ import com.e2eq.framework.model.securityrules.RuleEffect;
 import com.e2eq.framework.model.securityrules.SecurityURI;
 import com.e2eq.framework.model.securityrules.SecurityURIBody;
 import com.e2eq.framework.model.securityrules.SecurityURIHeader;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.security.runtime.RuleContext;
 import com.e2eq.framework.security.runtime.SecuritySession;
 import com.e2eq.framework.util.TestUtils;
@@ -17,11 +20,14 @@ import dev.morphia.MorphiaDatastore;
 import dev.morphia.query.filters.Filters;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -53,6 +59,9 @@ public class QueryGatewayGovernanceIT {
 
     @Inject
     RuleContext ruleContext;
+
+    @Inject
+    CodeListRepo codeListRepo;
 
     private String realm;
     private String marker;
@@ -90,7 +99,29 @@ public class QueryGatewayGovernanceIT {
         cl.setDescription("secret-" + key);
         cl.setValueType("STRING");
         cl.setDataDomain(dd);
-        return ds.save(cl);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            return ds.save(cl);
+        }
+    }
+
+    private void installDescriptionExclusionRule() {
+        SecurityURIHeader header = new SecurityURIHeader.Builder()
+                .withIdentity("admin").withArea("*").withFunctionalDomain("*").withAction("*").build();
+        SecurityURIBody body = new SecurityURIBody.Builder()
+                .withOrgRefName("*").withAccountNumber("*").withRealm("*")
+                .withTenantId("*").withOwnerId("*").withDataSegment("*").build();
+        Rule excludeRule = new Rule.Builder()
+                .withName("gateway-test-exclude-description-" + marker)
+                .withSecurityURI(new SecurityURI(header, body))
+                .withEffect(RuleEffect.ALLOW)
+                .withAndFilterString("dataDomain.tenantId:${pTenantId}")
+                .withExcludedFields(List.of("description"))
+                .withPriority(-50)
+                .withFinalRule(false)
+                .build();
+        ruleContext.addRule(header, excludeRule);
+        ruleContext.clearCacheForRealm(realm);
+        RuleContext.clearRequestCache();
     }
 
     @SuppressWarnings("unchecked")
@@ -151,25 +182,7 @@ public class QueryGatewayGovernanceIT {
 
     @Test
     public void find_strips_excluded_fields() {
-        SecurityURIHeader header = new SecurityURIHeader.Builder()
-                .withIdentity("admin").withArea("*").withFunctionalDomain("*").withAction("*").build();
-        SecurityURIBody body = new SecurityURIBody.Builder()
-                .withOrgRefName("*").withAccountNumber("*").withRealm("*")
-                .withTenantId("*").withOwnerId("*").withDataSegment("*").build();
-        Rule excludeRule = new Rule.Builder()
-                .withName("gateway-test-exclude-description-" + marker)
-                .withSecurityURI(new SecurityURI(header, body))
-                .withEffect(RuleEffect.ALLOW)
-                .withAndFilterString("dataDomain.tenantId:${pTenantId}")
-                .withExcludedFields(List.of("description"))
-                .withPriority(-50)
-                .withFinalRule(false)
-                .build();
-        ruleContext.addRule(header, excludeRule);
-        // Invalidate the realm's compiled rule index so the newly added rule (with its
-        // excludedFields) is recompiled into the effective rule set for this realm.
-        ruleContext.clearCacheForRealm(realm);
-        RuleContext.clearRequestCache();
+        installDescriptionExclusionRule();
 
         try (SecuritySession ignored = new SecuritySession(pcA, rc)) {
             // Precondition: the rule's excludedFields must resolve for this principal/resource,
@@ -194,6 +207,209 @@ public class QueryGatewayGovernanceIT {
         } finally {
             ruleContext.clear();
             ruleContext.ensureDefaultRules();
+        }
+    }
+
+    @Test
+    public void repository_point_reads_apply_excluded_field_projection() {
+        CodeList stored = seedRow(ddA, marker + "-point", "point");
+        installDescriptionExclusionRule();
+
+        try (SecuritySession ignored = new SecuritySession(pcA, rc)) {
+            CodeList byId = codeListRepo.findById(stored.getId(), realm).orElseThrow();
+            assertNull(byId.getDescription(), "findById must apply field policy projection");
+
+            CodeList byRefName = codeListRepo.findByRefName(stored.getRefName(), realm).orElseThrow();
+            assertNull(byRefName.getDescription(), "findByRefName must apply field policy projection");
+
+            List<CodeList> byIds = codeListRepo.getListFromIds(realm, List.of(stored.getId()));
+            assertEquals(1, byIds.size());
+            assertNull(byIds.get(0).getDescription(), "getListFromIds must apply field policy projection");
+
+            List<CodeList> byRefNames = codeListRepo.getListFromRefNames(realm, List.of(stored.getRefName()));
+            assertEquals(1, byRefNames.size());
+            assertNull(byRefNames.get(0).getDescription(),
+                    "getListFromRefNames must apply field policy projection");
+
+            List<CodeList> protectedOnlyProjection = codeListRepo.getListByQuery(
+                    realm, 0, 10, "category:" + stored.getCategory(), null,
+                    List.of(new ProjectionField("description", ProjectionField.ProjectionType.INCLUDE)));
+            assertEquals(1, protectedOnlyProjection.size());
+            assertNotNull(protectedOnlyProjection.get(0).getId());
+            assertNull(protectedOnlyProjection.get(0).getDescription(),
+                    "removing the caller's only included field must not widen to a full document");
+            assertNotEquals(stored.getRefName(), protectedOnlyProjection.get(0).getRefName(),
+                    "an emptied include projection must not disclose the stored refName");
+        } finally {
+            ruleContext.clear();
+            ruleContext.ensureDefaultRules();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // (b) save uses the registered repository and cannot choose another DataDomain
+    // ------------------------------------------------------------------
+
+    @Test
+    public void save_create_stamps_callers_dataDomain_instead_of_request_body_domain() {
+        QueryGatewayResource.SaveRequest req = new QueryGatewayResource.SaveRequest();
+        req.rootType = CodeList.class.getName();
+        req.realm = realm;
+        req.entity = new HashMap<>();
+        req.entity.put("category", marker + "-save");
+        req.entity.put("key", "created");
+        req.entity.put("refName", marker + "-save:created");
+        req.entity.put("valueType", "STRING");
+        req.entity.put("dataDomain", ddB);
+
+        String id;
+        ResourceContext saveContext = testUtils.getResourceContext("integration", "query", "save");
+        try (SecuritySession ignored = new SecuritySession(pcA, saveContext)) {
+            Response response = resource.save(req);
+            assertEquals(200, response.getStatus());
+            QueryGatewayResource.SaveResponse body = (QueryGatewayResource.SaveResponse) response.getEntity();
+            id = body.id;
+        }
+
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realm);
+        CodeList stored = ds.find(CodeList.class)
+                .filter(Filters.eq("_id", new org.bson.types.ObjectId(id)))
+                .first();
+        assertNotNull(stored);
+        assertEquals(ddA.getTenantId(), stored.getDataDomain().getTenantId(),
+                "generic save must stamp the authenticated caller's DataDomain");
+        ds.find(CodeList.class).filter(Filters.eq("_id", stored.getId())).delete();
+    }
+
+    @Test
+    public void save_update_preserves_excluded_field_and_masks_save_response() {
+        CodeList stored = seedRow(ddA, marker + "-save-field", "protected");
+        installDescriptionExclusionRule();
+
+        QueryGatewayResource.SaveRequest req = new QueryGatewayResource.SaveRequest();
+        req.rootType = CodeList.class.getName();
+        req.realm = realm;
+        req.entity = new HashMap<>();
+        req.entity.put("id", stored.getId());
+        req.entity.put("category", stored.getCategory());
+        req.entity.put("key", stored.getKey());
+        req.entity.put("refName", stored.getRefName());
+        req.entity.put("version", stored.getVersion());
+        req.entity.put("description", "overwrite-attempt");
+        req.entity.put("valueType", "STRING");
+        req.entity.put("dataDomain", ddA);
+
+        ResourceContext saveContext = testUtils.getResourceContext("integration", "query", "save");
+        try (SecuritySession ignored = new SecuritySession(pcA, saveContext)) {
+            Response response = resource.save(req);
+            assertEquals(200, response.getStatus());
+            QueryGatewayResource.SaveResponse body = (QueryGatewayResource.SaveResponse) response.getEntity();
+            assertFalse(body.entity.containsKey("description"),
+                    "save response must not disclose a field excluded by policy");
+        } finally {
+            ruleContext.clear();
+            ruleContext.ensureDefaultRules();
+        }
+
+        CodeList persisted = morphiaDataStoreWrapper.getDataStore(realm).find(CodeList.class)
+                .filter(Filters.eq("_id", stored.getId())).first();
+        assertNotNull(persisted);
+        assertEquals("secret-protected", persisted.getDescription(),
+                "standard repository save must preserve the stored protected value");
+    }
+
+    @Test
+    public void save_create_rejects_policy_excluded_field() {
+        installDescriptionExclusionRule();
+        String refName = marker + "-create-field:protected";
+
+        QueryGatewayResource.SaveRequest req = new QueryGatewayResource.SaveRequest();
+        req.rootType = CodeList.class.getName();
+        req.realm = realm;
+        req.entity = new HashMap<>();
+        req.entity.put("category", marker + "-create-field");
+        req.entity.put("key", "protected");
+        req.entity.put("refName", refName);
+        req.entity.put("description", "create-attempt");
+        req.entity.put("valueType", "STRING");
+
+        ResourceContext saveContext = testUtils.getResourceContext("integration", "query", "save");
+        try (SecuritySession ignored = new SecuritySession(pcA, saveContext)) {
+            ForbiddenException denied = assertThrows(ForbiddenException.class, () -> resource.save(req));
+            assertTrue(denied.getMessage().contains("protected by field-level policy"));
+        } finally {
+            ruleContext.clear();
+            ruleContext.ensureDefaultRules();
+        }
+
+        CodeList persisted = morphiaDataStoreWrapper.getDataStore(realm).find(CodeList.class)
+                .filter(Filters.eq("refName", refName)).first();
+        assertNull(persisted, "a create containing a protected field must not be persisted");
+    }
+
+    @Test
+    public void direct_field_update_rejects_policy_excluded_path() {
+        CodeList stored = seedRow(ddA, marker + "-direct-field-update", "protected-update");
+        installDescriptionExclusionRule();
+
+        ResourceContext updateContext = testUtils.getResourceContext("integration", "query", "save");
+        try (SecuritySession ignored = new SecuritySession(pcA, updateContext)) {
+            MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realm);
+            assertThrows(SecurityException.class, () -> codeListRepo.update(
+                    ds, stored.getId(), Pair.of("description", "overwrite-attempt")));
+        } finally {
+            ruleContext.clear();
+            ruleContext.ensureDefaultRules();
+        }
+
+        CodeList persisted = morphiaDataStoreWrapper.getDataStore(realm).find(CodeList.class)
+                .filter(Filters.eq("_id", stored.getId())).first();
+        assertNotNull(persisted);
+        assertEquals("secret-protected-update", persisted.getDescription());
+    }
+
+    @Test
+    public void save_update_cannot_upsert_or_overwrite_cross_dataDomain_row() {
+        CodeList bRow = seedRow(ddB, marker + "-save-cross", "bSave");
+
+        QueryGatewayResource.SaveRequest req = new QueryGatewayResource.SaveRequest();
+        req.rootType = CodeList.class.getName();
+        req.realm = realm;
+        req.entity = new HashMap<>();
+        req.entity.put("id", bRow.getId());
+        req.entity.put("category", bRow.getCategory());
+        req.entity.put("key", bRow.getKey());
+        req.entity.put("refName", bRow.getRefName());
+        req.entity.put("description", "tenant-A-overwrite-attempt");
+        req.entity.put("valueType", "STRING");
+        req.entity.put("dataDomain", ddA);
+
+        ResourceContext saveContext = testUtils.getResourceContext("integration", "query", "save");
+        try (SecuritySession ignored = new SecuritySession(pcA, saveContext)) {
+            assertThrows(jakarta.ws.rs.NotFoundException.class, () -> resource.save(req));
+        }
+
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realm);
+        CodeList stored = ds.find(CodeList.class).filter(Filters.eq("_id", bRow.getId())).first();
+        assertNotNull(stored);
+        assertEquals("secret-bSave", stored.getDescription(),
+                "a cross-domain update must leave the stored row unchanged");
+    }
+
+    @Test
+    public void save_rejects_body_realm_that_differs_from_authenticated_realm() {
+        QueryGatewayResource.SaveRequest req = new QueryGatewayResource.SaveRequest();
+        req.rootType = CodeList.class.getName();
+        req.realm = realm + "-OTHER";
+        req.entity = new HashMap<>();
+        req.entity.put("category", marker + "-realm");
+        req.entity.put("key", "wrong-realm");
+        req.entity.put("refName", marker + "-realm:wrong-realm");
+        req.entity.put("valueType", "STRING");
+
+        ResourceContext saveContext = testUtils.getResourceContext("integration", "query", "save");
+        try (SecuritySession ignored = new SecuritySession(pcA, saveContext)) {
+            assertThrows(jakarta.ws.rs.ForbiddenException.class, () -> resource.save(req));
         }
     }
 

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterResolveEffectiveRolesTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterResolveEffectiveRolesTest.java
@@ -5,8 +5,11 @@ import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.UserGroup;
 import com.e2eq.framework.model.security.UserProfile;
 import com.e2eq.framework.model.persistent.morphia.UserGroupRepo;
+import com.e2eq.framework.model.persistent.morphia.IdentityRoleResolver;
 import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
-import com.e2eq.framework.rest.models.Role;
+import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
+import com.e2eq.framework.model.security.UserRealmRole;
+import com.e2eq.framework.util.EnvConfigUtils;
 import io.quarkus.security.identity.SecurityIdentity;
 import org.junit.jupiter.api.Test;
 
@@ -66,25 +69,54 @@ public class SecurityFilterResolveEffectiveRolesTest {
         public List<UserGroup> findByUserProfileRef(EntityReference userProfileRef) {
             return byEntityRef.getOrDefault(userProfileRef.getEntityRefName(), Collections.emptyList());
         }
+        @Override
+        public List<UserGroup> findByUserProfileRefWithIgnoreRules(String realm, EntityReference userProfileRef) {
+            return findByUserProfileRef(userProfileRef);
+        }
+    }
+
+    private static class StubUserRealmRoleRepo extends UserRealmRoleRepo {
+        @Override
+        public Optional<UserRealmRole> findActiveAssignmentForRealmWithIgnoreRules(
+                String userId, String realmRefName, String systemRealmId) {
+            return Optional.empty();
+        }
     }
 
     private static SecurityFilter newFilterWithRepos(StubUserProfileRepo upr, StubUserGroupRepo ugr) throws Exception {
         SecurityFilter filter = new SecurityFilter();
         setField(filter, "userProfileRepo", upr);
         setField(filter, "userGroupRepo", ugr);
+        IdentityRoleResolver resolver = new IdentityRoleResolver();
+        setDeclaredField(resolver, IdentityRoleResolver.class, "userProfileRepo", upr);
+        setDeclaredField(resolver, IdentityRoleResolver.class, "userGroupRepo", ugr);
+        setDeclaredField(resolver, IdentityRoleResolver.class, "userRealmRoleRepo", new StubUserRealmRoleRepo());
+        EnvConfigUtils envConfig = new EnvConfigUtils();
+        envConfig.setSystemRealm("system-com");
+        setDeclaredField(resolver, IdentityRoleResolver.class, "envConfigUtils", envConfig);
+        setField(filter, "identityRoleResolver", resolver);
         return filter;
     }
 
     private static void setField(Object target, String fieldName, Object value) throws Exception {
-        Field f = SecurityFilter.class.getDeclaredField(fieldName);
+        setDeclaredField(target, SecurityFilter.class, fieldName, value);
+    }
+
+    private static void setDeclaredField(Object target, Class<?> owner, String fieldName, Object value) throws Exception {
+        Field f = owner.getDeclaredField(fieldName);
         f.setAccessible(true);
         f.set(target, value);
     }
 
-    private static String[] invokeResolveEffectiveRoles(SecurityFilter filter, SecurityIdentity identity, CredentialUserIdPassword cred) throws Exception {
-        Method m = SecurityFilter.class.getDeclaredMethod("resolveEffectiveRoles", SecurityIdentity.class, CredentialUserIdPassword.class);
+    private static String[] invokeResolveEffectiveRoles(
+            SecurityFilter filter,
+            SecurityIdentity identity,
+            CredentialUserIdPassword cred,
+            String realm) throws Exception {
+        Method m = SecurityFilter.class.getDeclaredMethod(
+                "resolveEffectiveRoles", SecurityIdentity.class, CredentialUserIdPassword.class, String.class);
         m.setAccessible(true);
-        return (String[]) m.invoke(filter, identity, cred);
+        return (String[]) m.invoke(filter, identity, cred, realm);
     }
 
     @Test
@@ -129,7 +161,7 @@ public class SecurityFilterResolveEffectiveRolesTest {
 
         SecurityFilter filter = newFilterWithRepos(upr, ugr);
 
-        String[] effective = invokeResolveEffectiveRoles(filter, identity, cred);
+        String[] effective = invokeResolveEffectiveRoles(filter, identity, cred, "realmA");
         Set<String> result = new HashSet<>(Arrays.asList(effective));
 
         // Expected union: identity(user, viewer) U cred(editor, user) U groups(user, admin, developer)
@@ -145,7 +177,7 @@ public class SecurityFilterResolveEffectiveRolesTest {
         StubUserGroupRepo ugr = new StubUserGroupRepo();
         SecurityFilter filter = newFilterWithRepos(upr, ugr);
 
-        String[] effective = invokeResolveEffectiveRoles(filter, identity, null);
+        String[] effective = invokeResolveEffectiveRoles(filter, identity, null, "system-com");
         assertArrayEquals(new String[]{"ANONYMOUS"}, effective);
     }
 }

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/resources/TenantProvisioningResourceIT.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/resources/TenantProvisioningResourceIT.java
@@ -1,19 +1,26 @@
 package com.e2eq.framework.rest.resources;
 
+import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
+import com.e2eq.framework.util.EnvConfigUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
 @TestSecurity(user = "sysAdmin@system-com", roles = {"admin"})
 public class TenantProvisioningResourceIT {
+
+    @Inject UserRealmRoleRepo userRealmRoleRepo;
+    @Inject EnvConfigUtils envConfigUtils;
 
     @Test
     void provision_with_archetype_applies_seed_packs() {
@@ -45,6 +52,15 @@ public class TenantProvisioningResourceIT {
 
         String realm = response.getString("realmId");
         String executionRef = response.getString("executionRef");
+
+        assertThat(
+            userRealmRoleRepo.findActiveRolesForRealmWithIgnoreRules(
+                "admin@demo-archetype.example",
+                realm,
+                envConfigUtils.getSystemRealm()
+            ),
+            containsInAnyOrder("admin", "user")
+        );
 
         given()
             .when()

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/services/AuthCredentialServiceTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/services/AuthCredentialServiceTest.java
@@ -54,7 +54,7 @@ class AuthCredentialServiceTest {
     }
 
     @Test
-    void credentialAuthProviderNameRoutesToNamedProvider() {
+    void credentialAuthProviderNameIsProvenanceNotRouting() {
         TestAuthProviderFactory factory = new TestAuthProviderFactory();
         TestUserManager defaultManager = new TestUserManager("custom", "https://custom.example.com");
         TestUserManager oidcManager = new TestUserManager("oidc", "https://oidc.example.com");
@@ -65,11 +65,11 @@ class AuthCredentialServiceTest {
         credential.setAuthProviderName("oidc");
         AuthCredentialService service = service(factory, Optional.of(credential));
 
-        assertSame(oidcManager, service.resolveUserManager("alice", null));
+        assertSame(defaultManager, service.resolveUserManager("alice", null));
     }
 
     @Test
-    void nonPasswordCredentialFallsBackToDefaultProvider() {
+    void nonPasswordCredentialCannotUsePasswordManagement() {
         TestAuthProviderFactory factory = new TestAuthProviderFactory();
         TestUserManager defaultManager = new TestUserManager("custom", "https://custom.example.com");
         TestUserManager oidcManager = new TestUserManager("oidc", "https://oidc.example.com");
@@ -81,7 +81,8 @@ class AuthCredentialServiceTest {
         credential.setAuthProviderName("oidc");
         AuthCredentialService service = service(factory, Optional.of(credential));
 
-        assertSame(defaultManager, service.resolveUserManager("alice", null));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.resolveUserManager("alice", null));
     }
 
     @Test

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/services/AuthLoginServiceRealmTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/services/AuthLoginServiceRealmTest.java
@@ -1,0 +1,37 @@
+package com.e2eq.framework.rest.services;
+
+import com.e2eq.framework.model.auth.AuthProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthLoginServiceRealmTest {
+
+    @Test
+    void selectedRealmIsForwardedToAuthenticationProvider() {
+        AtomicReference<String> selectedRealm = new AtomicReference<>();
+        AuthProvider provider = new AuthProvider() {
+            @Override public SecurityIdentity validateAccessToken(String token) { return null; }
+            @Override public String getName() { return "test"; }
+            @Override public LoginResponse login(String userId, String password) { return failure(); }
+            @Override public LoginResponse login(String userId, String password,
+                                                  String applicationId, String realmId) {
+                selectedRealm.set(realmId);
+                return failure();
+            }
+            @Override public LoginResponse refreshTokens(String refreshToken) { return failure(); }
+            private LoginResponse failure() {
+                return new LoginResponse(false, new LoginNegativeResponse(
+                    "local-test", 401, 401, "test", "test", "test", "system-com"));
+            }
+        };
+
+        AuthLoginService.dispatchLogin(
+            provider, "local-test", "secret", "helixor-di", "northstar-field-service-com");
+
+        assertEquals("northstar-field-service-com", selectedRealm.get());
+    }
+}

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/AccessListResolverRuleIndexTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/AccessListResolverRuleIndexTest.java
@@ -78,9 +78,11 @@ public class AccessListResolverRuleIndexTest extends BaseRepoTest {
                 .build();
         p.getRules().add(r);
 
-        policyRepo.save(realm, p);
-        // reload which will build the index due to the TestProfile override
-        ruleContext.reloadFromRepo(realm);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            policyRepo.save(realm, p);
+            // Reload the fixture without applying the policy being installed to its own write.
+            ruleContext.reloadFromRepo(realm);
+        }
 
         // Build contexts that match the resolver's supports() and the rule
         PrincipalContext pc = new PrincipalContext.Builder()

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/AccessListResolverRuleTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/AccessListResolverRuleTest.java
@@ -81,8 +81,10 @@ public class AccessListResolverRuleTest extends BaseRepoTest {
                 .build();
         p.getRules().add(r);
 
-        policyRepo.save(realm, p);
-        ruleContext.reloadFromRepo(realm);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            policyRepo.save(realm, p);
+            ruleContext.reloadFromRepo(realm);
+        }
 
         // Build contexts that match the resolver's supports() and the rule
         PrincipalContext pc = new PrincipalContext.Builder()

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/AccessListResolverStringLiteralTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/AccessListResolverStringLiteralTest.java
@@ -75,8 +75,10 @@ public class AccessListResolverStringLiteralTest extends BaseRepoTest {
                 .build();
         p.getRules().add(r);
 
-        policyRepo.save(realm, p);
-        ruleContext.reloadFromRepo(realm);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            policyRepo.save(realm, p);
+            ruleContext.reloadFromRepo(realm);
+        }
 
         // Build contexts that match the resolver's supports() and the rule
         PrincipalContext pc = new PrincipalContext.Builder()

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/CheckEvalModeTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/CheckEvalModeTest.java
@@ -61,8 +61,10 @@ public class CheckEvalModeTest extends BaseRepoTest {
                 .withFinalRule(false)
                 .build();
         p.getRules().add(r);
-        policyRepo.save(realm, p);
-        ruleContext.reloadFromRepo(realm);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            policyRepo.save(realm, p);
+            ruleContext.reloadFromRepo(realm);
+        }
     }
 
     private PrincipalContext pc(String realm) {

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/TestRuleContext.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/TestRuleContext.java
@@ -364,10 +364,11 @@ public class TestRuleContext extends BaseRepoTest {
                 .withFinalRule(false)
                 .build();
         userOwnResourcesPolicy.getRules().add(viewOwnRule);
-        policyRepo.save(testRealm, userOwnResourcesPolicy);
-
-        // Reload so the just-seeded policy (plus default system rules) is loaded for the test realm.
-        injectedRuleContext.reloadFromRepo(testRealm);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            policyRepo.save(testRealm, userOwnResourcesPolicy);
+            // Reload so the just-seeded policy (plus default system rules) is loaded for the test realm.
+            injectedRuleContext.reloadFromRepo(testRealm);
+        }
 
         // test that an admin can view system admins profile.
         // Admin should have access via the adminTenantPolicy from seed data
@@ -477,8 +478,10 @@ public class TestRuleContext extends BaseRepoTest {
         userPolicy.getRules().add(denyDelete);
 
         // Persist and hydrate
-        policyRepo.save(realm, userPolicy);
-        injectedRuleContext.reloadFromRepo(realm);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            policyRepo.save(realm, userPolicy);
+            injectedRuleContext.reloadFromRepo(realm);
+        }
 
         // Build principal and resource contexts
         String userId = testUtils.getTestUserId();
@@ -535,8 +538,10 @@ public class TestRuleContext extends BaseRepoTest {
                 .build();
         adminPolicy.getRules().add(adminAllowAll);
 
-        policyRepo.save(realm, adminPolicy);
-        injectedRuleContext.reloadFromRepo(realm);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            policyRepo.save(realm, adminPolicy);
+            injectedRuleContext.reloadFromRepo(realm);
+        }
 
         // Build principal and a random resource context
         PrincipalContext admin = new PrincipalContext.Builder()

--- a/quantum-framework/src/test/java/com/e2eq/framework/seeds/TestSeederService.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/seeds/TestSeederService.java
@@ -9,6 +9,7 @@ import com.e2eq.framework.model.security.*;
 import com.e2eq.framework.model.securityrules.FilterJoinOp;
 import com.e2eq.framework.security.runtime.RuleContext;
 import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.model.securityrules.SecurityURI;
 import com.e2eq.framework.model.securityrules.SecurityURIBody;
 import com.e2eq.framework.model.securityrules.SecurityURIHeader;
@@ -43,6 +44,8 @@ public class TestSeederService {
 
         int writes = 0;
 
+        try (SecurityCallScope.Scope privilegedSeedScope = SecurityCallScope.openIgnoringRules()) {
+
         // Ensure the system credential exists so repository security context resolution can succeed
         try { writes += ensureSystemCredential(); } catch (Throwable t) { Log.debug("ensureSystemCredential failed", t); }
 
@@ -67,7 +70,7 @@ public class TestSeederService {
                 .withRealm(envConfigUtils.getSystemRealm())
                 .withArea("security")
                 .withFunctionalDomain("auth")
-                .withAction("seed")
+                .withAction("WRITE")
                 .withOwnerId(pc.getUserId())
                 .build();
         com.e2eq.framework.model.securityrules.SecurityContext.setResourceContext(rc);
@@ -130,11 +133,12 @@ public class TestSeederService {
         // Finally, refresh rule context so tests can use the new policies
         try { ruleContext.reloadFromRepo(realm); } catch (Throwable t) { Log.debug("reloadFromRepo failed", t); }
 
-        // Clear contexts set for seeding
-        com.e2eq.framework.model.securityrules.SecurityContext.clearResourceContext();
-        com.e2eq.framework.model.securityrules.SecurityContext.clearPrincipalContext();
-
-        return writes;
+            return writes;
+        } finally {
+            // Never leak the test fixture's elevated contexts into the next test.
+            com.e2eq.framework.model.securityrules.SecurityContext.clearResourceContext();
+            com.e2eq.framework.model.securityrules.SecurityContext.clearPrincipalContext();
+        }
     }
 
     private int ensureCredentialInRealm(String userId, String realm, DataDomain fallback) {

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/TenantLifecycleAdapterTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/TenantLifecycleAdapterTest.java
@@ -83,4 +83,16 @@ class TenantLifecycleAdapterTest {
         Assertions.assertEquals(3, contract.deletedCredentialCount());
         Assertions.assertEquals(List.of(), contract.warnings());
     }
+
+    @Test
+    void directDeleteFailsClosedWithoutTouchingRealmPersistence() {
+        TenantProvisioningService service = new TenantProvisioningService();
+
+        UnsupportedOperationException exception = Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> service.deleteTenant("acme-com")
+        );
+
+        Assertions.assertTrue(exception.getMessage().contains("governed realm lifecycle"));
+    }
 }

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/TenantProvisioningServiceCatalogTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/TenantProvisioningServiceCatalogTest.java
@@ -1,0 +1,114 @@
+package com.e2eq.framework.service;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.model.security.Realm;
+import com.e2eq.framework.system.catalog.RealmCatalogService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TenantProvisioningServiceCatalogTest {
+
+    @Test
+    void rejectsHistoricalDomainSpellingThatCollidesWithExistingRealmId() {
+        Realm existing = realm(
+            "northstar-field-service-com",
+            "northstar.field.service.com",
+            "northstar.field.service.com"
+        );
+        Realm desired = realm(
+            "northstar-field-service-com",
+            "northstar-field-service.com",
+            "northstar-field-service.com"
+        );
+        RecordingRealmCatalog catalog = new RecordingRealmCatalog(existing);
+        TenantProvisioningService service = new TenantProvisioningService();
+        service.realmCatalog = catalog;
+
+        TenantProvisioningService.ProvisionTenantCommand command =
+            TenantProvisioningService.ProvisionTenantCommand.builder()
+                .tenantDisplayName("Northstar Field Service")
+                .tenantEmailDomain("northstar-field-service.com")
+                .orgRefName("northstar-field-service")
+                .accountId("0000000001")
+                .adminUserId("local-test")
+                .adminSubject("local-test-subject")
+                .adminPassword("unused-in-catalog-test")
+                .build();
+        TenantProvisioningService.ProvisioningContext context =
+            TenantProvisioningService.ProvisioningContext.builder()
+                .command(command)
+                .result(new TenantProvisioningService.ProvisionResult())
+                .systemRealm("system-com")
+                .realmId("northstar-field-service-com")
+                .desiredRealm(desired)
+                .build();
+
+        IllegalStateException error = assertThrows(
+            IllegalStateException.class,
+            () -> service.ensureRealmCatalog(context)
+        );
+
+        assertTrue(error.getMessage().contains("emailDomain"));
+        assertTrue(error.getMessage().contains("northstar.field.service.com"));
+        assertTrue(error.getMessage().contains("northstar-field-service.com"));
+        assertFalse(catalog.registerCalled);
+    }
+
+    private static Realm realm(String refName, String emailDomain, String tenantId) {
+        DataDomain dataDomain = DataDomain.builder()
+            .orgRefName("northstar-field-service")
+            .accountNum("0000000001")
+            .tenantId(tenantId)
+            .ownerId("local-test")
+            .build();
+        DomainContext domainContext = DomainContext.builder()
+            .tenantId(tenantId)
+            .defaultRealm(refName)
+            .orgRefName("northstar-field-service")
+            .accountId("0000000001")
+            .build();
+        return Realm.builder()
+            .refName(refName)
+            .displayName("Northstar Field Service")
+            .emailDomain(emailDomain)
+            .databaseName(refName)
+            .domainContext(domainContext)
+            .dataDomain(dataDomain)
+            .defaultAdminUserId("local-test")
+            .defaultPerspective("TENANT_ADMIN")
+            .build();
+    }
+
+    private static final class RecordingRealmCatalog extends RealmCatalogService {
+        private final Realm existing;
+        private boolean registerCalled;
+
+        private RecordingRealmCatalog(Realm existing) {
+            this.existing = existing;
+        }
+
+        @Override
+        public Optional<Realm> findByEmailDomain(String emailDomain) {
+            return Optional.of(existing)
+                .filter(realm -> realm.getEmailDomain().equals(emailDomain));
+        }
+
+        @Override
+        public Optional<Realm> findByRefName(String refName) {
+            return Optional.of(existing)
+                .filter(realm -> realm.getRefName().equals(refName));
+        }
+
+        @Override
+        public Realm register(Realm realm) {
+            registerCalled = true;
+            return realm;
+        }
+    }
+}

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/MorphiaSeedRepositoryIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/MorphiaSeedRepositoryIntegrationTest.java
@@ -11,6 +11,7 @@ import com.e2eq.framework.persistent.TestEntityReferenceHolderRepo;
 import com.e2eq.framework.persistent.TestParentRepo;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.test.AuthorModel;
 import com.e2eq.framework.test.BookModel;
@@ -70,6 +71,8 @@ class MorphiaSeedRepositoryIntegrationTest {
     @Inject
     TestParentRepo testParentRepo;
 
+    private SecurityCallScope.Scope ignoredRulesScope;
+
     @BeforeEach
     void setup() {
         // Clean DB
@@ -91,10 +94,15 @@ class MorphiaSeedRepositoryIntegrationTest {
                 .build();
         SecurityContext.setPrincipalContext(pc);
         SecurityContext.setResourceContext(rc);
+        ignoredRulesScope = SecurityCallScope.openIgnoringRules();
     }
 
     @AfterEach
     void cleanUpThreads() {
+       if (ignoredRulesScope != null) {
+          ignoredRulesScope.close();
+          ignoredRulesScope = null;
+       }
        SecurityContext.clear();
     }
 

--- a/quantum-framework/src/test/java/com/e2eq/framework/system/TestFieldPolicyEnforcer.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/system/TestFieldPolicyEnforcer.java
@@ -25,6 +25,11 @@ public class TestFieldPolicyEnforcer {
         }
     }
 
+    static class PrimitiveRecord {
+        boolean enabled;
+        int priority;
+    }
+
     @Test
     public void masksTopLevelAndNestedPaths() {
         Order order = new Order("O-1", "12 Main St", new Pricing(10.5, 0.3));
@@ -38,17 +43,40 @@ public class TestFieldPolicyEnforcer {
     }
 
     @Test
-    public void masksCollectionsElementWiseAndIgnoresUnknownPaths() {
+    public void masksCollectionsElementWise() {
         List<Order> orders = List.of(
             new Order("O-1", "A", new Pricing(1.0, 0.1)),
             new Order("O-2", "B", new Pricing(2.0, 0.2)));
 
-        FieldPolicyEnforcer.mask(orders, Set.of("pricing", "noSuchField", "no.such.path"));
+        FieldPolicyEnforcer.mask(orders, Set.of("pricing"));
 
         for (Order order : orders) {
             Assertions.assertNull(order.pricing);
             Assertions.assertNotNull(order.orderId);
         }
+    }
+
+    @Test
+    public void masksPrimitiveFieldsToTheirDefaultValues() {
+        PrimitiveRecord record = new PrimitiveRecord();
+        record.enabled = true;
+        record.priority = 7;
+
+        FieldPolicyEnforcer.mask(record, Set.of("enabled", "priority"));
+
+        Assertions.assertFalse(record.enabled);
+        Assertions.assertEquals(0, record.priority);
+    }
+
+    @Test
+    public void unknownReadPolicyPathFailsClosed() {
+        Order order = new Order("O-1", "A", new Pricing(1.0, 0.1));
+
+        IllegalStateException failure = Assertions.assertThrows(IllegalStateException.class,
+            () -> FieldPolicyEnforcer.mask(order, Set.of("pricing.noSuchField")));
+
+        Assertions.assertTrue(failure.getMessage().contains("failing closed"));
+        Assertions.assertInstanceOf(NoSuchFieldException.class, failure.getCause());
     }
 
     @Test
@@ -60,5 +88,32 @@ public class TestFieldPolicyEnforcer {
 
         Assertions.assertEquals(10.5, incoming.pricing.unitPrice, "hidden field overwrite must be reverted");
         Assertions.assertEquals(0.99, incoming.pricing.margin, "non-protected sibling stays");
+    }
+
+    @Test
+    public void unknownWritePolicyPathFailsClosed() {
+        Order stored = new Order("O-1", "A", new Pricing(1.0, 0.1));
+        Order incoming = new Order("O-1", "B", new Pricing(2.0, 0.2));
+
+        Assertions.assertThrows(NoSuchFieldException.class,
+            () -> FieldPolicyEnforcer.copyPath(stored, incoming, "pricing.noSuchField"));
+    }
+
+    @Test
+    public void createRejectsProtectedValuesInsteadOfSilentlyClearingThem() {
+        Order incoming = new Order("O-1", "12 Main St", new Pricing(10.5, 0.3));
+
+        SecurityException failure = Assertions.assertThrows(SecurityException.class,
+            () -> FieldPolicyEnforcer.assertUnset(incoming, Set.of("shippingAddress", "pricing.margin")));
+
+        Assertions.assertTrue(failure.getMessage().contains("protected by field-level policy"));
+    }
+
+    @Test
+    public void createAllowsPayloadWhenProtectedPathsAreUnset() {
+        Order incoming = new Order("O-1", null, new Pricing(10.5, null));
+
+        Assertions.assertDoesNotThrow(
+            () -> FieldPolicyEnforcer.assertUnset(incoming, Set.of("shippingAddress", "pricing.margin")));
     }
 }

--- a/quantum-framework/src/test/java/com/e2eq/framework/test/TestEquals.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/test/TestEquals.java
@@ -1,6 +1,7 @@
 package com.e2eq.framework.test;
 
 import com.e2eq.framework.persistent.TestParentRepo;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import io.quarkus.test.junit.QuarkusTest;
 
 import jakarta.inject.Inject;
@@ -23,9 +24,11 @@ public class TestEquals {
       ParentModel t2 = new ParentModel();
       t2.setTestField("test");
       Assertions.assertEquals(t, t2);
-      ParentModel t3 = parentRepo.save(t);
-      Optional<ParentModel> t4 = parentRepo.findById(t3.getId().toHexString(), true);
-      assertTrue(t4.isPresent());
-      Assertions.assertEquals(t3, t4.get());
+      try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+         ParentModel t3 = parentRepo.save(t);
+         Optional<ParentModel> t4 = parentRepo.findById(t3.getId().toHexString(), true);
+         assertTrue(t4.isPresent());
+         Assertions.assertEquals(t3, t4.get());
+      }
    }
 }

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -13,12 +13,14 @@ import com.e2eq.framework.model.auth.RoleAssignment;
 import com.e2eq.framework.model.auth.RoleSource;
 import com.e2eq.framework.model.auth.UserManagement;
 import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.RealmRepo;
 import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
 import com.e2eq.framework.model.persistent.morphia.UserGroupRepo;
 import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
 import com.e2eq.framework.model.security.CredentialRefreshToken;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.model.security.Realm;
 import com.e2eq.framework.model.security.UserRealmRole;
 import com.e2eq.framework.plugins.BaseAuthProvider;
 import com.e2eq.framework.model.security.UserGroup;
@@ -35,8 +37,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
@@ -46,12 +46,6 @@ import java.util.Arrays;
 
 @ApplicationScoped
 public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthProvider, ClaimsAuthProvider, UserManagement{
-
-   @ConfigProperty(name = "auth.jwt.secret")
-   String secretKey;
-
-   @ConfigProperty(name = "auth.jwt.expiration")
-   Long expirationInMinutes;
 
    @ConfigProperty(name = "mp.jwt.verify.issuer")
    String issuer;
@@ -73,6 +67,9 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
 
    @Inject
    CredentialRepo credentialRepo;
+
+   @Inject
+   RealmRepo realmRepo;
 
    @Inject
    UserRealmRoleRepo userRealmRoleRepo;
@@ -480,11 +477,16 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
 
    @Override
    public LoginResponse login (String userId, String password) {
-      return login(userId, password, (String) null);
+      return login(userId, password, null, null);
    }
 
    @Override
    public LoginResponse login (String userId, String password, String applicationId) {
+      return login(userId, password, applicationId, null);
+   }
+
+   @Override
+   public LoginResponse login (String userId, String password, String applicationId, String requestedRealm) {
       try {
          String configuredRealm = envConfigUtils.getSystemRealm();
          Log.infof("Checking for auth against %s realm", configuredRealm);
@@ -510,30 +512,43 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                boolean isCredentialValid = EncryptionUtils.checkPassword(password, credential.getPasswordHash());
                if (isCredentialValid) {
                   // String authToken = generateAuthToken(userId);
-                  Set<String> groups = new HashSet<>(Arrays.asList(credential.getRoles()));
+                  String credentialRealm = (credential.getDomainContext() != null)
+                     ? credential.getDomainContext().getDefaultRealm()
+                     : envConfigUtils.getSystemRealm();
+                   String tokenRealm = (requestedRealm == null || requestedRealm.isBlank())
+                      ? credentialRealm
+                      : requestedRealm.trim();
+                   Optional<Realm> operatingRealm = Objects.equals(credentialRealm, tokenRealm)
+                      ? Optional.empty()
+                      : realmRepo.findByRefName(tokenRealm, true, envConfigUtils.getSystemRealm());
+                   if (!Objects.equals(credentialRealm, tokenRealm) && operatingRealm.isEmpty()) {
+                      return new LoginResponse(false,
+                         new LoginNegativeResponse(userId,
+                            403,
+                            403,
+                            "Realm is not registered: " + tokenRealm,
+                            "RealmNotAuthorized",
+                            tokenRealm,
+                            tokenRealm));
+                   }
+                  boolean credentialRealmAuthorized = securityUtils
+                     .computeAllowedRealmRefNames(credential, List.of(tokenRealm))
+                     .stream()
+                     .anyMatch(allowedRealm -> allowedRealm.equalsIgnoreCase(tokenRealm));
+                  Set<String> groups = new HashSet<>();
+                  if (Objects.equals(credentialRealm, tokenRealm) && credential.getRoles() != null) {
+                     groups.addAll(Arrays.asList(credential.getRoles()));
+                  }
 
-                  // Handle missing subject: use userId as fallback or generate one
                   String subject = credential.getSubject();
                   if (subject == null || subject.isEmpty()) {
-                     Log.warnf("Credential for userId:%s has null or empty subject, using userId as fallback", userId);
-                     // Use userId as fallback, or generate UUID if userId is also null/empty
-                     if (credential.getUserId() != null && !credential.getUserId().isEmpty()) {
-                        subject = credential.getUserId();
-                     } else {
-                        subject = java.util.UUID.randomUUID().toString();
-                        Log.warnf("Both subject and userId are null/empty for credential, generated new subject: %s", subject);
-                     }
-                     // Update the credential with the generated subject to fix it for future logins
-                     credential.setSubject(subject);
-                     credentialRepo.save(credential);
+                     throw new IllegalStateException(
+                        "Credential subject is required for userId: " + userId);
                   }
 
                   // B4 membership ADR: one global identity, per-realm roles.
                   // Union the user's UserRealmRole assignment for the realm
                   // this token is scoped to into the token's role claims.
-                  String tokenRealm = (credential.getDomainContext() != null)
-                     ? credential.getDomainContext().getDefaultRealm()
-                     : envConfigUtils.getSystemRealm();
                   Optional<UserRealmRole> realmAssignment = Optional.empty();
                   java.util.Set<String> realmAssignedRoles = new java.util.LinkedHashSet<>();
                   try {
@@ -541,7 +556,24 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                         userId, tokenRealm, envConfigUtils.getSystemRealm());
                      realmAssignment.map(UserRealmRole::getRoles).ifPresent(realmAssignedRoles::addAll);
                   } catch (Exception e) {
-                     Log.warn("Failed to resolve per-realm role assignments; continuing with credential roles", e);
+                     return new LoginResponse(false,
+                        new LoginNegativeResponse(userId,
+                           403,
+                           403,
+                           "Unable to verify authorization for realm: " + tokenRealm,
+                           "RealmAuthorizationUnavailable",
+                           tokenRealm,
+                           tokenRealm));
+                  }
+                  if (!credentialRealmAuthorized && realmAssignment.isEmpty()) {
+                     return new LoginResponse(false,
+                        new LoginNegativeResponse(userId,
+                           403,
+                           403,
+                           "Not authorized for realm: " + tokenRealm,
+                           "RealmNotAuthorized",
+                           tokenRealm,
+                           tokenRealm));
                   }
                   groups.addAll(realmAssignedRoles);
 
@@ -550,10 +582,11 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                   // (single default audience, unchanged behavior); RESOLVED = multi-aud
                   // token + azp; AMBIGUOUS/DENIED short-circuit to a negative response the
                   // login resource maps to 400 (needs selection) / 403 (not authorized).
-                  ApplicationAuthorizationResolver.Result appAuth = ApplicationAuthorizationResolver.resolve(
-                     realmAssignment.map(UserRealmRole::getAuthorizedApplications).orElse(null),
-                     realmAssignment.map(UserRealmRole::getDefaultApplication).orElse(null),
-                     applicationId);
+                   ApplicationAuthorizationResolver.Result appAuth = ApplicationAuthorizationResolver.resolve(
+                      realmAssignment.map(UserRealmRole::getAuthorizedApplications).orElse(null),
+                      credential.getApplicationRegEx(),
+                      realmAssignment.map(UserRealmRole::getDefaultApplication).orElse(null),
+                      applicationId);
                   switch (appAuth.outcome()) {
                      case AMBIGUOUS:
                         return new LoginResponse(false,
@@ -573,6 +606,14 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                         break; // LEGACY or RESOLVED — mint below
                   }
 
+                  DomainContext tokenDomainContext = Objects.equals(credentialRealm, tokenRealm)
+                     ? credential.getDomainContext()
+                     : operatingRealm.map(Realm::getDomainContext).orElse(null);
+                  if (tokenDomainContext == null) {
+                     throw new IllegalStateException(
+                        "Realm has no data-domain configuration: " + tokenRealm);
+                  }
+
                   String authToken;
                   if (appAuth.resolved()) {
                      if (appAuth.wildcard()) {
@@ -581,7 +622,12 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                      }
                      authToken = TokenUtils.generateUserToken(
                         subject,
+                        credential.getUserId(),
                         groups,
+                        tokenRealm,
+                        tokenDomainContext.getTenantId(),
+                        tokenDomainContext.getOrgRefName(),
+                        tokenDomainContext.getAccountId(),
                         appAuth.audiences(),
                         appAuth.activeApplication(),
                         TokenUtils.expiresAt(durationInSeconds),
@@ -589,25 +635,37 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                   } else {
                      authToken = TokenUtils.generateUserToken(
                         subject,
+                        credential.getUserId(),
                         groups,
+                        tokenRealm,
+                        tokenDomainContext.getTenantId(),
+                        tokenDomainContext.getOrgRefName(),
+                        tokenDomainContext.getAccountId(),
                         TokenUtils.expiresAt(durationInSeconds),
                         issuer);
                   }
 
-                  String refreshToken = generateRefreshToken(credential.getUserId(), authToken,
-                     TokenUtils.currentTimeInSecs() + durationInSeconds + TokenUtils.REFRESH_ADDITIONAL_DURATION_SECONDS);
+                  String refreshToken = generateRefreshToken(
+                     subject,
+                     credential.getUserId(),
+                     tokenRealm,
+                     appAuth.resolved() ? appAuth.activeApplication() : null,
+                     authToken,
+                     durationInSeconds);
                   SecurityIdentity identity = validateAccessToken(authToken);
                   // Compute role provenance locally for login response: IDP + CREDENTIAL + USERGROUP
                   // Auth plugins do NOT need to do this; it's optional for login response only.
                   // Use the credential's realm context instead of hardcoded system realm
                   String realm = tokenRealm;
                   java.util.Set<String> idpRoles = (identity != null) ? new java.util.LinkedHashSet<>(identity.getRoles()) : java.util.Set.of();
-                  java.util.Set<String> credentialRoles = new java.util.LinkedHashSet<>(Arrays.asList(credential.getRoles()));
+                  java.util.Set<String> credentialRoles = credentialRolesForRealm(
+                     credential.getRoles(), credentialRealm, tokenRealm);
                   java.util.Set<String> userGroupRoles = new java.util.LinkedHashSet<>();
                   try {
                      var userProfileOpt = userProfileRepo.getBySubject(realm, subject);
                      if (userProfileOpt.isPresent()) {
-                        var userGroups = userGroupRepo.findByUserProfileRef(userProfileOpt.get().createEntityReference());
+                        var userGroups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
+                           realm, userProfileOpt.get().createEntityReference());
                         if (userGroups != null) {
                            for (UserGroup g : userGroups) {
                               if (g != null && g.getRoles() != null) {
@@ -617,7 +675,9 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                         }
                      }
                   } catch (Exception e) {
-                     Log.warn("Failed to expand roles via user groups; continuing without group roles", e);
+                     throw new IllegalStateException(
+                        "Unable to resolve user-group roles for user '" + userId
+                           + "' in realm '" + tokenRealm + "'", e);
                   }
 
                   java.util.Set<String> rolesSet = new java.util.LinkedHashSet<>();
@@ -692,80 +752,129 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
       }
    }
 
+   static Set<String> credentialRolesForRealm(String[] roles, String credentialRealm, String tokenRealm) {
+      if (!Objects.equals(credentialRealm, tokenRealm) || roles == null) {
+         return Set.of();
+      }
+      return new LinkedHashSet<>(Arrays.asList(roles));
+   }
+
    @Override
    public LoginResponse refreshTokens (String refreshToken) {
-      SecurityIdentity identity = validateAccessToken(refreshToken);
-      String refreshSubject = identity.getPrincipal().getName();
-      String newRefreshToken = null;
       try {
-         // Recompute provenance for refresh; optional for plugins, framework handles groups for checks
-         java.util.Set<String> idpRoles = (identity != null) ? new java.util.LinkedHashSet<>(identity.getRoles()) : java.util.Set.of();
-         java.util.Set<String> credentialRoles = new java.util.LinkedHashSet<>();
-         java.util.Set<String> userGroupRoles = new java.util.LinkedHashSet<>();
+         var refreshJwt = jwtParser.parse(refreshToken);
+         if (!TokenUtils.REFRESH_SCOPE.equals(claimString(refreshJwt, "scope"))) {
+            throw new SecurityException("Token is not a refresh token");
+         }
+         String refreshSubject = refreshJwt.getSubject();
+         String tokenRealm = claimString(refreshJwt, "realm");
+         String tokenUserId = claimString(refreshJwt, "userId");
+         String activeApplication = claimString(refreshJwt, "azp");
+         if (refreshSubject == null || refreshSubject.isBlank() || tokenRealm == null) {
+            throw new SecurityException("Refresh token is missing subject or realm authority");
+         }
+
          String configuredRealm = envConfigUtils.getSystemRealm();
-         Optional<CredentialUserIdPassword> ocred = getCredentials(configuredRealm, refreshSubject);
-         if (ocred.isEmpty()) {
-            Optional<CredentialUserIdPassword> bySubject = credentialRepo.findBySubject(refreshSubject, configuredRealm, true);
-            if (bySubject.isPresent()) {
-               ocred = bySubject;
-            }
-         }
-         if (ocred.isEmpty()) {
-            throw new SecurityException(String.format("No credential found for refresh subject: %s", refreshSubject));
-         }
-
-         CredentialUserIdPassword credential = ocred.get();
+         CredentialUserIdPassword credential = credentialRepo
+            .findBySubject(refreshSubject, configuredRealm, true)
+            .orElseThrow(() -> new SecurityException(
+               "No credential found for refresh subject: " + refreshSubject));
          String userId = credential.getUserId();
-         String tokenSubject = credential.getSubject();
-         if (tokenSubject == null || tokenSubject.isBlank()) {
-            throw new SecurityException(String.format("Credential subject missing for userId: %s", userId));
+         if (tokenUserId != null && !tokenUserId.equals(userId)) {
+            throw new SecurityException("Refresh-token userId does not match its credential subject");
          }
 
-         String newAuthToken = generateAuthToken(tokenSubject);
-         newRefreshToken = generateRefreshToken(userId, newAuthToken, durationInSeconds);
-         final String[] responseRealm = new String[] { envConfigUtils.getSystemRealm() };
+         String credentialRealm = credential.getDomainContext() != null
+            ? credential.getDomainContext().getDefaultRealm()
+            : null;
+         if (credentialRealm == null) {
+            throw new SecurityException("Credential has no home realm: " + userId);
+         }
+
+         Optional<Realm> operatingRealm = Objects.equals(credentialRealm, tokenRealm)
+            ? Optional.empty()
+            : realmRepo.findByRefName(tokenRealm, true, configuredRealm);
+         if (!Objects.equals(credentialRealm, tokenRealm) && operatingRealm.isEmpty()) {
+            throw new SecurityException("Refresh-token realm is not registered: " + tokenRealm);
+         }
+
+         Optional<UserRealmRole> realmAssignment;
          try {
-            if (credential.getRoles() != null) {
-               for (String r : credential.getRoles()) {
-                       if (r != null) credentialRoles.add(r);
+            realmAssignment = userRealmRoleRepo.findActiveAssignmentForRealmWithIgnoreRules(
+               userId, tokenRealm, configuredRealm);
+         } catch (RuntimeException e) {
+            throw new SecurityException("Unable to verify realm authorization during refresh", e);
+         }
+         boolean credentialRealmAuthorized = securityUtils
+            .computeAllowedRealmRefNames(credential, List.of(tokenRealm))
+            .stream()
+            .anyMatch(tokenRealm::equalsIgnoreCase);
+         if (!credentialRealmAuthorized && realmAssignment.isEmpty()) {
+            throw new SecurityException("Credential is no longer authorized for realm: " + tokenRealm);
+         }
+
+         Set<String> credentialRoles = credentialRolesForRealm(
+            credential.getRoles(), credentialRealm, tokenRealm);
+         Set<String> realmRoles = new LinkedHashSet<>();
+         realmAssignment.map(UserRealmRole::getRoles).ifPresent(realmRoles::addAll);
+         Set<String> userGroupRoles = new LinkedHashSet<>();
+         userProfileRepo.getBySubject(tokenRealm, credential.getSubject()).ifPresent(profile -> {
+            var userGroups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
+               tokenRealm, profile.createEntityReference());
+            if (userGroups != null) {
+               for (UserGroup group : userGroups) {
+                  if (group != null && group.getRoles() != null) {
+                     userGroupRoles.addAll(group.getRoles());
+                  }
                }
             }
-            String credRealm = (credential.getDomainContext() != null)
-                  ? credential.getDomainContext().getDefaultRealm()
-                  : envConfigUtils.getSystemRealm();
-            responseRealm[0] = credRealm;
-            try {
-               userProfileRepo.getBySubject(credRealm, credential.getSubject()).ifPresent(profile -> {
-                  var userGroups = userGroupRepo.findByUserProfileRef(profile.createEntityReference());
-                  if (userGroups != null) {
-                     for (UserGroup g : userGroups) {
-                        if (g != null && g.getRoles() != null) {
-                           for (String r : g.getRoles()) {
-                              if (r != null) userGroupRoles.add(r);
-                           }
-                        }
-                     }
-                  }
-               });
-            } catch (Exception e) {
-               Log.warn("Failed to expand user-group roles during refresh; continuing", e);
-            }
-         } catch (Exception e) {
-            Log.warn("Credential lookup failed during refresh; proceeding with IDP roles only", e);
+         });
+
+         Set<String> allRoles = new LinkedHashSet<>();
+         allRoles.addAll(credentialRoles);
+         allRoles.addAll(realmRoles);
+         allRoles.addAll(userGroupRoles);
+
+         ApplicationAuthorizationResolver.Result appAuth = ApplicationAuthorizationResolver.resolve(
+            realmAssignment.map(UserRealmRole::getAuthorizedApplications).orElse(null),
+            credential.getApplicationRegEx(),
+            realmAssignment.map(UserRealmRole::getDefaultApplication).orElse(null),
+            activeApplication);
+         if (appAuth.outcome() == ApplicationAuthorizationResolver.Outcome.DENIED
+               || appAuth.outcome() == ApplicationAuthorizationResolver.Outcome.AMBIGUOUS) {
+            throw new SecurityException("Application authorization is no longer valid during refresh");
          }
 
-         java.util.Set<String> allRoles = new java.util.LinkedHashSet<>();
-         allRoles.addAll(idpRoles);
-         allRoles.addAll(credentialRoles);
-         allRoles.addAll(userGroupRoles);
+         DomainContext tokenDomainContext = Objects.equals(credentialRealm, tokenRealm)
+            ? credential.getDomainContext()
+            : operatingRealm.map(Realm::getDomainContext).orElse(null);
+         if (tokenDomainContext == null) {
+            throw new SecurityException("Realm has no data-domain configuration: " + tokenRealm);
+         }
+
+         String newAuthToken = appAuth.resolved()
+            ? TokenUtils.generateUserToken(
+               refreshSubject, userId, allRoles, tokenRealm,
+               tokenDomainContext.getTenantId(), tokenDomainContext.getOrgRefName(),
+               tokenDomainContext.getAccountId(), appAuth.audiences(),
+               appAuth.activeApplication(), TokenUtils.expiresAt(durationInSeconds), issuer)
+            : TokenUtils.generateUserToken(
+               refreshSubject, userId, allRoles, tokenRealm,
+               tokenDomainContext.getTenantId(), tokenDomainContext.getOrgRefName(),
+               tokenDomainContext.getAccountId(), TokenUtils.expiresAt(durationInSeconds), issuer);
+         String newRefreshToken = generateRefreshToken(
+            refreshSubject, userId, tokenRealm,
+            appAuth.resolved() ? appAuth.activeApplication() : null,
+            newAuthToken, durationInSeconds);
+         SecurityIdentity identity = validateAccessToken(newAuthToken);
 
          java.util.List<RoleAssignment> roleAssignments = allRoles.stream()
                  .filter(Objects::nonNull)
                  .map(role -> {
                     java.util.EnumSet<RoleSource> src = java.util.EnumSet.noneOf(RoleSource.class);
-                    if (idpRoles.contains(role)) src.add(RoleSource.TOKEN);
                     if (credentialRoles.contains(role)) src.add(RoleSource.CREDENTIAL);
                     if (userGroupRoles.contains(role)) src.add(RoleSource.USERGROUP);
+                    if (realmRoles.contains(role)) src.add(RoleSource.REALM);
                     return new RoleAssignment(role, src);
                  })
                  .toList();
@@ -780,12 +889,14 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
               newRefreshToken,
               TokenUtils.currentTimeInSecs() + durationInSeconds,
               mongodbConnectionString,
-              responseRealm[0]));
-      } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+              tokenRealm,
+              appAuth.resolved() ? appAuth.audiences() : null,
+              appAuth.resolved() ? appAuth.activeApplication() : null));
+      } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException | ParseException e) {
          return new LoginResponse(false,
-            new LoginNegativeResponse(refreshSubject,
+            new LoginNegativeResponse(null,
                400,
-               500,
+               401,
                e.getMessage(),
                e.getClass().getName(),
                e.toString(),
@@ -797,10 +908,20 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
    public SecurityIdentity validateAccessToken (String token) {
       try {
          var jwt = jwtParser.parse(token);
-         String userId = jwt.getSubject();
+         if (!TokenUtils.AUTH_SCOPE.equals(claimString(jwt, "scope"))) {
+            throw new SecurityException("Token is not an access token");
+         }
+         String subject = jwt.getSubject();
          Set<String> roles = new HashSet<>(jwt.getGroups());
 
-         SecurityIdentity identity = buildIdentity(userId, roles);
+         SecurityIdentity identity = buildIdentity(subject, roles, Map.ofEntries(
+            Map.entry("userId", Objects.requireNonNullElse(claimString(jwt, "userId"), subject)),
+            Map.entry("realm", Objects.requireNonNullElse(claimString(jwt, "realm"), "")),
+            Map.entry("tenantId", Objects.requireNonNullElse(claimString(jwt, "tenantId"), "")),
+            Map.entry("orgRefName", Objects.requireNonNullElse(claimString(jwt, "orgRefName"), "")),
+            Map.entry("accountNum", Objects.requireNonNullElse(claimString(jwt, "accountNum"), "")),
+            Map.entry("activeApplication", Objects.requireNonNullElse(claimString(jwt, "azp"), ""))
+         ));
          return identity;
       } catch (ParseException e) {
          Log.error("Token validation failed", e);
@@ -812,6 +933,9 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
    public ProviderClaims validateTokenToClaims(String token) {
       try {
          var jwt = jwtParser.parse(token);
+         if (!TokenUtils.AUTH_SCOPE.equals(claimString(jwt, "scope"))) {
+            throw new SecurityException("Token is not an access token");
+         }
          String subject = jwt.getSubject();
          Set<String> roles = new HashSet<>(jwt.getGroups());
          ProviderClaims.Builder b = ProviderClaims.builder(subject)
@@ -824,6 +948,10 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
          if (email != null) b.putAttribute("email", email);
          String iss = jwt.getIssuer();
          if (iss != null) b.putAttribute("iss", iss);
+         for (String claim : List.of("userId", "realm", "tenantId", "orgRefName", "accountNum", "azp")) {
+            String value = claimString(jwt, claim);
+            if (value != null) b.putAttribute(claim, value);
+         }
          return b.build();
       } catch (ParseException e) {
          Log.error("Token validation to claims failed", e);
@@ -831,38 +959,21 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
       }
    }
 
-   private String generateAuthToken (String userId) {
-      try {
-         Date now = new Date();
-         Date expiration = new Date(now.getTime() + (expirationInMinutes * 60 * 1000));
-
-         String header = Base64.getUrlEncoder().encodeToString("{\"alg\":\"HS256\",\"typ\":\"JWT\"}".getBytes());
-         String payload =
-            Base64.getUrlEncoder().encodeToString(("{\"sub\":\"" + userId + "\",\"iat\":" + now.getTime() / 1000 + "," +
-                                                      "\"exp\":" + expiration.getTime() / 1000 + "}").getBytes());
-
-         String signature = sign(header + "." + payload, secretKey);
-
-         return header + "." + payload + "." + signature;
-      } catch (Exception e) {
-         throw new RuntimeException("Failed to generate auth token", e);
-      }
-   }
-
-   private String sign (String data, String secret) throws Exception {
-      Mac mac = Mac.getInstance("HmacSHA256");
-      SecretKeySpec secretKeySpec = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
-      mac.init(secretKeySpec);
-      return Base64.getUrlEncoder().withoutPadding().encodeToString(mac.doFinal(data.getBytes()));
-   }
-
-   private String generateRefreshToken (String userId, String accessToken, long durationInSeconds) throws IOException
+   private String generateRefreshToken (String subject,
+                                        String userId,
+                                        String realm,
+                                        String activeApplication,
+                                        String accessToken,
+                                        long durationInSeconds) throws IOException
                                                                                                              ,
                                                                                                              NoSuchAlgorithmException, InvalidKeySpecException {
 
       String refreshToken = TokenUtils.generateRefreshToken(
+         subject,
          userId,
-         TokenUtils.currentTimeInSecs() + durationInSeconds + TokenUtils.REFRESH_ADDITIONAL_DURATION_SECONDS,
+         realm,
+         activeApplication,
+         durationInSeconds,
          issuer);
 
       CredentialRefreshToken refreshToken1 = CredentialRefreshToken.builder()
@@ -885,14 +996,26 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
    }
 
    private SecurityIdentity buildIdentity (String userId, Set<String> roles) {
+      return buildIdentity(userId, roles, Map.of());
+   }
+
+   private SecurityIdentity buildIdentity (String userId, Set<String> roles, Map<String, Object> attributes) {
       QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
       builder.setPrincipal(() -> userId);
       roles.forEach(builder::addRole);
 
       builder.addAttribute("token_type", "custom");
       builder.addAttribute("auth_time", System.currentTimeMillis());
+      attributes.forEach(builder::addAttribute);
 
       return builder.build();
+   }
+
+   private String claimString(org.eclipse.microprofile.jwt.JsonWebToken jwt, String claim) {
+      Object value = jwt.getClaim(claim);
+      if (value == null) return null;
+      String text = String.valueOf(value).trim();
+      return text.isEmpty() ? null : text;
    }
 
 

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
@@ -205,6 +205,21 @@ public class TokenUtils {
 											String activeApplication,
 											long expiresAt,
 											String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+		return generateUserToken(subject, null, groups, null, null, null, null,
+				audiences, activeApplication, expiresAt, issuer);
+	}
+
+	public static String generateUserToken(String subject,
+											String userId,
+											Set<String> groups,
+											String realm,
+											String tenantId,
+											String orgRefName,
+											String accountNum,
+											Set<String> audiences,
+											String activeApplication,
+											long expiresAt,
+											String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
 
 		Objects.requireNonNull(subject, "subject cannot be null");
 		Objects.requireNonNull(issuer, "Issuer cannot be null");
@@ -226,6 +241,7 @@ public class TokenUtils {
 		claimsBuilder.expiresAt(expiresAt);
 		claimsBuilder.groups(groups);
 		claimsBuilder.claim("scope", AUTH_SCOPE);
+		addPrincipalClaims(claimsBuilder, userId, realm, tenantId, orgRefName, accountNum);
 		if (activeApplication != null && !activeApplication.isBlank()) {
 			claimsBuilder.claim("azp", activeApplication);
 		}
@@ -233,7 +249,21 @@ public class TokenUtils {
 	}
 
 	public static String generateRefreshToken(String subject,  long durationInSeconds, String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+		return generateRefreshToken(subject, null, null, null, durationInSeconds, issuer);
+	}
 
+	public static String generateRefreshToken(String subject,
+											 String userId,
+											 String realm,
+											 String activeApplication,
+											 long durationInSeconds,
+											 String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+		Objects.requireNonNull(subject, "subject cannot be null");
+		Objects.requireNonNull(issuer, "Issuer cannot be null");
+		if (durationInSeconds <= 0) {
+			throw new ValidationException("Refresh-token duration must be greater than zero seconds");
+		}
                 PrivateKey privateKey = cachedPrivateKey != null ? cachedPrivateKey : readPrivateKey(privateKeyLocation);
 		JwtClaimsBuilder claimsBuilder = Jwt.claims();
 		long currentTimeInSecs = currentTimeInSecs();
@@ -243,7 +273,23 @@ public class TokenUtils {
 		claimsBuilder.audience("b2bi-api-client-refresh");
 		claimsBuilder.expiresAt(currentTimeInSecs + durationInSeconds + REFRESH_ADDITIONAL_DURATION_SECONDS);
 		claimsBuilder.claim("scope", REFRESH_SCOPE);
+		if (userId != null && !userId.isBlank()) claimsBuilder.claim("userId", userId);
+		if (realm != null && !realm.isBlank()) claimsBuilder.claim("realm", realm);
+		if (activeApplication != null && !activeApplication.isBlank()) claimsBuilder.claim("azp", activeApplication);
 		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
+	}
+
+	private static void addPrincipalClaims(JwtClaimsBuilder claimsBuilder,
+										 String userId,
+										 String realm,
+										 String tenantId,
+										 String orgRefName,
+										 String accountNum) {
+		if (userId != null && !userId.isBlank()) claimsBuilder.claim("userId", userId);
+		if (realm != null && !realm.isBlank()) claimsBuilder.claim("realm", realm);
+		if (tenantId != null && !tenantId.isBlank()) claimsBuilder.claim("tenantId", tenantId);
+		if (orgRefName != null && !orgRefName.isBlank()) claimsBuilder.claim("orgRefName", orgRefName);
+		if (accountNum != null && !accountNum.isBlank()) claimsBuilder.claim("accountNum", accountNum);
 	}
 
         public static PrivateKey readPrivateKey(final String pemResName) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProviderRealmTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProviderRealmTest.java
@@ -1,0 +1,22 @@
+package com.e2eq.framework.model.auth.provider.jwtToken;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CustomTokenAuthProviderRealmTest {
+
+    @Test
+    void credentialRolesApplyOnlyToCredentialDefaultRealm() {
+        String[] globalRoles = {"system", "admin", "user"};
+
+        assertEquals(Set.of("system", "admin", "user"),
+            CustomTokenAuthProvider.credentialRolesForRealm(
+                globalRoles, "system-com", "system-com"));
+        assertEquals(Set.of(),
+            CustomTokenAuthProvider.credentialRolesForRealm(
+                globalRoles, "system-com", "northstar-field-service-com"));
+    }
+}

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/api/agent/AgentExecuteHandler.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/api/agent/AgentExecuteHandler.java
@@ -42,7 +42,14 @@ public class AgentExecuteHandler {
 
         return switch (tool) {
             case "query_rootTypes" -> {
-                QueryGatewayResource.RootTypesResponse r = queryGatewayResource.listRootTypes();
+                Object realmValue = arguments.get("realm");
+                if (realmValue != null && !(realmValue instanceof String)) {
+                    yield Response.status(Response.Status.BAD_REQUEST)
+                            .entity(Map.of("error", "InvalidRealm", "message", "realm must be a string"))
+                            .build();
+                }
+                QueryGatewayResource.RootTypesResponse r =
+                        queryGatewayResource.listRootTypes((String) realmValue);
                 yield Response.ok(r).build();
             }
             case "query_plan" -> {

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/api/agent/AgentResource.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/api/agent/AgentResource.java
@@ -70,13 +70,14 @@ public class AgentResource {
      * Returns the list of entity types (root types) that can be used with the gateway.
      * Wraps GET /api/query/rootTypes for a single integration point.
      *
+     * @param realm optional realm; authenticated requests remain bound to their effective realm
      * @return root types list and count (same shape as QueryGatewayResource.listRootTypes)
      */
     @GET
     @Path("/schema")
     @FunctionalAction("listSchema")
-    public QueryGatewayResource.RootTypesResponse schema() {
-        return queryGatewayResource.listRootTypes();
+    public QueryGatewayResource.RootTypesResponse schema(@QueryParam("realm") String realm) {
+        return queryGatewayResource.listRootTypes(realm);
     }
 
     /**

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpOntologyTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpOntologyTools.java
@@ -1,7 +1,6 @@
 package com.e2eq.framework.mcp;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
-import com.e2eq.framework.model.persistent.morphia.MorphiaDataStoreWrapper;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.ontology.core.OntologyRegistry;
@@ -167,33 +166,37 @@ public class McpOntologyTools {
     }
 
     private DataDomain resolveDataDomain(String realm) {
-        // Try SecurityContext first
-        DataDomain dd = SecurityContext.getPrincipalContext()
-                .map(PrincipalContext::getDataDomain)
-                .orElse(null);
-        if (dd != null) {
-            return dd;
+        PrincipalContext principal = requirePrincipal();
+        requireEffectiveRealm(principal, realm);
+        DataDomain dataDomain = principal.getDataDomain();
+        if (dataDomain == null) {
+            throw new IllegalStateException("Authenticated principal has no effective DataDomain");
         }
-        // Fallback: build minimal DataDomain from realm
-        if (realm != null && !realm.isBlank()) {
-            dd = new DataDomain();
-            dd.setOrgRefName("system");
-            dd.setAccountNum("0000000000");
-            dd.setTenantId(realm.replace('-', '.'));
-            dd.setOwnerId("system");
-            dd.setDataSegment(0);
-            return dd;
-        }
-        return null;
+        return dataDomain;
     }
 
     private String resolveRealm(String requestRealm) {
-        if (requestRealm != null && !requestRealm.isBlank()) {
-            return requestRealm;
-        }
+        PrincipalContext principal = requirePrincipal();
+        return requireEffectiveRealm(principal, requestRealm);
+    }
+
+    private PrincipalContext requirePrincipal() {
         return SecurityContext.getPrincipalContext()
-                .map(PrincipalContext::getDefaultRealm)
-                .orElse("defaultRealm");
+                .orElseThrow(() -> new SecurityException(
+                        "Authenticated principal context is required for ontology access"));
+    }
+
+    private String requireEffectiveRealm(PrincipalContext principal, String requestRealm) {
+        String effectiveRealm = principal.getDefaultRealm();
+        if (effectiveRealm == null || effectiveRealm.isBlank()) {
+            throw new SecurityException("Authenticated principal has no effective realm");
+        }
+        if (requestRealm != null && !requestRealm.isBlank()
+                && !effectiveRealm.equals(requestRealm.trim())) {
+            throw new SecurityException("Requested realm '" + requestRealm
+                    + "' does not match authenticated effective realm '" + effectiveRealm + "'");
+        }
+        return effectiveRealm;
     }
 
     private static String escapeJson(String s) {

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpSchemaResources.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpSchemaResources.java
@@ -45,7 +45,7 @@ public class McpSchemaResources {
     @Resource(uri = "quantum://schema", description = "List all available entity types (root types) with class name, simple name, and collection name")
     ResourceResponse listSchema() {
         try {
-            QueryGatewayResource.RootTypesResponse rootTypes = queryGatewayResource.listRootTypes();
+            QueryGatewayResource.RootTypesResponse rootTypes = queryGatewayResource.listRootTypes(null);
             String json = objectMapper.writeValueAsString(rootTypes);
             return new ResourceResponse(List.of(
                     TextResourceContents.create("quantum://schema", json)));

--- a/quantum-mcp-server/src/test/java/com/e2eq/framework/api/agent/AgentResourceIT.java
+++ b/quantum-mcp-server/src/test/java/com/e2eq/framework/api/agent/AgentResourceIT.java
@@ -119,6 +119,18 @@ public class AgentResourceIT {
     }
 
     @Test
+    public void execute_query_rootTypes_rejects_non_string_realm() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("{\"tool\":\"query_rootTypes\",\"arguments\":{\"realm\":42}}")
+        .when()
+            .post("/api/agent/execute")
+        .then()
+            .statusCode(400)
+            .body("error", is("InvalidRealm"));
+    }
+
+    @Test
     public void execute_query_plan_returns_plan() {
         given()
             .contentType(ContentType.JSON)

--- a/quantum-mcp-server/src/test/java/com/e2eq/framework/mcp/McpOntologyToolsSecurityTest.java
+++ b/quantum-mcp-server/src/test/java/com/e2eq/framework/mcp/McpOntologyToolsSecurityTest.java
@@ -1,0 +1,57 @@
+package com.e2eq.framework.mcp;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class McpOntologyToolsSecurityTest {
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContext.clear();
+    }
+
+    @Test
+    void relationshipQueryRejectsRealmDifferentFromAuthenticatedRealm() {
+        SecurityContext.setPrincipalContext(principal("tenant-a"));
+
+        String result = new McpOntologyTools()
+                .query_relationships("entity-1", "both", null, "tenant-b");
+
+        Assertions.assertTrue(result.contains("RelationshipQueryFailed"));
+        Assertions.assertTrue(result.contains("does not match authenticated effective realm"));
+    }
+
+    @Test
+    void predicateQueryRejectsRealmDifferentFromAuthenticatedRealm() {
+        SecurityContext.setPrincipalContext(principal("tenant-a"));
+
+        String result = new McpOntologyTools()
+                .query_predicates(null, null, "tenant-b");
+
+        Assertions.assertTrue(result.contains("PredicateQueryFailed"));
+        Assertions.assertTrue(result.contains("does not match authenticated effective realm"));
+    }
+
+    @Test
+    void explicitRealmCannotReplaceMissingPrincipalContext() {
+        String result = new McpOntologyTools()
+                .query_relationships("entity-1", "both", null, "tenant-a");
+
+        Assertions.assertTrue(result.contains("RelationshipQueryFailed"));
+        Assertions.assertTrue(result.contains("Authenticated principal context is required"));
+    }
+
+    private PrincipalContext principal(String realm) {
+        return new PrincipalContext.Builder()
+                .withUserId("user@tenant-a")
+                .withDefaultRealm(realm)
+                .withDataDomain(new DataDomain("tenant-a", "0000000000", "tenant.a", 0, "user@tenant-a"))
+                .withRoles(new String[] { "user" })
+                .withScope("AUTHENTICATED")
+                .build();
+    }
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Resolves which application(s) a token should be scoped to at login, from a
@@ -82,9 +84,21 @@ public final class ApplicationAuthorizationResolver {
     public static Result resolve(List<String> authorizedApplications,
                                  String defaultApplication,
                                  String requestedApplicationId) {
+        return resolve(authorizedApplications, null, defaultApplication, requestedApplicationId);
+    }
+
+    /**
+     * Resolves a per-realm application list, falling back to the credential-wide
+     * application pattern only when the list is absent. Patterns are matched against
+     * the complete application id; {@code "*"} is the unrestricted wildcard.
+     */
+    public static Result resolve(List<String> authorizedApplications,
+                                 String applicationRegEx,
+                                 String defaultApplication,
+                                 String requestedApplicationId) {
         List<String> granted = normalize(authorizedApplications);
         if (granted.isEmpty()) {
-            return Result.legacy();
+            return resolvePattern(applicationRegEx, defaultApplication, requestedApplicationId);
         }
 
         String requested = trimToNull(requestedApplicationId);
@@ -123,6 +137,48 @@ public final class ApplicationAuthorizationResolver {
         }
 
         return Result.ambiguous(new ArrayList<>(concrete), false);
+    }
+
+    private static Result resolvePattern(String applicationRegEx,
+                                         String defaultApplication,
+                                         String requestedApplicationId) {
+        String expression = trimToNull(applicationRegEx);
+        if (expression == null) {
+            String requested = trimToNull(requestedApplicationId);
+            return requested == null ? Result.legacy() : Result.denied(requested);
+        }
+
+        String requested = trimToNull(requestedApplicationId);
+        String defaultApp = trimToNull(defaultApplication);
+        boolean wildcard = WILDCARD.equals(expression);
+
+        if (requested != null) {
+            if (matches(expression, requested)) {
+                return Result.resolved(new LinkedHashSet<>(List.of(requested)), requested, wildcard);
+            }
+            return Result.denied(requested);
+        }
+
+        if (defaultApp != null && matches(expression, defaultApp)) {
+            return Result.resolved(new LinkedHashSet<>(List.of(defaultApp)), defaultApp, wildcard);
+        }
+
+        // A pattern can authorize an unbounded set, so callers must name an app.
+        return Result.ambiguous(List.of(), wildcard);
+    }
+
+    private static boolean matches(String expression, String applicationId) {
+        if (WILDCARD.equals(expression)) {
+            return true;
+        }
+        try {
+            return Pattern.compile(expression, Pattern.CASE_INSENSITIVE)
+                    .matcher(applicationId)
+                    .matches();
+        } catch (PatternSyntaxException ignored) {
+            // Persisted invalid patterns fail closed; validation should reject new ones.
+            return false;
+        }
     }
 
     private static List<String> normalize(List<String> apps) {

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProvider.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProvider.java
@@ -121,6 +121,18 @@ public interface AuthProvider {
         return login(userId, password);
     }
 
+    /**
+     * Realm- and application-scoped login. Providers that understand realm membership
+     * should validate {@code realmId} and mint only the roles effective in that realm.
+     * Other providers retain their existing behavior through this compatibility default.
+     */
+    default LoginResponse login(String userId, String password, String applicationId, String realmId) {
+        if (realmId != null && !realmId.isBlank()) {
+            throw new UnsupportedOperationException("This authentication provider does not support realm-scoped login");
+        }
+        return login(userId, password, applicationId);
+    }
+
     LoginResponse refreshTokens(String refreshToken);
 
     /**

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProviderFactory.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthProviderFactory.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @ApplicationScoped
 public class AuthProviderFactory {
 
-    public static final String DEFAULT_AUTH_PROVIDER_CHAIN = "custom,oidc";
+    public static final String DEFAULT_AUTH_PROVIDER_CHAIN = "custom";
 
     @ConfigProperty(name = "auth.provider", defaultValue = DEFAULT_AUTH_PROVIDER_CHAIN)
     String configuredAuthProviders; // supports comma-separated list (for example "custom,oidc")
@@ -31,14 +31,7 @@ public class AuthProviderFactory {
      * Backward compatible — single-value config works as before.
      */
     public AuthProvider getAuthProvider() {
-        for (String providerName : getConfiguredProviderNames()) {
-            Optional<AuthProvider> provider = findProviderByName(providerName);
-            if (provider.isPresent()) {
-                return provider.get();
-            }
-        }
-        throw new IllegalArgumentException(String.format(
-                "None of the configured auth providers are available: %s", getConfiguredProviderNames()));
+        return getProviderByName(getConfiguredProviderNames().get(0));
     }
 
     public List<String> getConfiguredProviderNames() {
@@ -90,35 +83,38 @@ public class AuthProviderFactory {
      *
      * <p>Resolution order:
      * <ol>
-     *   <li>Explicit request provider, when supplied. This disables fallback.</li>
-     *   <li>Credential-level provider override, when supplied. This must exist.</li>
-     *   <li>Configured provider list from {@code auth.provider}, in order. Missing
-     *       configured providers are skipped so open-source services can list optional
-     *       enterprise providers without depending on their jars.</li>
+     *   <li>Explicit request provider chain, when supplied. This replaces the configured
+     *       chain and is tried in the caller-supplied order.</li>
+     *   <li>Configured provider list from {@code auth.provider}, in order.</li>
      * </ol>
+     * Every named provider must be available. Configuration errors fail immediately
+     * rather than changing authentication semantics through silent provider skipping.
      */
-    public List<AuthProvider> getLoginProviders(String requestedProviderName, String credentialProviderName) {
-        if (requestedProviderName != null && !requestedProviderName.isBlank()) {
-            return List.of(getProviderByName(requestedProviderName));
+    public List<AuthProvider> getLoginProviders(String requestedProviderNames) {
+        List<String> providerNames = requestedProviderNames == null || requestedProviderNames.isBlank()
+                ? getConfiguredProviderNames()
+                : parseProviderNames(requestedProviderNames);
+        if (providerNames.isEmpty()) {
+            throw new IllegalArgumentException("The requested authentication provider chain is empty");
         }
 
         List<AuthProvider> providers = new ArrayList<>();
-        if (credentialProviderName != null && !credentialProviderName.isBlank()) {
-            providers.add(getProviderByName(credentialProviderName));
-        }
-
-        LinkedHashSet<String> configuredNames = new LinkedHashSet<>(getConfiguredProviderNames());
-        if (credentialProviderName != null && !credentialProviderName.isBlank()) {
-            configuredNames.removeIf(name -> name.equalsIgnoreCase(credentialProviderName.trim()));
-        }
-        for (String name : configuredNames) {
-            findProviderByName(name).ifPresent(providers::add);
-        }
-        if (providers.isEmpty()) {
-            throw new IllegalArgumentException(String.format(
-                    "None of the configured auth providers are available: %s", getConfiguredProviderNames()));
+        for (String providerName : providerNames) {
+            providers.add(getProviderByName(providerName));
         }
         return providers;
+    }
+
+    private List<String> parseProviderNames(String providerNames) {
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        if (providerNames != null) {
+            for (String part : providerNames.split(",")) {
+                if (part != null && !part.trim().isBlank()) {
+                    names.add(part.trim());
+                }
+            }
+        }
+        return new ArrayList<>(names);
     }
 
     /**
@@ -142,20 +138,23 @@ public class AuthProviderFactory {
     }
 
     /**
-     * Resolve provider by JWT issuer claim. Iterates configured providers
-     * and matches against their getIssuer(). Falls back to default provider.
+     * Resolve provider by JWT issuer claim. Unknown or missing issuers fail closed;
+     * callers that intentionally want the configured default must call
+     * {@link #getAuthProvider()} explicitly.
      */
     public AuthProvider getProviderForIssuer(String issuer) {
-        if (issuer == null) return getAuthProvider();
+        if (issuer == null || issuer.isBlank()) {
+            throw new IllegalArgumentException("JWT issuer is required to resolve an authentication provider");
+        }
 
         for (String providerName : getConfiguredProviderNames()) {
-            Optional<AuthProvider> provider = findProviderByName(providerName);
-            if (provider.isPresent() && issuer.equals(provider.get().getIssuer())) {
-                return provider.get();
+            AuthProvider provider = getProviderByName(providerName);
+            if (issuer.equals(provider.getIssuer())) {
+                return provider;
             }
         }
-        // No match — fall back to default provider
-        return getAuthProvider();
+        throw new IllegalArgumentException(String.format(
+                "No configured authentication provider matches issuer '%s'", issuer));
     }
 
     public UserManagement getUserManager() {

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/CredentialUserIdPassword.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/CredentialUserIdPassword.java
@@ -113,9 +113,18 @@ public class CredentialUserIdPassword extends BaseModel {
 
    protected List<RealmEntry> authorizedRealms;
    //@Regex
-   @ToString.Exclude
-   protected String realmRegEx; // if the authorizedRealms is not found or null, then this is used if defined
-   protected String authProviderName; // the provider this record belongs to.
+    protected String realmRegEx; // if the authorizedRealms is not found or null, then this is used if defined
+    /**
+     * Credential-wide application entitlement pattern. Per-realm application grants
+     * remain authoritative when present; otherwise this pattern is evaluated against
+     * the requested application. The value {@code "*"} authorizes any named application.
+     */
+    protected String applicationRegEx;
+   /**
+    * Informational provenance naming the provider that resolved the credential/token.
+    * This value is not an authentication routing or authorization binding.
+    */
+   protected String authProviderName;
 
    /**
     * Utility method to set the password hash from a plain text password.

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/RealmTenantMembership.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/RealmTenantMembership.java
@@ -28,6 +28,9 @@ public class RealmTenantMembership extends BaseModel {
    protected String provisioningMode;
    protected String participationStatus;
 
+   public static final String PARTICIPATION_STATUS_ACTIVE = "ACTIVE";
+   public static final String PARTICIPATION_STATUS_SUSPENDED = "SUSPENDED";
+
    /**
     * Membership role of this org/account within the realm (B4 identity model;
     * realm-membership ADR): exactly one OWNER per realm (lifecycle authority:

--- a/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/FieldPolicyEnforcer.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/FieldPolicyEnforcer.java
@@ -28,7 +28,8 @@ import java.util.Collection;
  * Masking semantics: excluded paths are set to null on the materialized
  * object (with the platform's NON_NULL serialization defaults they are omitted
  * from JSON). Dotted paths descend embedded objects; collections are masked
- * element-wise. Unknown paths are ignored (nothing to protect on this type).
+ * element-wise. Invalid configured paths fail closed because silently ignoring
+ * a policy/schema mismatch would expose data.
  */
 public final class FieldPolicyEnforcer {
 
@@ -64,11 +65,14 @@ public final class FieldPolicyEnforcer {
         String[] parts = dottedPath.split("\\.", 2);
         Field field = findField(target.getClass(), parts[0]);
         if (field == null) {
-            return;
+            throw new NoSuchFieldException("Policy path '" + dottedPath
+                + "' does not exist on " + target.getClass().getName());
         }
         field.setAccessible(true);
         if (parts.length == 1) {
-            field.set(target, null);
+            field.set(target, field.getType().isPrimitive()
+                    ? primitiveDefaultValue(field.getType())
+                    : null);
             return;
         }
         Object child = field.get(target);
@@ -95,7 +99,8 @@ public final class FieldPolicyEnforcer {
         String[] parts = dottedPath.split("\\.", 2);
         Field field = findField(source.getClass(), parts[0]);
         if (field == null) {
-            return;
+            throw new NoSuchFieldException("Policy path '" + dottedPath
+                + "' does not exist on " + source.getClass().getName());
         }
         field.setAccessible(true);
         if (parts.length == 1) {
@@ -108,7 +113,93 @@ public final class FieldPolicyEnforcer {
             field.set(target, sourceChild);
             return;
         }
+        if (sourceChild instanceof Collection<?>) {
+            // Collection elements may be reordered or keyed independently. Preserving the
+            // complete stored collection is the only fail-closed generic operation without
+            // an explicit element identity contract.
+            field.set(target, sourceChild);
+            return;
+        }
         copyPath(sourceChild, targetChild, parts[1]);
+    }
+
+    /**
+     * Rejects a create payload that supplies any field hidden by policy.
+     *
+     * <p>Silently clearing a submitted value makes an unauthorized write look
+     * successful. Creates therefore fail explicitly; trusted seed/migration code
+     * must use an explicit {@link SecurityCallScope#openIgnoringRules()} boundary.</p>
+     */
+    public static void assertUnset(Object root, Collection<String> dottedPaths) {
+        if (root == null || dottedPaths == null || dottedPaths.isEmpty()) {
+            return;
+        }
+        for (String path : dottedPaths) {
+            if (path == null || path.isBlank()) {
+                continue;
+            }
+            try {
+                if (isSet(root, path.trim())) {
+                    throw new SecurityException(
+                        "Create payload supplies field '" + path + "' protected by field-level policy");
+                }
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException(
+                    "Field-level policy could not validate create path '" + path + "' on "
+                    + root.getClass().getSimpleName() + "; failing closed.", e);
+            }
+        }
+    }
+
+    private static boolean isSet(Object target, String dottedPath) throws ReflectiveOperationException {
+        if (target == null) {
+            return false;
+        }
+        if (target instanceof Collection<?> many) {
+            for (Object item : many) {
+                if (isSet(item, dottedPath)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        String[] parts = dottedPath.split("\\.", 2);
+        Field field = findField(target.getClass(), parts[0]);
+        if (field == null) {
+            throw new NoSuchFieldException("Policy path '" + dottedPath
+                + "' does not exist on " + target.getClass().getName());
+        }
+        field.setAccessible(true);
+        Object value = field.get(target);
+        if (parts.length == 1) {
+            return value != null && !isPrimitiveDefault(field.getType(), value);
+        }
+        return value != null && isSet(value, parts[1]);
+    }
+
+    private static boolean isPrimitiveDefault(Class<?> type, Object value) {
+        if (!type.isPrimitive()) {
+            return false;
+        }
+        if (type == boolean.class) {
+            return Boolean.FALSE.equals(value);
+        }
+        if (type == char.class) {
+            return Character.valueOf('\0').equals(value);
+        }
+        return value instanceof Number number && number.doubleValue() == 0D;
+    }
+
+    private static Object primitiveDefaultValue(Class<?> type) {
+        if (type == boolean.class) return false;
+        if (type == char.class) return '\0';
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        if (type == double.class) return 0D;
+        throw new IllegalArgumentException("Unsupported primitive field type: " + type.getName());
     }
 
     static Field findField(Class<?> type, String name) {

--- a/quantum-models/src/main/java/com/e2eq/framework/util/SecurityUtils.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/util/SecurityUtils.java
@@ -158,8 +158,8 @@ public class SecurityUtils {
    // If authorizedRealms present, intersect candidates with that list; else if realmRegEx present, filter by it;
    // else, return only the default realm from the credential's domain context if included in candidates; if
    // candidates is null, return a singleton list with the default realm.
-   // The credential's domainContext.defaultRealm is always implicitly authorized, so it is unioned into the
-   // result of the authorizedRealms and realmRegEx branches when it appears in the candidate catalog.
+   // Preserve the 1.3 contract: the credential's domainContext.defaultRealm is implicitly authorized, so it is
+   // unioned into explicit-list and regex results when it appears in the candidate catalog.
    public java.util.List<String> computeAllowedRealmRefNames(
            com.e2eq.framework.model.security.CredentialUserIdPassword credential,
            java.util.List<String> candidateRealmRefNames) {

--- a/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
@@ -3,6 +3,7 @@ package com.e2eq.framework.model.auth;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -17,17 +18,43 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ApplicationAuthorizationResolverTest {
 
     @Test
-    void nullGrant_isLegacy() {
+    void credentialWildcardResolvesExplicitApplication() {
+        var r = ApplicationAuthorizationResolver.resolve(null, "*", null, "system-admin");
+        assertEquals(ApplicationAuthorizationResolver.Outcome.RESOLVED, r.outcome());
+        assertEquals(Set.of("system-admin"), r.audiences());
+        assertEquals("system-admin", r.activeApplication());
+        assertTrue(r.wildcard());
+    }
+
+    @Test
+    void credentialRegexAllowsMatchingApplicationAndDeniesOthers() {
+        var allowed = ApplicationAuthorizationResolver.resolve(null, "helixor-.*", null, "helixor-di");
+        var denied = ApplicationAuthorizationResolver.resolve(null, "helixor-.*", null, "quantum-system");
+
+        assertEquals(ApplicationAuthorizationResolver.Outcome.RESOLVED, allowed.outcome());
+        assertEquals(ApplicationAuthorizationResolver.Outcome.DENIED, denied.outcome());
+    }
+
+    @Test
+    void perRealmGrantTakesPrecedenceOverCredentialPattern() {
+        var r = ApplicationAuthorizationResolver.resolve(
+                List.of("tenant-console"), "*", null, "system-admin");
+
+        assertEquals(ApplicationAuthorizationResolver.Outcome.DENIED, r.outcome());
+    }
+
+    @Test
+    void nullGrant_deniesExplicitApplication() {
         var r = ApplicationAuthorizationResolver.resolve(null, null, "scheduler");
-        assertEquals(ApplicationAuthorizationResolver.Outcome.LEGACY, r.outcome());
+        assertEquals(ApplicationAuthorizationResolver.Outcome.DENIED, r.outcome());
         assertNull(r.audiences());
         assertNull(r.activeApplication());
     }
 
     @Test
-    void emptyGrant_isLegacy() {
+    void emptyGrant_deniesExplicitApplication() {
         var r = ApplicationAuthorizationResolver.resolve(List.of(), null, "scheduler");
-        assertEquals(ApplicationAuthorizationResolver.Outcome.LEGACY, r.outcome());
+        assertEquals(ApplicationAuthorizationResolver.Outcome.DENIED, r.outcome());
     }
 
     @Test

--- a/quantum-models/src/test/java/com/e2eq/framework/model/auth/AuthProviderFactoryTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/auth/AuthProviderFactoryTest.java
@@ -1,27 +1,32 @@
 package com.e2eq.framework.model.auth;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AuthProviderFactoryTest {
 
     @Test
-    void missingProviderConfigDefaultsToCustomOidcChain() {
+    void missingProviderConfigDefaultsToCustomProvider() {
         AuthProviderFactory factory = new AuthProviderFactory();
         factory.configuredAuthProviders = null;
 
-        assertEquals(List.of("custom", "oidc"), factory.getConfiguredProviderNames());
+        assertEquals(List.of("custom"), factory.getConfiguredProviderNames());
     }
 
     @Test
-    void blankProviderConfigDefaultsToCustomOidcChain() {
+    void blankProviderConfigDefaultsToCustomProvider() {
         AuthProviderFactory factory = new AuthProviderFactory();
         factory.configuredAuthProviders = " , ";
 
-        assertEquals(List.of("custom", "oidc"), factory.getConfiguredProviderNames());
+        assertEquals(List.of("custom"), factory.getConfiguredProviderNames());
     }
 
     @Test
@@ -30,5 +35,77 @@ class AuthProviderFactoryTest {
         factory.configuredAuthProviders = " oidc, custom, oidc ";
 
         assertEquals(List.of("oidc", "custom"), factory.getConfiguredProviderNames());
+    }
+
+    @Test
+    void explicitProviderOverrideAcceptsAnOrderedList() {
+        TestFactory factory = new TestFactory(provider("custom"), provider("oidc"));
+        factory.configuredAuthProviders = "custom";
+
+        assertEquals(List.of("oidc", "custom"),
+                factory.getLoginProviders("oidc,custom,oidc").stream()
+                        .map(AuthProvider::getName)
+                        .toList());
+    }
+
+    @Test
+    void configuredProviderChainFailsWhenAProviderIsUnavailable() {
+        TestFactory factory = new TestFactory(provider("custom"));
+        factory.configuredAuthProviders = "custom,oidc";
+
+        assertThrows(IllegalArgumentException.class, () -> factory.getLoginProviders(null));
+    }
+
+    @Test
+    void explicitProviderOverrideFailsRatherThanUsingConfiguredFallback() {
+        TestFactory factory = new TestFactory(provider("custom"));
+        factory.configuredAuthProviders = "custom";
+
+        assertThrows(IllegalArgumentException.class, () -> factory.getLoginProviders("oidc"));
+    }
+
+    private static AuthProvider provider(String name) {
+        return new AuthProvider() {
+            @Override
+            public SecurityIdentity validateAccessToken(String token) {
+                return null;
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public LoginResponse login(String userId, String password) {
+                return null;
+            }
+
+            @Override
+            public LoginResponse refreshTokens(String refreshToken) {
+                return null;
+            }
+        };
+    }
+
+    private static final class TestFactory extends AuthProviderFactory {
+        private final Map<String, AuthProvider> providers = new HashMap<>();
+
+        private TestFactory(AuthProvider... providers) {
+            for (AuthProvider provider : providers) {
+                this.providers.put(provider.getName(), provider);
+            }
+        }
+
+        @Override
+        public AuthProvider getProviderByName(String name) {
+            return findProviderByName(name).orElseThrow(() ->
+                    new IllegalArgumentException("Missing provider " + name));
+        }
+
+        @Override
+        public Optional<AuthProvider> findProviderByName(String name) {
+            return Optional.ofNullable(providers.get(name));
+        }
     }
 }

--- a/quantum-models/src/test/java/com/e2eq/framework/util/ComputeAllowedRealmRefNamesTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/util/ComputeAllowedRealmRefNamesTest.java
@@ -159,4 +159,31 @@ class ComputeAllowedRealmRefNamesTest {
 
         assertEquals(List.of("acme-prod", "acme-dev", "other-realm"), result);
     }
+
+    @Test
+    void wildcardAuthorizesRequestedRealmDuringLogin() {
+        CredentialUserIdPassword cred = buildCredential(null, "*", "realm-a");
+
+        assertEquals(
+            List.of("customer-realm"),
+            securityUtils.computeAllowedRealmRefNames(cred, List.of("customer-realm"))
+        );
+    }
+
+    @Test
+    void unmatchedPatternDeniesRequestedRealmDuringLogin() {
+        CredentialUserIdPassword cred = buildCredential(null, "acme-.*", "realm-a");
+
+        assertTrue(securityUtils.computeAllowedRealmRefNames(cred, List.of("other-realm")).isEmpty());
+    }
+
+    @Test
+    void defaultRealmRemainsAuthorizedWithoutOverrides() {
+        CredentialUserIdPassword cred = buildCredential(null, null, "realm-a");
+
+        assertEquals(
+            List.of("realm-a"),
+            securityUtils.computeAllowedRealmRefNames(cred, List.of("realm-a"))
+        );
+    }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/BaseMorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/BaseMorphiaRepo.java
@@ -271,6 +271,21 @@ public interface BaseMorphiaRepo<T extends UnversionedBaseModel> {
    List<T> getListByQuery(@NotNull Datastore datastore, int skip, int limit, @Nullable String query, @Nullable List<SortField> sortFields, @Nullable List<ProjectionField> projectionFields);
 
    /**
+    * Executes an expand/aggregation query with row, field, and relationship policy
+    * applied to both the root collection and every declared join target.
+    */
+   default List<org.bson.Document> getSecuredAggregationDocuments(
+           @Nullable String realmId,
+           int skip,
+           int limit,
+           @NotNull String query,
+           @Nullable List<SortField> sortFields,
+           @Nullable List<ProjectionField> projectionFields) {
+      throw new UnsupportedOperationException(
+              "Governed aggregation is not implemented by repository " + getClass().getName());
+   }
+
+   /**
     * Returns entities based on the given filters and sort fields in the default realm.
     * @param skip    must be 0 or greater
     * @param limit   can be 0 or negative to return all; positive for page size

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/BaseMorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/BaseMorphiaRepo.java
@@ -290,6 +290,21 @@ public interface BaseMorphiaRepo<T extends UnversionedBaseModel> {
    List<T> getListByQuery(@NotNull Datastore datastore, int skip, int limit, @Nullable String query, @Nullable List<SortField> sortFields, @Nullable List<ProjectionField> projectionFields);
 
    /**
+    * Executes an expand/aggregation query with row, field, and relationship policy
+    * applied to both the root collection and every declared join target.
+    */
+   default List<org.bson.Document> getSecuredAggregationDocuments(
+           @Nullable String realmId,
+           int skip,
+           int limit,
+           @NotNull String query,
+           @Nullable List<SortField> sortFields,
+           @Nullable List<ProjectionField> projectionFields) {
+      throw new UnsupportedOperationException(
+              "Governed aggregation is not implemented by repository " + getClass().getName());
+   }
+
+   /**
     * Returns entities based on the given filters and sort fields in the default realm.
     * @param skip    must be 0 or greater
     * @param limit   can be 0 or negative to return all; positive for page size

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/CredentialRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/CredentialRepo.java
@@ -139,6 +139,33 @@ public class CredentialRepo extends MorphiaRepo<CredentialUserIdPassword> {
       return Optional.ofNullable(obj);
    }
 
+   public CredentialUserIdPassword saveApplicationRegExBySubject(
+           @NotNull String subject,
+           String applicationRegEx) {
+      if (subject.isBlank()) {
+         throw new IllegalArgumentException("Subject cannot be blank");
+      }
+      String normalizedPattern = applicationRegEx == null ? null : applicationRegEx.trim();
+      if (normalizedPattern != null && normalizedPattern.isEmpty()) {
+         throw new IllegalArgumentException("ApplicationRegEx cannot be blank");
+      }
+      if (normalizedPattern != null && !"*".equals(normalizedPattern)) {
+         try {
+            java.util.regex.Pattern.compile(normalizedPattern);
+         } catch (java.util.regex.PatternSyntaxException invalidPattern) {
+            throw new IllegalArgumentException(
+                    "ApplicationRegEx is invalid: " + invalidPattern.getDescription(),
+                    invalidPattern);
+         }
+      }
+      CredentialUserIdPassword credential = findBySubject(subject)
+              .orElseThrow(() -> new jakarta.ws.rs.NotFoundException(
+                      String.format("User with subject %s not found", subject)));
+      credential.setApplicationRegEx(normalizedPattern);
+      credential.setLastUpdate(new java.util.Date());
+      return save(credential);
+   }
+
 
    public Optional<CredentialUserIdPassword> findByUserId(@NotNull String userId)
    {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolver.java
@@ -37,6 +37,9 @@ public class IdentityRoleResolver {
     UserGroupRepo userGroupRepo;
 
     @Inject
+    UserRealmRoleRepo userRealmRoleRepo;
+
+    @Inject
     EnvConfigUtils envConfigUtils;
 
     /**
@@ -63,88 +66,54 @@ public class IdentityRoleResolver {
      * @param realm the target realm for UserProfile/UserGroup lookups (e.g., from X-Realm header or credential's default)
      */
     public String[] resolveEffectiveRoles(SecurityIdentity identity, CredentialUserIdPassword credential, String realm) {
-        // Best-effort identity value for provenance: prefer principal name; otherwise credential userId
-        String identityValue = null;
-        if (identity != null && identity.getPrincipal() != null) {
-            identityValue = identity.getPrincipal().getName();
-        }
-        if ((identityValue == null || identityValue.isBlank()) && credential != null) {
-            identityValue = credential.getUserId();
-        }
+        String authorityRealm = credentialHomeRealm(credential);
+        return resolveEffectiveRoles(identity, credential, authorityRealm, realm);
+    }
 
-        // We do not have realm here; group/credential expansion below uses the subject from the provided credential.
-        // Build provenance inline to ensure RoleSource is constructed while roles are aggregated.
+    /**
+     * Resolve roles for an effective realm while keeping token and flat credential
+     * authorities bound to the realm in which they were issued.
+     */
+    public String[] resolveEffectiveRoles(SecurityIdentity identity,
+                                          CredentialUserIdPassword credential,
+                                          String authorityRealm,
+                                          String effectiveRealm) {
+        String targetRealm = requireRealm(effectiveRealm);
         LinkedHashMap<String, EnumSet<RoleSource>> provenance = new LinkedHashMap<>();
+        boolean sameAuthorityRealm = sameRealm(authorityRealm, targetRealm);
 
-        // TOKEN roles: included only if identityValue equals the principal (i.e., checking current user)
-        if (identity != null && identityValue != null && identity.getPrincipal() != null
-                && identityValue.equals(identity.getPrincipal().getName())) {
-            for (String r : identity.getRoles()) {
-                if (r == null || r.isBlank()) continue;
-                provenance.computeIfAbsent(r, k -> EnumSet.noneOf(RoleSource.class)).add(RoleSource.TOKEN);
-            }
+        if (sameAuthorityRealm && identity != null) {
+            addRoles(provenance, identity.getRoles(), RoleSource.TOKEN);
+        }
+        if (sameAuthorityRealm && credential != null) {
+            addRoles(provenance, credential.getRoles(), RoleSource.CREDENTIAL);
         }
 
-        // CREDENTIAL roles
-        if (credential != null && credential.getRoles() != null) {
-            for (String r : credential.getRoles()) {
-                if (r == null || r.isBlank()) continue;
-                provenance.computeIfAbsent(r, k -> EnumSet.noneOf(RoleSource.class)).add(RoleSource.CREDENTIAL);
-            }
-        }
+        if (credential != null) {
+            try {
+                userRealmRoleRepo.findActiveAssignmentForRealmWithIgnoreRules(
+                                credential.getUserId(), targetRealm, envConfigUtils.getSystemRealm())
+                        .ifPresent(assignment -> addRoles(provenance, assignment.getRoles(), RoleSource.REALM));
 
-        // USERGROUP roles via UserProfile -> UserGroup definitions
-        try {
-            if (credential != null) {
-                // Use the provided realm for UserProfile/UserGroup lookups
-                // This ensures we query the correct tenant's datastore, not just system-com
-                Log.debugf("IdentityRoleResolver: looking up UserProfile for subject=%s in realm=%s",
-                    credential.getSubject(), realm);
-
-                Optional<UserProfile> userProfileOpt;
-                if (realm != null && !realm.isBlank()) {
-                    userProfileOpt = userProfileRepo.getBySubject(realm, credential.getSubject());
-                } else {
-                    // Fallback to no-realm method (will use security context realm)
-                    Log.warnf("IdentityRoleResolver: realm is null/blank, falling back to context realm for subject=%s",
-                        credential.getSubject());
-                    userProfileOpt = userProfileRepo.getBySubject(credential.getSubject());
-                }
-                if (userProfileOpt.isPresent()) {
-                    Log.debugf("IdentityRoleResolver: UserProfile found for subject=%s, looking up UserGroups in realm=%s",
-                        credential.getSubject(), realm);
-                    // IMPORTANT: Pass the realm to findByUserProfileRef to query the correct database
-                    // The security context may be different (e.g., system-com during login)
-                    // Use findByUserProfileRefWithIgnoreRules to bypass security context check
-                    // since we're in the process of building the PrincipalContext
-                    var groups = (realm != null && !realm.isBlank())
-                        ? userGroupRepo.findByUserProfileRefWithIgnoreRules(realm, userProfileOpt.get().createEntityReference())
-                        : userGroupRepo.findByUserProfileRef(userProfileOpt.get().createEntityReference());
-                    if (groups != null && !groups.isEmpty()) {
-                        Log.debugf("IdentityRoleResolver: found %d UserGroups for subject=%s", groups.size(), credential.getSubject());
-                        for (UserGroup g : groups) {
-                            if (g == null || g.getRoles() == null) continue;
-                            Log.debugf("IdentityRoleResolver: UserGroup '%s' has roles: %s", g.getRefName(), java.util.Arrays.toString(g.getRoles().toArray()));
-                            for (String r : g.getRoles()) {
-                                if (r == null || r.isBlank()) continue;
-                                provenance.computeIfAbsent(r, k -> EnumSet.noneOf(RoleSource.class)).add(RoleSource.USERGROUP);
+                Optional<UserProfile> profile = userProfileRepo.getBySubject(targetRealm, credential.getSubject());
+                if (profile.isPresent()) {
+                    List<UserGroup> groups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
+                            targetRealm, profile.get().createEntityReference());
+                    if (groups != null) {
+                        for (UserGroup group : groups) {
+                            if (group != null) {
+                                addRoles(provenance, group.getRoles(), RoleSource.USERGROUP);
                             }
                         }
-                    } else {
-                        Log.debugf("IdentityRoleResolver: no UserGroups found for subject=%s", credential.getSubject());
                     }
                 }
-                else {
-                    // No matching UserProfile found, assume anonymous
-                    Log.warnf("No matching UserProfile found for subject=%s in realm=%s when attempting to resolve groups in role resolver",
-                        credential.getSubject(), realm);
-                }
+            } catch (RuntimeException e) {
+                throw new IllegalStateException(String.format(
+                        "Unable to resolve role authorities for user '%s' in realm '%s'",
+                        credential.getUserId(), targetRealm), e);
             }
-        } catch (Exception e) {
-            Log.warn("Failed to expand roles via user groups; continuing", e);
         }
 
-        // Return the union
         if (provenance.isEmpty()) return new String[]{"ANONYMOUS"};
         return provenance.keySet().toArray(new String[0]);
     }
@@ -157,14 +126,9 @@ public class IdentityRoleResolver {
         LinkedHashSet<String> out = new LinkedHashSet<>();
         if (identity == null || identity.isBlank()) return out;
         out.add(identity);
-        try {
-            // Build provenance centrally and reuse for union to avoid duplicated logic and inconsistent conditions
-            Map<String, EnumSet<RoleSource>> provenance = resolveRoleSources(identity, realm, securityIdentity);
-            if (!provenance.isEmpty()) {
-                out.addAll(provenance.keySet());
-            }
-        } catch (Exception e) {
-            Log.warnf(e, "Error resolving roles for identity %s in realm %s", identity, realm);
+        Map<String, EnumSet<RoleSource>> provenance = resolveRoleSources(identity, realm, securityIdentity);
+        if (!provenance.isEmpty()) {
+            out.addAll(provenance.keySet());
         }
         return out;
     }
@@ -179,99 +143,86 @@ public class IdentityRoleResolver {
      */
     public Map<String, EnumSet<RoleSource>> resolveRoleSources(String identity, String realm, SecurityIdentity securityIdentity) {
         LinkedHashMap<String, EnumSet<RoleSource>> out = new LinkedHashMap<>();
-
-        Log.debugf("resolveRoleSources: identity=%s, realm=%s", identity, realm);
-
-        // TOKEN roles from the current security identity (include when the current identity matches by principal name or augmented userId attribute)
-        if (securityIdentity != null) {
-            String principalName = (securityIdentity.getPrincipal() != null) ? securityIdentity.getPrincipal().getName() : null;
-            String attrUserId = null;
-            try {
-                Object attr = securityIdentity.getAttribute("userId");
-                if (attr instanceof String s) attrUserId = s;
-            } catch (Throwable ignored) {}
-
-            boolean matches = (identity != null) && (
-                    (principalName != null && identity.equals(principalName)) ||
-                    (attrUserId != null && identity.equals(attrUserId))
-            );
-
-            if (matches) {
-                for (String r : securityIdentity.getRoles()) {
-                    if (r == null || r.isEmpty()) continue;
-                    out.computeIfAbsent(r, k -> EnumSet.noneOf(RoleSource.class)).add(RoleSource.TOKEN);
-                }
-            }
+        String targetRealm = requireRealm(realm);
+        String systemRealm = envConfigUtils.getSystemRealm();
+        Optional<CredentialUserIdPassword> credential = credentialRepo.findByUserId(identity, systemRealm, true);
+        String authorityRealm = identityRealm(securityIdentity);
+        if (authorityRealm == null && credential.isPresent()) {
+            authorityRealm = credentialHomeRealm(credential.get());
         }
 
-        try {
-            // IMPORTANT: Credentials are ALWAYS stored in system-com (global), not in tenant realms.
-            // Use envConfigUtils.getSystemRealm() for credential lookup, regardless of the realm parameter.
-            String systemRealm = envConfigUtils.getSystemRealm();
-            Log.debugf("resolveRoleSources: looking up credential in systemRealm=%s for identity=%s", systemRealm, identity);
+        if (sameRealm(authorityRealm, targetRealm) && currentIdentityMatches(identity, securityIdentity)) {
+            addRoles(out, securityIdentity.getRoles(), RoleSource.TOKEN);
+        }
 
-            var ocreds = credentialRepo.findByUserId(identity, systemRealm, true);
-            if (ocreds.isPresent()) {
-                var cred = ocreds.get();
-                Log.debugf("resolveRoleSources: credential found for identity=%s, subject=%s", identity, cred.getSubject());
+        if (credential.isPresent()) {
+            CredentialUserIdPassword cred = credential.get();
+            if (sameRealm(credentialHomeRealm(cred), targetRealm)) {
+                addRoles(out, cred.getRoles(), RoleSource.CREDENTIAL);
+            }
+            userRealmRoleRepo.findActiveAssignmentForRealmWithIgnoreRules(
+                            cred.getUserId(), targetRealm, systemRealm)
+                    .ifPresent(assignment -> addRoles(out, assignment.getRoles(), RoleSource.REALM));
 
-                // Credential roles
-                if (cred.getRoles() != null) {
-                    for (String r : cred.getRoles()) {
-                        if (r == null || r.isEmpty()) continue;
-                        out.computeIfAbsent(r, k -> EnumSet.noneOf(RoleSource.class)).add(RoleSource.CREDENTIAL);
-                    }
-                }
-                // User group roles via profile (always unioned when credential exists)
-                try {
-                    // Use the provided realm to ensure we read the profile from the correct tenant datastore
-                    // If realm is null/blank, fall back to the no-realm method (uses security context realm)
-                    Log.debugf("resolveRoleSources: looking up UserProfile in realm=%s for subject=%s", realm, cred.getSubject());
-                    Optional<UserProfile> userProfileOpt;
-                    if (realm != null && !realm.isBlank()) {
-                        userProfileOpt = userProfileRepo.getBySubject(realm, cred.getSubject());
-                    } else {
-                        Log.warnf("resolveRoleSources: realm is null/blank, falling back to context realm for subject=%s", cred.getSubject());
-                        userProfileOpt = userProfileRepo.getBySubject(cred.getSubject());
-                    }
-                    if (userProfileOpt.isPresent()) {
-                        Log.debugf("resolveRoleSources: UserProfile found for subject=%s, looking up UserGroups in realm=%s", cred.getSubject(), realm);
-                        // IMPORTANT: Pass the realm to findByUserProfileRefWithIgnoreRules to query the correct database
-                        // The security context may be different (e.g., system-com during login)
-                        // Use findByUserProfileRefWithIgnoreRules to bypass security context check
-                        // since we're in the process of building the PrincipalContext
-                        var groups = (realm != null && !realm.isBlank())
-                            ? userGroupRepo.findByUserProfileRefWithIgnoreRules(realm, userProfileOpt.get().createEntityReference())
-                            : userGroupRepo.findByUserProfileRef(userProfileOpt.get().createEntityReference());
-                        if (groups != null) {
-                            Log.debugf("resolveRoleSources: found %d UserGroups for subject=%s", groups.size(), cred.getSubject());
-                            for (UserGroup g : groups) {
-                                if (g != null && g.getRoles() != null) {
-                                    Log.debugf("resolveRoleSources: UserGroup '%s' has roles: %s", g.getRefName(), g.getRoles());
-                                    for (String r : g.getRoles()) {
-                                        if (r == null || r.isEmpty()) continue;
-                                        out.computeIfAbsent(r, k -> EnumSet.noneOf(RoleSource.class)).add(RoleSource.USERGROUP);
-                                    }
-                                }
-                            }
-                        } else {
-                            Log.debugf("resolveRoleSources: no UserGroups found for subject=%s", cred.getSubject());
+            Optional<UserProfile> profile = userProfileRepo.getBySubject(targetRealm, cred.getSubject());
+            if (profile.isPresent()) {
+                List<UserGroup> groups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
+                        targetRealm, profile.get().createEntityReference());
+                if (groups != null) {
+                    for (UserGroup group : groups) {
+                        if (group != null) {
+                            addRoles(out, group.getRoles(), RoleSource.USERGROUP);
                         }
-                    } else {
-                        Log.debugf("resolveRoleSources: no UserProfile found in realm=%s for subject=%s", realm, cred.getSubject());
                     }
-                } catch (Exception e) {
-                    Log.warn("Failed to expand user-group roles; continuing", e);
                 }
-            } else {
-                Log.debugf("resolveRoleSources: no credential found in systemRealm=%s for identity=%s", systemRealm, identity);
             }
-        } catch (Exception e) {
-            Log.warnf(e, "Error resolving role sources for identity %s in realm %s", identity, realm);
         }
-
-        Log.debugf("resolveRoleSources: returning roles=%s", out.keySet());
         return out;
+    }
+
+    private String credentialHomeRealm(CredentialUserIdPassword credential) {
+        if (credential == null || credential.getDomainContext() == null) return null;
+        return credential.getDomainContext().getDefaultRealm();
+    }
+
+    private String identityRealm(SecurityIdentity identity) {
+        if (identity == null) return null;
+        Object value = identity.getAttribute("realm");
+        return value instanceof String s && !s.isBlank() ? s : null;
+    }
+
+    private boolean currentIdentityMatches(String identity, SecurityIdentity securityIdentity) {
+        if (identity == null || securityIdentity == null || securityIdentity.getPrincipal() == null) return false;
+        if (identity.equals(securityIdentity.getPrincipal().getName())) return true;
+        Object userId = securityIdentity.getAttribute("userId");
+        return userId instanceof String s && identity.equals(s);
+    }
+
+    private String requireRealm(String realm) {
+        if (realm == null || realm.isBlank()) {
+            throw new IllegalArgumentException("A non-blank realm is required for role resolution");
+        }
+        return realm.trim();
+    }
+
+    private boolean sameRealm(String left, String right) {
+        return left != null && right != null && left.equalsIgnoreCase(right);
+    }
+
+    private void addRoles(Map<String, EnumSet<RoleSource>> target,
+                          Collection<String> roles,
+                          RoleSource source) {
+        if (roles == null) return;
+        for (String role : roles) {
+            if (role == null || role.isBlank()) continue;
+            target.computeIfAbsent(role, ignored -> EnumSet.noneOf(RoleSource.class)).add(source);
+        }
+    }
+
+    private void addRoles(Map<String, EnumSet<RoleSource>> target,
+                          String[] roles,
+                          RoleSource source) {
+        addRoles(target, roles == null ? null : Arrays.asList(roles), source);
     }
 
     /** Small immutable DTO bundling the union of roles with their assignments. */

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
@@ -7,6 +7,12 @@ import com.e2eq.framework.model.persistent.InvalidStateTransitionException;
 import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
 import com.e2eq.framework.model.persistent.StateNode;
 import com.e2eq.framework.model.persistent.base.*;
+import com.e2eq.framework.model.persistent.morphia.compiler.mongo.MongoAggregationCompiler;
+import com.e2eq.framework.model.persistent.morphia.metadata.DefaultMetadataRegistry;
+import com.e2eq.framework.model.persistent.morphia.metadata.JoinSpec;
+import com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan;
+import com.e2eq.framework.model.persistent.morphia.planner.PlannedQuery;
+import com.e2eq.framework.model.persistent.morphia.planner.PlannerResult;
 import com.e2eq.framework.model.securityrules.*;
 import com.e2eq.framework.rest.models.UIAction;
 import com.e2eq.framework.rest.models.UIActionList;
@@ -41,6 +47,8 @@ import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.PathParam;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
+import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jetbrains.annotations.NotNull;
@@ -78,8 +86,8 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     // Empty locale disables collation and preserves upstream binary-order behavior.
     // Downstreams (e.g. Movista, MOV-12188) set locale=en, strength=2 (SECONDARY)
     // to get case-insensitive text sorting for AG Grid list grids.
-    @ConfigProperty(name = "quantum.sort.collation.locale", defaultValue = "")
-    protected String sortCollationLocale;
+    @ConfigProperty(name = "quantum.sort.collation.locale")
+    protected Optional<String> sortCollationLocale = Optional.empty();
 
     @ConfigProperty(name = "quantum.sort.collation.strength", defaultValue = "2")
     protected int sortCollationStrength;
@@ -266,8 +274,11 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
           qfilters = filters.toArray(qfilters);
        }
 
-        Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
-        T obj = query.first();
+         Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
+         FindOptions findOptions = ignoreRules
+                 ? new FindOptions()
+                 : buildFindOptions(0, 1, null, null);
+         T obj = query.first(findOptions);
 
         if (obj != null) {
             UIActionList uiActions = obj.calculateStateBasedUIActions();
@@ -308,8 +319,11 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
           qfilters = filters.toArray(qfilters);
        }
 
-        Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
-        T obj = query.first();
+         Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
+         FindOptions findOptions = ignoreRules
+                 ? new FindOptions()
+                 : buildFindOptions(0, 1, null, null);
+         T obj = query.first(findOptions);
 
         if (obj != null) {
             UIActionList uiActions = obj.calculateStateBasedUIActions();
@@ -485,33 +499,51 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
         // (exclusion wins); caller exclude-projection -> union with policy.
         java.util.Set<String> policyExcluded = securityFilterBuilder().buildExcludedFieldPaths();
 
-        List<ProjectionField> effectiveProjection = projectionFields;
-        if (!policyExcluded.isEmpty() && projectionFields != null && !projectionFields.isEmpty()) {
-            effectiveProjection = new ArrayList<>();
-            for (ProjectionField pf : projectionFields) {
-                if (pf.getProjectionType() == ProjectionField.ProjectionType.INCLUDE
-                        && policyExcluded.contains(pf.getFieldName())) {
-                    continue; // policy exclusion wins over a requested include
-                }
-                effectiveProjection.add(pf);
-            }
-            for (String path : policyExcluded) {
-                if (effectiveProjection.stream().anyMatch(pf ->
-                        pf.getProjectionType() == ProjectionField.ProjectionType.EXCLUDE)) {
-                    effectiveProjection.add(new ProjectionField(path, ProjectionField.ProjectionType.EXCLUDE));
-                }
-            }
-        }
+         List<ProjectionField> effectiveProjection = projectionFields;
+         boolean callerIncludes = projectionFields != null && projectionFields.stream().anyMatch(pf ->
+                 pf.getProjectionType() == ProjectionField.ProjectionType.INCLUDE);
+         if (!policyExcluded.isEmpty() && projectionFields != null && !projectionFields.isEmpty()) {
+             effectiveProjection = new ArrayList<>();
+             for (ProjectionField pf : projectionFields) {
+                 if (pf.getProjectionType() == ProjectionField.ProjectionType.INCLUDE
+                         && policyExcluded.stream().anyMatch(path -> pathsOverlap(pf.getFieldName(), path))) {
+                     continue; // policy exclusion wins over exact, parent, or child includes
+                 }
+                 effectiveProjection.add(pf);
+             }
+             if (!callerIncludes) {
+                 for (String path : policyExcluded) {
+                     boolean alreadyExcluded = effectiveProjection.stream().anyMatch(pf ->
+                             pf.getProjectionType() == ProjectionField.ProjectionType.EXCLUDE
+                                     && Objects.equals(pf.getFieldName(), path));
+                     if (!alreadyExcluded) {
+                         effectiveProjection.add(new ProjectionField(path, ProjectionField.ProjectionType.EXCLUDE));
+                     }
+                 }
+             }
+         }
 
-        if (effectiveProjection != null && !effectiveProjection.isEmpty()) {
-            findOptions.projection().knownFields();
-            findOptions = convertToProjection(findOptions, effectiveProjection);
+         if (callerIncludes && (effectiveProjection == null || effectiveProjection.isEmpty())) {
+             // Never turn an emptied include projection into an unrestricted read.
+             findOptions.projection().include("_id");
+         } else if (effectiveProjection != null && !effectiveProjection.isEmpty()) {
+             findOptions.projection().knownFields();
+             findOptions = convertToProjection(findOptions, effectiveProjection);
         } else if (!policyExcluded.isEmpty()) {
             findOptions.projection().exclude(policyExcluded.toArray(new String[0]));
         }
 
-        return findOptions;
-    }
+         return findOptions;
+     }
+
+     private static boolean pathsOverlap(String requestedPath, String excludedPath) {
+         if (requestedPath == null || excludedPath == null) {
+             return false;
+         }
+         return requestedPath.equals(excludedPath)
+                 || requestedPath.startsWith(excludedPath + ".")
+                 || excludedPath.startsWith(requestedPath + ".");
+     }
 
     /**
      * Default {@link BaseMorphiaRepo#getSortCollation()} implementation
@@ -539,18 +571,19 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     }
 
     private Collation buildSortCollation() {
-        if (sortCollationLocale == null || sortCollationLocale.isBlank()) {
+        String locale = sortCollationLocale == null ? null : sortCollationLocale.orElse(null);
+        if (locale == null || locale.isBlank()) {
             return null;
         }
         try {
             return Collation.builder()
-                    .locale(sortCollationLocale)
+                    .locale(locale)
                     .collationStrength(CollationStrength.fromInt(sortCollationStrength))
                     .build();
         } catch (IllegalArgumentException ex) {
             Log.warnf(
                     "Invalid quantum.sort.collation.strength=%d for locale=%s; disabling sort collation. Valid range is 1-5 (PRIMARY..IDENTICAL).",
-                    sortCollationStrength, sortCollationLocale);
+                    sortCollationStrength, locale);
             return null;
         }
     }
@@ -673,6 +706,200 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
         return list;
     }
 
+    @Override
+    public List<Document> getSecuredAggregationDocuments(
+            @Nullable String realmId,
+            int skip,
+            int limit,
+            @NotNull String query,
+            @Nullable List<SortField> sortFields,
+            @Nullable List<ProjectionField> projectionFields) {
+        if (skip < 0 || limit < 0) {
+            throw new IllegalArgumentException("skip and limit cannot be negative for aggregation");
+        }
+        Objects.requireNonNull(query, "aggregation query cannot be null");
+        Datastore datastore = morphiaDataStoreWrapper.getDataStore(
+                realmId == null || realmId.isBlank() ? getSecurityContextRealmId() : realmId);
+        if (!(datastore instanceof MorphiaDatastore morphiaDatastore)) {
+            throw new IllegalStateException("Governed aggregation requires a MorphiaDatastore");
+        }
+
+        List<LogicalPlan.SortSpec.Field> plannerSort = sortFields == null ? null : sortFields.stream()
+                .map(field -> new LogicalPlan.SortSpec.Field(
+                        field.getFieldName(),
+                        field.getSortDirection() == SortField.SortDirection.DESC ? -1 : 1))
+                .toList();
+        PlannedQuery planned = MorphiaUtils.convertToPlannedQuery(
+                query, getPersistentClass(), limit, skip, plannerSort);
+        if (planned.getMode() != PlannerResult.Mode.AGGREGATION) {
+            throw new IllegalArgumentException("Query does not contain a valid expand(...) operation");
+        }
+
+        List<Document> pipeline = new ArrayList<>();
+        for (Bson stage : planned.getAggregation()) {
+            if (!(stage instanceof Document document)) {
+                throw new IllegalStateException("Aggregation compiler emitted an unsupported stage type: "
+                        + stage.getClass().getName());
+            }
+            if (!document.containsKey("$plannedExpandPaths")) {
+                pipeline.add(new Document(document));
+            }
+        }
+
+        MongoAggregationCompiler filterCompiler = new MongoAggregationCompiler(morphiaDatastore);
+        Document rootPolicyMatch = compilePolicyMatch(
+                filterCompiler,
+                securityFilterBuilder().buildSecuredFilters(new ArrayList<>(), getPersistentClass()));
+        if (rootPolicyMatch != null && !rootPolicyMatch.isEmpty()) {
+            pipeline.add(0, new Document("$match", rootPolicyMatch));
+        }
+
+        Map<String, AggregationAccessPolicy> lookupPolicies = resolveLookupPolicies(query, filterCompiler);
+        applyLookupPolicies(pipeline, lookupPolicies);
+        applyCallerProjection(pipeline, projectionFields);
+        appendExclusionProjection(pipeline, securityFilterBuilder().buildExcludedFieldPaths());
+
+        String rootCollection = morphiaDatastore.getMapper()
+                .getEntityModel(getPersistentClass()).collectionName();
+        return morphiaDatastore.getDatabase()
+                .getCollection(rootCollection)
+                .aggregate(new ArrayList<Bson>(pipeline), Document.class)
+                .into(new ArrayList<>());
+    }
+
+    private Document compilePolicyMatch(MongoAggregationCompiler compiler, List<Filter> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return null;
+        }
+        Filter combined = filters.size() == 1
+                ? filters.get(0)
+                : Filters.and(filters.toArray(new Filter[0]));
+        return compiler.compileMatch(combined);
+    }
+
+    private Map<String, AggregationAccessPolicy> resolveLookupPolicies(
+            String query, MongoAggregationCompiler compiler) {
+        com.e2eq.framework.model.persistent.morphia.planner.QueryPlanner planner =
+                new com.e2eq.framework.model.persistent.morphia.planner.QueryPlanner();
+        DefaultMetadataRegistry metadata = new DefaultMetadataRegistry();
+        Map<String, AggregationAccessPolicy> policies = new LinkedHashMap<>();
+        for (String path : planner.analyze(query).getExpandPaths()) {
+            JoinSpec join = metadata.resolveJoin(getPersistentClass(), path);
+            if (join.fromCollection == null || join.fromCollection.isBlank()
+                    || join.targetType == null
+                    || !UnversionedBaseModel.class.isAssignableFrom(join.targetType)) {
+                throw new SecurityException("Expand path '" + path
+                        + "' has no governable target model/collection");
+            }
+            @SuppressWarnings("unchecked")
+            Class<? extends UnversionedBaseModel> targetType =
+                    (Class<? extends UnversionedBaseModel>) join.targetType;
+            com.e2eq.framework.annotations.FunctionalMapping mapping =
+                    targetType.getAnnotation(com.e2eq.framework.annotations.FunctionalMapping.class);
+            if (mapping == null) {
+                throw new SecurityException("Expand target " + targetType.getName()
+                        + " must declare @FunctionalMapping for policy evaluation");
+            }
+            ResourceContext current = SecurityContext.getResourceContext()
+                    .orElseThrow(() -> new SecurityException(
+                            "Governed aggregation requires a ResourceContext"));
+            ResourceContext targetContext = new ResourceContext.Builder()
+                    .withRealm(current.getRealm())
+                    .withArea(mapping.area())
+                    .withFunctionalDomain(mapping.domain())
+                    .withAction(current.getAction())
+                    .withResourceId(current.getResourceId())
+                    .build();
+            AggregationAccessPolicy policy;
+            try (SecurityCallScope.Scope ignored = SecurityCallScope.openResourceOnly(targetContext)) {
+                Document targetMatch = compilePolicyMatch(compiler,
+                        securityFilterBuilder().buildSecuredFilters(new ArrayList<>(), targetType));
+                Set<String> targetExcluded = new LinkedHashSet<>(
+                        securityFilterBuilder().buildExcludedFieldPaths());
+                policy = new AggregationAccessPolicy(targetMatch, targetExcluded);
+            }
+            AggregationAccessPolicy previous = policies.putIfAbsent(join.fromCollection, policy);
+            if (previous != null && !previous.equals(policy)) {
+                throw new SecurityException("Conflicting policies resolved for expand collection "
+                        + join.fromCollection);
+            }
+        }
+        return policies;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void applyLookupPolicies(
+            List<Document> pipeline, Map<String, AggregationAccessPolicy> policies) {
+        for (Document stage : pipeline) {
+            if (!stage.containsKey("$lookup")) {
+                continue;
+            }
+            Document lookup = stage.get("$lookup", Document.class);
+            if (lookup == null) {
+                throw new SecurityException("Aggregation contains an invalid $lookup stage");
+            }
+            String from = lookup.getString("from");
+            AggregationAccessPolicy policy = policies.get(from);
+            if (from == null || "__unknown__".equals(from) || policy == null) {
+                throw new SecurityException("Aggregation lookup target is unresolved or unauthorized: " + from);
+            }
+            List<Document> lookupPipeline = new ArrayList<>();
+            Object existing = lookup.get("pipeline");
+            if (existing instanceof List<?> stages) {
+                for (Object nested : stages) {
+                    if (!(nested instanceof Document document)) {
+                        throw new SecurityException("Lookup pipeline contains an unsupported stage");
+                    }
+                    lookupPipeline.add(new Document(document));
+                }
+            }
+            if (policy.rowMatch() != null && !policy.rowMatch().isEmpty()) {
+                lookupPipeline.add(new Document("$match", policy.rowMatch()));
+            }
+            if (!policy.excludedFields().isEmpty()) {
+                lookupPipeline.add(exclusionProjection(policy.excludedFields()));
+            }
+            lookup.put("pipeline", lookupPipeline);
+        }
+    }
+
+    private void applyCallerProjection(List<Document> pipeline, List<ProjectionField> projectionFields) {
+        if (projectionFields == null || projectionFields.isEmpty()) {
+            return;
+        }
+        boolean includeMode = projectionFields.stream().anyMatch(field ->
+                field.getProjectionType() == ProjectionField.ProjectionType.INCLUDE);
+        Document projection = new Document();
+        for (ProjectionField field : projectionFields) {
+            if (includeMode && field.getProjectionType() == ProjectionField.ProjectionType.EXCLUDE
+                    && !"_id".equals(field.getFieldName())) {
+                throw new IllegalArgumentException(
+                        "Aggregation projection cannot mix includes with non-_id excludes");
+            }
+            projection.put(field.getFieldName(),
+                    field.getProjectionType() == ProjectionField.ProjectionType.INCLUDE ? 1 : 0);
+        }
+        if (includeMode && !projection.containsKey("_id")) {
+            projection.put("_id", 1);
+        }
+        pipeline.add(new Document("$project", projection));
+    }
+
+    private void appendExclusionProjection(List<Document> pipeline, Set<String> excludedFields) {
+        if (excludedFields != null && !excludedFields.isEmpty()) {
+            pipeline.add(exclusionProjection(excludedFields));
+        }
+    }
+
+    private Document exclusionProjection(Set<String> excludedFields) {
+        Document projection = new Document();
+        excludedFields.forEach(path -> projection.put(path, 0));
+        return new Document("$project", projection);
+    }
+
+    private record AggregationAccessPolicy(Document rowMatch, Set<String> excludedFields) {
+    }
+
     // Convenience method that uses the default datastore
     @Override
     public CloseableIterator<T> getStreamByQuery(int skip, int limit, @Nullable String query, @Nullable List<SortField> sortFields, @Nullable List<ProjectionField> projectionFields) {
@@ -756,10 +983,10 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
         filters.add(Filters.in("_id", ids));
 
-        FindOptions findOptions = new FindOptions();
+         FindOptions findOptions = buildFindOptions(0, -1, null, null);
 
         Filter[] filterArray = new Filter[filters.size()];
-        Query<T> query = morphiaDataStoreWrapper.getDataStore(getSecurityContextRealmId()).find(getPersistentClass())
+         Query<T> query = datastore.find(getPersistentClass())
                 .filter(filters.toArray(filterArray));
 
         List<T> list = query.iterator(findOptions).toList();
@@ -792,11 +1019,11 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
         filters.add(Filters.in("refName", refNames));
 
-        FindOptions findOptions = new FindOptions();
-       String realm= getSecurityContextRealmId();
+         FindOptions findOptions = buildFindOptions(0, -1, null, null);
+        String realm = datastore.getDatabase().getName();
 
         Filter[] filterArray = new Filter[filters.size()];
-        Query<T> query = morphiaDataStoreWrapper.getDataStore(realm).find(getPersistentClass())
+         Query<T> query = datastore.find(getPersistentClass())
                 .filter(filters.toArray(filterArray));
 
         List<T> list = query.iterator(findOptions).toList();
@@ -941,6 +1168,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
    }
 
     public T save(@NotNull MorphiaSession session, @Valid T value) {
+        value = restorePolicyExcludedFields(session, value);
         if (value.getClass().getAnnotation(Stateful.class)!= null) {
            try {
               validateStateTransitions(session, value);
@@ -948,7 +1176,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
               throw new RuntimeException("State transition validation failed", e);
            }
         }
-       setDefaultValues(value);
+        setDefaultValues(value);
         value.validate();
         T saved = session.save(value);
         callPostPersistHooks(getSecurityContextRealmId(), saved);
@@ -968,6 +1196,9 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public List<T> save(@NotNull Datastore datastore, List<T> entities) {
+       entities = entities.stream()
+               .map(entity -> restorePolicyExcludedFields(datastore, entity))
+               .collect(Collectors.toCollection(ArrayList::new));
        entities.forEach(entity -> {
           if (entity.getClass().getAnnotation(Stateful.class)!= null) {
              try {
@@ -988,7 +1219,9 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public List<T> save(@NotNull MorphiaSession session, List<T> entities) {
-
+       entities = entities.stream()
+               .map(entity -> restorePolicyExcludedFields(session, entity))
+               .collect(Collectors.toCollection(ArrayList::new));
        entities.forEach(entity -> {
           if (entity.getClass().getAnnotation(Stateful.class)!= null) {
              try {
@@ -1010,6 +1243,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public T save(@NotNull Datastore datastore, @Valid T value) {
+       value = restorePolicyExcludedFields(datastore, value);
        if (value.getClass().getAnnotation(Stateful.class)!= null) {
           try {
              validateStateTransitions(datastore, value);
@@ -1017,7 +1251,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
              throw new RuntimeException("State transition validation failed", e);
           }
        }
-       setDefaultValues(value);
+        setDefaultValues(value);
        value.validate();
        T saved = datastore.save(value);
        callPostPersistHooks(getSecurityContextRealmId(), saved);
@@ -1312,6 +1546,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     public final long update(MorphiaSession session, @NotNull String id, @NotNull Pair<String, Object>... pairs) {
         List<UpdateOperator> updateOperators = new ArrayList<>();
         for (Pair<String, Object> pair : pairs) {
+            assertFieldUpdateAllowed(pair.getKey());
             // check that the pair key corresponds to a field in the persistent class that is an enum
             Field field = null;
             try {
@@ -1376,6 +1611,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
        T currentEntity = currentEntityOpt.get();
 
        for (Pair<String, Object> pair : pairs) {
+          assertFieldUpdateAllowed(pair.getKey());
           if (reservedFields.contains(pair.getKey())) {
              throw new IllegalArgumentException("Field:" + pair.getKey() + " is a reserved field and can't be updated");
           }
@@ -1463,6 +1699,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     public final long update(MorphiaSession session, @NotNull ObjectId id, @NotNull Pair<String, Object>... pairs) {
         List<UpdateOperator> updateOperators = new ArrayList<>();
         for (Pair<String, Object> pair : pairs) {
+           assertFieldUpdateAllowed(pair.getKey());
             // check that the pair key corresponds to a field in the persistent class that is an enum
             Field field = null;
             try {
@@ -1657,11 +1894,12 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     }
 
    @SafeVarargs
-    private  List<UpdateOperator> buildValidatedUpdateOperators(@NotNull Pair<String, Object>... pairs) {
+     private  List<UpdateOperator> buildValidatedUpdateOperators(@NotNull Pair<String, Object>... pairs) {
         Objects.requireNonNull(pairs, "update pairs must not be null");
         List<UpdateOperator> updateOperators = new ArrayList<>();
         List<String> reservedFields = List.of("refName", "id", "version", "references", "auditInfo", "persistentEvents");
-        for (Pair<String, Object> pair : pairs) {
+         for (Pair<String, Object> pair : pairs) {
+             assertFieldUpdateAllowed(pair.getKey());
             if (reservedFields.contains(pair.getKey())) {
                 throw new IllegalArgumentException("Field:" + pair.getKey() + " is a reserved field and can't be updated");
             }
@@ -1707,19 +1945,29 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
      * must not be able to overwrite it on update. For each excluded path, the
      * stored document's current value is restored onto the incoming entity
      * before persisting (preserve-hidden-field semantics). Top-level and
-     * one-level-nested ("parent.child") paths are supported in v1.
+     * nested paths are supported. When a nested collection is excluded, the
+     * stored collection is preserved as a unit because element identity is not
+     * available at this generic boundary.
      */
-    protected T restorePolicyExcludedFields(Datastore datastore, T entity) {
-        java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
-        if (excluded.isEmpty() || entity.getId() == null) {
-            return entity;
-        }
-        T stored = datastore.find(getPersistentClass())
-                .filter(dev.morphia.query.filters.Filters.eq("_id", entity.getId()))
-                .first();
-        if (stored == null) {
-            return entity;
-        }
+     protected T restorePolicyExcludedFields(Datastore datastore, T entity) {
+         java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
+         if (excluded.isEmpty()) {
+             return entity;
+         }
+         if (entity.getId() == null) {
+             FieldPolicyEnforcer.assertUnset(entity, excluded);
+             return entity;
+         }
+         List<Filter> filters = securityFilterBuilder().buildSecuredFilters(
+                 new ArrayList<>(), getPersistentClass());
+         filters.add(dev.morphia.query.filters.Filters.eq("_id", entity.getId()));
+         T stored = datastore.find(getPersistentClass())
+                 .filter(filters.toArray(new Filter[0]))
+                 .first();
+         if (stored == null) {
+             throw new SecurityException(
+                     "Entity is not available in the caller's governed scope; update rejected");
+         }
         for (String path : excluded) {
             try {
                 com.e2eq.framework.model.securityrules.FieldPolicyEnforcer.copyPath(stored, entity, path);
@@ -1729,8 +1977,49 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
                     + getPersistentClass().getSimpleName() + "; failing closed.", e);
             }
         }
-        return entity;
-    }
+         return entity;
+     }
+
+     protected T restorePolicyExcludedFields(MorphiaSession session, T entity) {
+         java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
+         if (excluded.isEmpty()) {
+             return entity;
+         }
+         if (entity.getId() == null) {
+             FieldPolicyEnforcer.assertUnset(entity, excluded);
+             return entity;
+         }
+         List<Filter> filters = securityFilterBuilder().buildSecuredFilters(
+                 new ArrayList<>(), getPersistentClass());
+         filters.add(dev.morphia.query.filters.Filters.eq("_id", entity.getId()));
+         T stored = session.find(getPersistentClass())
+                 .filter(filters.toArray(new Filter[0]))
+                 .first();
+         if (stored == null) {
+             throw new SecurityException(
+                     "Entity is not available in the caller's governed scope; update rejected");
+         }
+         for (String path : excluded) {
+             try {
+                 com.e2eq.framework.model.securityrules.FieldPolicyEnforcer.copyPath(stored, entity, path);
+             } catch (ReflectiveOperationException e) {
+                 throw new RuntimeException(
+                         "Field-level policy could not restore excluded path '" + path + "' on "
+                                 + getPersistentClass().getSimpleName() + "; failing closed.", e);
+             }
+         }
+         return entity;
+     }
+
+     private void assertFieldUpdateAllowed(String requestedPath) {
+         java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
+         for (String excludedPath : excluded) {
+             if (pathsOverlap(requestedPath, excludedPath)) {
+                 throw new SecurityException(
+                         "Field '" + requestedPath + "' is protected by field-level policy");
+             }
+         }
+     }
 
     @Override
     public T merge(@NotNull T entity){
@@ -1739,6 +2028,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public T merge(Datastore datastore, @NotNull T entity) {
+       entity = restorePolicyExcludedFields(datastore, entity);
        if (entity.getClass().getAnnotation(Stateful.class) != null) {
           try {
              validateStateTransitions(datastore, entity);
@@ -1746,12 +2036,12 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
              throw new RuntimeException("State transition validation failed", e);
           }
        }
-        entity = restorePolicyExcludedFields(datastore, entity);
         return datastore.merge(entity);
     }
 
     @Override
     public T merge(MorphiaSession session, @NotNull T entity) {
+       entity = restorePolicyExcludedFields(session, entity);
        if (entity.getClass().getAnnotation(Stateful.class) != null) {
           try {
              validateStateTransitions(session, entity);
@@ -1759,7 +2049,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
              throw new RuntimeException("State transition validation failed", e);
           }
        }
-        return session.merge(entity);
+         return session.merge(entity);
     }
 
     @Override
@@ -1769,11 +2059,17 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public List<T> merge(Datastore datastore, List<T> entities) {
-        return datastore.merge(entities);
+         entities = entities.stream()
+                 .map(entity -> restorePolicyExcludedFields(datastore, entity))
+                 .collect(Collectors.toCollection(ArrayList::new));
+         return datastore.merge(entities);
     }
 
     @Override
     public List<T> merge(MorphiaSession session, List<T> entities) {
+        entities = entities.stream()
+                .map(entity -> restorePolicyExcludedFields(session, entity))
+                .collect(Collectors.toCollection(ArrayList::new));
        entities.forEach(entity -> {
           if (entity.getClass().getAnnotation(Stateful.class) != null) {
              try {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
@@ -7,6 +7,12 @@ import com.e2eq.framework.model.persistent.InvalidStateTransitionException;
 import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
 import com.e2eq.framework.model.persistent.StateNode;
 import com.e2eq.framework.model.persistent.base.*;
+import com.e2eq.framework.model.persistent.morphia.compiler.mongo.MongoAggregationCompiler;
+import com.e2eq.framework.model.persistent.morphia.metadata.DefaultMetadataRegistry;
+import com.e2eq.framework.model.persistent.morphia.metadata.JoinSpec;
+import com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan;
+import com.e2eq.framework.model.persistent.morphia.planner.PlannedQuery;
+import com.e2eq.framework.model.persistent.morphia.planner.PlannerResult;
 import com.e2eq.framework.model.securityrules.*;
 import com.e2eq.framework.rest.models.UIAction;
 import com.e2eq.framework.rest.models.UIActionList;
@@ -39,6 +45,8 @@ import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.PathParam;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
+import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jetbrains.annotations.NotNull;
@@ -251,8 +259,11 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
           qfilters = filters.toArray(qfilters);
        }
 
-        Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
-        T obj = query.first();
+         Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
+         FindOptions findOptions = ignoreRules
+                 ? new FindOptions()
+                 : buildFindOptions(0, 1, null, null);
+         T obj = query.first(findOptions);
 
         if (obj != null) {
             UIActionList uiActions = obj.calculateStateBasedUIActions();
@@ -293,8 +304,11 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
           qfilters = filters.toArray(qfilters);
        }
 
-        Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
-        T obj = query.first();
+         Query<T> query = datastore.find(getPersistentClass()).filter(qfilters);
+         FindOptions findOptions = ignoreRules
+                 ? new FindOptions()
+                 : buildFindOptions(0, 1, null, null);
+         T obj = query.first(findOptions);
 
         if (obj != null) {
             UIActionList uiActions = obj.calculateStateBasedUIActions();
@@ -466,33 +480,51 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
         // (exclusion wins); caller exclude-projection -> union with policy.
         java.util.Set<String> policyExcluded = securityFilterBuilder().buildExcludedFieldPaths();
 
-        List<ProjectionField> effectiveProjection = projectionFields;
-        if (!policyExcluded.isEmpty() && projectionFields != null && !projectionFields.isEmpty()) {
-            effectiveProjection = new ArrayList<>();
-            for (ProjectionField pf : projectionFields) {
-                if (pf.getProjectionType() == ProjectionField.ProjectionType.INCLUDE
-                        && policyExcluded.contains(pf.getFieldName())) {
-                    continue; // policy exclusion wins over a requested include
-                }
-                effectiveProjection.add(pf);
-            }
-            for (String path : policyExcluded) {
-                if (effectiveProjection.stream().anyMatch(pf ->
-                        pf.getProjectionType() == ProjectionField.ProjectionType.EXCLUDE)) {
-                    effectiveProjection.add(new ProjectionField(path, ProjectionField.ProjectionType.EXCLUDE));
-                }
-            }
-        }
+         List<ProjectionField> effectiveProjection = projectionFields;
+         boolean callerIncludes = projectionFields != null && projectionFields.stream().anyMatch(pf ->
+                 pf.getProjectionType() == ProjectionField.ProjectionType.INCLUDE);
+         if (!policyExcluded.isEmpty() && projectionFields != null && !projectionFields.isEmpty()) {
+             effectiveProjection = new ArrayList<>();
+             for (ProjectionField pf : projectionFields) {
+                 if (pf.getProjectionType() == ProjectionField.ProjectionType.INCLUDE
+                         && policyExcluded.stream().anyMatch(path -> pathsOverlap(pf.getFieldName(), path))) {
+                     continue; // policy exclusion wins over exact, parent, or child includes
+                 }
+                 effectiveProjection.add(pf);
+             }
+             if (!callerIncludes) {
+                 for (String path : policyExcluded) {
+                     boolean alreadyExcluded = effectiveProjection.stream().anyMatch(pf ->
+                             pf.getProjectionType() == ProjectionField.ProjectionType.EXCLUDE
+                                     && Objects.equals(pf.getFieldName(), path));
+                     if (!alreadyExcluded) {
+                         effectiveProjection.add(new ProjectionField(path, ProjectionField.ProjectionType.EXCLUDE));
+                     }
+                 }
+             }
+         }
 
-        if (effectiveProjection != null && !effectiveProjection.isEmpty()) {
-            findOptions.projection().knownFields();
-            findOptions = convertToProjection(findOptions, effectiveProjection);
+         if (callerIncludes && (effectiveProjection == null || effectiveProjection.isEmpty())) {
+             // Never turn an emptied include projection into an unrestricted read.
+             findOptions.projection().include("_id");
+         } else if (effectiveProjection != null && !effectiveProjection.isEmpty()) {
+             findOptions.projection().knownFields();
+             findOptions = convertToProjection(findOptions, effectiveProjection);
         } else if (!policyExcluded.isEmpty()) {
             findOptions.projection().exclude(policyExcluded.toArray(new String[0]));
         }
 
-        return findOptions;
-    }
+         return findOptions;
+     }
+
+     private static boolean pathsOverlap(String requestedPath, String excludedPath) {
+         if (requestedPath == null || excludedPath == null) {
+             return false;
+         }
+         return requestedPath.equals(excludedPath)
+                 || requestedPath.startsWith(excludedPath + ".")
+                 || excludedPath.startsWith(requestedPath + ".");
+     }
 
     @Override
     public CloseableIterator<T> getStreamByQuery(Datastore datastore, int skip, int limit, @Nullable String query, @Nullable List<SortField> sortFields, @Nullable List<ProjectionField> projectionFields) {
@@ -612,6 +644,200 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
         return list;
     }
 
+    @Override
+    public List<Document> getSecuredAggregationDocuments(
+            @Nullable String realmId,
+            int skip,
+            int limit,
+            @NotNull String query,
+            @Nullable List<SortField> sortFields,
+            @Nullable List<ProjectionField> projectionFields) {
+        if (skip < 0 || limit < 0) {
+            throw new IllegalArgumentException("skip and limit cannot be negative for aggregation");
+        }
+        Objects.requireNonNull(query, "aggregation query cannot be null");
+        Datastore datastore = morphiaDataStoreWrapper.getDataStore(
+                realmId == null || realmId.isBlank() ? getSecurityContextRealmId() : realmId);
+        if (!(datastore instanceof MorphiaDatastore morphiaDatastore)) {
+            throw new IllegalStateException("Governed aggregation requires a MorphiaDatastore");
+        }
+
+        List<LogicalPlan.SortSpec.Field> plannerSort = sortFields == null ? null : sortFields.stream()
+                .map(field -> new LogicalPlan.SortSpec.Field(
+                        field.getFieldName(),
+                        field.getSortDirection() == SortField.SortDirection.DESC ? -1 : 1))
+                .toList();
+        PlannedQuery planned = MorphiaUtils.convertToPlannedQuery(
+                query, getPersistentClass(), limit, skip, plannerSort);
+        if (planned.getMode() != PlannerResult.Mode.AGGREGATION) {
+            throw new IllegalArgumentException("Query does not contain a valid expand(...) operation");
+        }
+
+        List<Document> pipeline = new ArrayList<>();
+        for (Bson stage : planned.getAggregation()) {
+            if (!(stage instanceof Document document)) {
+                throw new IllegalStateException("Aggregation compiler emitted an unsupported stage type: "
+                        + stage.getClass().getName());
+            }
+            if (!document.containsKey("$plannedExpandPaths")) {
+                pipeline.add(new Document(document));
+            }
+        }
+
+        MongoAggregationCompiler filterCompiler = new MongoAggregationCompiler(morphiaDatastore);
+        Document rootPolicyMatch = compilePolicyMatch(
+                filterCompiler,
+                securityFilterBuilder().buildSecuredFilters(new ArrayList<>(), getPersistentClass()));
+        if (rootPolicyMatch != null && !rootPolicyMatch.isEmpty()) {
+            pipeline.add(0, new Document("$match", rootPolicyMatch));
+        }
+
+        Map<String, AggregationAccessPolicy> lookupPolicies = resolveLookupPolicies(query, filterCompiler);
+        applyLookupPolicies(pipeline, lookupPolicies);
+        applyCallerProjection(pipeline, projectionFields);
+        appendExclusionProjection(pipeline, securityFilterBuilder().buildExcludedFieldPaths());
+
+        String rootCollection = morphiaDatastore.getMapper()
+                .getEntityModel(getPersistentClass()).collectionName();
+        return morphiaDatastore.getDatabase()
+                .getCollection(rootCollection)
+                .aggregate(new ArrayList<Bson>(pipeline), Document.class)
+                .into(new ArrayList<>());
+    }
+
+    private Document compilePolicyMatch(MongoAggregationCompiler compiler, List<Filter> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return null;
+        }
+        Filter combined = filters.size() == 1
+                ? filters.get(0)
+                : Filters.and(filters.toArray(new Filter[0]));
+        return compiler.compileMatch(combined);
+    }
+
+    private Map<String, AggregationAccessPolicy> resolveLookupPolicies(
+            String query, MongoAggregationCompiler compiler) {
+        com.e2eq.framework.model.persistent.morphia.planner.QueryPlanner planner =
+                new com.e2eq.framework.model.persistent.morphia.planner.QueryPlanner();
+        DefaultMetadataRegistry metadata = new DefaultMetadataRegistry();
+        Map<String, AggregationAccessPolicy> policies = new LinkedHashMap<>();
+        for (String path : planner.analyze(query).getExpandPaths()) {
+            JoinSpec join = metadata.resolveJoin(getPersistentClass(), path);
+            if (join.fromCollection == null || join.fromCollection.isBlank()
+                    || join.targetType == null
+                    || !UnversionedBaseModel.class.isAssignableFrom(join.targetType)) {
+                throw new SecurityException("Expand path '" + path
+                        + "' has no governable target model/collection");
+            }
+            @SuppressWarnings("unchecked")
+            Class<? extends UnversionedBaseModel> targetType =
+                    (Class<? extends UnversionedBaseModel>) join.targetType;
+            com.e2eq.framework.annotations.FunctionalMapping mapping =
+                    targetType.getAnnotation(com.e2eq.framework.annotations.FunctionalMapping.class);
+            if (mapping == null) {
+                throw new SecurityException("Expand target " + targetType.getName()
+                        + " must declare @FunctionalMapping for policy evaluation");
+            }
+            ResourceContext current = SecurityContext.getResourceContext()
+                    .orElseThrow(() -> new SecurityException(
+                            "Governed aggregation requires a ResourceContext"));
+            ResourceContext targetContext = new ResourceContext.Builder()
+                    .withRealm(current.getRealm())
+                    .withArea(mapping.area())
+                    .withFunctionalDomain(mapping.domain())
+                    .withAction(current.getAction())
+                    .withResourceId(current.getResourceId())
+                    .build();
+            AggregationAccessPolicy policy;
+            try (SecurityCallScope.Scope ignored = SecurityCallScope.openResourceOnly(targetContext)) {
+                Document targetMatch = compilePolicyMatch(compiler,
+                        securityFilterBuilder().buildSecuredFilters(new ArrayList<>(), targetType));
+                Set<String> targetExcluded = new LinkedHashSet<>(
+                        securityFilterBuilder().buildExcludedFieldPaths());
+                policy = new AggregationAccessPolicy(targetMatch, targetExcluded);
+            }
+            AggregationAccessPolicy previous = policies.putIfAbsent(join.fromCollection, policy);
+            if (previous != null && !previous.equals(policy)) {
+                throw new SecurityException("Conflicting policies resolved for expand collection "
+                        + join.fromCollection);
+            }
+        }
+        return policies;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void applyLookupPolicies(
+            List<Document> pipeline, Map<String, AggregationAccessPolicy> policies) {
+        for (Document stage : pipeline) {
+            if (!stage.containsKey("$lookup")) {
+                continue;
+            }
+            Document lookup = stage.get("$lookup", Document.class);
+            if (lookup == null) {
+                throw new SecurityException("Aggregation contains an invalid $lookup stage");
+            }
+            String from = lookup.getString("from");
+            AggregationAccessPolicy policy = policies.get(from);
+            if (from == null || "__unknown__".equals(from) || policy == null) {
+                throw new SecurityException("Aggregation lookup target is unresolved or unauthorized: " + from);
+            }
+            List<Document> lookupPipeline = new ArrayList<>();
+            Object existing = lookup.get("pipeline");
+            if (existing instanceof List<?> stages) {
+                for (Object nested : stages) {
+                    if (!(nested instanceof Document document)) {
+                        throw new SecurityException("Lookup pipeline contains an unsupported stage");
+                    }
+                    lookupPipeline.add(new Document(document));
+                }
+            }
+            if (policy.rowMatch() != null && !policy.rowMatch().isEmpty()) {
+                lookupPipeline.add(new Document("$match", policy.rowMatch()));
+            }
+            if (!policy.excludedFields().isEmpty()) {
+                lookupPipeline.add(exclusionProjection(policy.excludedFields()));
+            }
+            lookup.put("pipeline", lookupPipeline);
+        }
+    }
+
+    private void applyCallerProjection(List<Document> pipeline, List<ProjectionField> projectionFields) {
+        if (projectionFields == null || projectionFields.isEmpty()) {
+            return;
+        }
+        boolean includeMode = projectionFields.stream().anyMatch(field ->
+                field.getProjectionType() == ProjectionField.ProjectionType.INCLUDE);
+        Document projection = new Document();
+        for (ProjectionField field : projectionFields) {
+            if (includeMode && field.getProjectionType() == ProjectionField.ProjectionType.EXCLUDE
+                    && !"_id".equals(field.getFieldName())) {
+                throw new IllegalArgumentException(
+                        "Aggregation projection cannot mix includes with non-_id excludes");
+            }
+            projection.put(field.getFieldName(),
+                    field.getProjectionType() == ProjectionField.ProjectionType.INCLUDE ? 1 : 0);
+        }
+        if (includeMode && !projection.containsKey("_id")) {
+            projection.put("_id", 1);
+        }
+        pipeline.add(new Document("$project", projection));
+    }
+
+    private void appendExclusionProjection(List<Document> pipeline, Set<String> excludedFields) {
+        if (excludedFields != null && !excludedFields.isEmpty()) {
+            pipeline.add(exclusionProjection(excludedFields));
+        }
+    }
+
+    private Document exclusionProjection(Set<String> excludedFields) {
+        Document projection = new Document();
+        excludedFields.forEach(path -> projection.put(path, 0));
+        return new Document("$project", projection);
+    }
+
+    private record AggregationAccessPolicy(Document rowMatch, Set<String> excludedFields) {
+    }
+
     // Convenience method that uses the default datastore
     @Override
     public CloseableIterator<T> getStreamByQuery(int skip, int limit, @Nullable String query, @Nullable List<SortField> sortFields, @Nullable List<ProjectionField> projectionFields) {
@@ -695,10 +921,10 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
         filters.add(Filters.in("_id", ids));
 
-        FindOptions findOptions = new FindOptions();
+         FindOptions findOptions = buildFindOptions(0, -1, null, null);
 
         Filter[] filterArray = new Filter[filters.size()];
-        Query<T> query = morphiaDataStoreWrapper.getDataStore(getSecurityContextRealmId()).find(getPersistentClass())
+         Query<T> query = datastore.find(getPersistentClass())
                 .filter(filters.toArray(filterArray));
 
         List<T> list = query.iterator(findOptions).toList();
@@ -731,11 +957,11 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
         filters.add(Filters.in("refName", refNames));
 
-        FindOptions findOptions = new FindOptions();
-       String realm= getSecurityContextRealmId();
+         FindOptions findOptions = buildFindOptions(0, -1, null, null);
+        String realm = datastore.getDatabase().getName();
 
         Filter[] filterArray = new Filter[filters.size()];
-        Query<T> query = morphiaDataStoreWrapper.getDataStore(realm).find(getPersistentClass())
+         Query<T> query = datastore.find(getPersistentClass())
                 .filter(filters.toArray(filterArray));
 
         List<T> list = query.iterator(findOptions).toList();
@@ -880,6 +1106,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
    }
 
     public T save(@NotNull MorphiaSession session, @Valid T value) {
+        value = restorePolicyExcludedFields(session, value);
         if (value.getClass().getAnnotation(Stateful.class)!= null) {
            try {
               validateStateTransitions(session, value);
@@ -887,7 +1114,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
               throw new RuntimeException("State transition validation failed", e);
            }
         }
-       setDefaultValues(value);
+        setDefaultValues(value);
         value.validate();
         T saved = session.save(value);
         callPostPersistHooks(getSecurityContextRealmId(), saved);
@@ -907,6 +1134,9 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public List<T> save(@NotNull Datastore datastore, List<T> entities) {
+       entities = entities.stream()
+               .map(entity -> restorePolicyExcludedFields(datastore, entity))
+               .collect(Collectors.toCollection(ArrayList::new));
        entities.forEach(entity -> {
           if (entity.getClass().getAnnotation(Stateful.class)!= null) {
              try {
@@ -927,7 +1157,9 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public List<T> save(@NotNull MorphiaSession session, List<T> entities) {
-
+       entities = entities.stream()
+               .map(entity -> restorePolicyExcludedFields(session, entity))
+               .collect(Collectors.toCollection(ArrayList::new));
        entities.forEach(entity -> {
           if (entity.getClass().getAnnotation(Stateful.class)!= null) {
              try {
@@ -949,6 +1181,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public T save(@NotNull Datastore datastore, @Valid T value) {
+       value = restorePolicyExcludedFields(datastore, value);
        if (value.getClass().getAnnotation(Stateful.class)!= null) {
           try {
              validateStateTransitions(datastore, value);
@@ -956,7 +1189,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
              throw new RuntimeException("State transition validation failed", e);
           }
        }
-       setDefaultValues(value);
+        setDefaultValues(value);
        value.validate();
        T saved = datastore.save(value);
        callPostPersistHooks(getSecurityContextRealmId(), saved);
@@ -1251,6 +1484,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     public final long update(MorphiaSession session, @NotNull String id, @NotNull Pair<String, Object>... pairs) {
         List<UpdateOperator> updateOperators = new ArrayList<>();
         for (Pair<String, Object> pair : pairs) {
+            assertFieldUpdateAllowed(pair.getKey());
             // check that the pair key corresponds to a field in the persistent class that is an enum
             Field field = null;
             try {
@@ -1315,6 +1549,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
        T currentEntity = currentEntityOpt.get();
 
        for (Pair<String, Object> pair : pairs) {
+          assertFieldUpdateAllowed(pair.getKey());
           if (reservedFields.contains(pair.getKey())) {
              throw new IllegalArgumentException("Field:" + pair.getKey() + " is a reserved field and can't be updated");
           }
@@ -1402,6 +1637,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     public final long update(MorphiaSession session, @NotNull ObjectId id, @NotNull Pair<String, Object>... pairs) {
         List<UpdateOperator> updateOperators = new ArrayList<>();
         for (Pair<String, Object> pair : pairs) {
+           assertFieldUpdateAllowed(pair.getKey());
             // check that the pair key corresponds to a field in the persistent class that is an enum
             Field field = null;
             try {
@@ -1596,11 +1832,12 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
     }
 
    @SafeVarargs
-    private  List<UpdateOperator> buildValidatedUpdateOperators(@NotNull Pair<String, Object>... pairs) {
+     private  List<UpdateOperator> buildValidatedUpdateOperators(@NotNull Pair<String, Object>... pairs) {
         Objects.requireNonNull(pairs, "update pairs must not be null");
         List<UpdateOperator> updateOperators = new ArrayList<>();
         List<String> reservedFields = List.of("refName", "id", "version", "references", "auditInfo", "persistentEvents");
-        for (Pair<String, Object> pair : pairs) {
+         for (Pair<String, Object> pair : pairs) {
+             assertFieldUpdateAllowed(pair.getKey());
             if (reservedFields.contains(pair.getKey())) {
                 throw new IllegalArgumentException("Field:" + pair.getKey() + " is a reserved field and can't be updated");
             }
@@ -1646,19 +1883,29 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
      * must not be able to overwrite it on update. For each excluded path, the
      * stored document's current value is restored onto the incoming entity
      * before persisting (preserve-hidden-field semantics). Top-level and
-     * one-level-nested ("parent.child") paths are supported in v1.
+     * nested paths are supported. When a nested collection is excluded, the
+     * stored collection is preserved as a unit because element identity is not
+     * available at this generic boundary.
      */
-    protected T restorePolicyExcludedFields(Datastore datastore, T entity) {
-        java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
-        if (excluded.isEmpty() || entity.getId() == null) {
-            return entity;
-        }
-        T stored = datastore.find(getPersistentClass())
-                .filter(dev.morphia.query.filters.Filters.eq("_id", entity.getId()))
-                .first();
-        if (stored == null) {
-            return entity;
-        }
+     protected T restorePolicyExcludedFields(Datastore datastore, T entity) {
+         java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
+         if (excluded.isEmpty()) {
+             return entity;
+         }
+         if (entity.getId() == null) {
+             FieldPolicyEnforcer.assertUnset(entity, excluded);
+             return entity;
+         }
+         List<Filter> filters = securityFilterBuilder().buildSecuredFilters(
+                 new ArrayList<>(), getPersistentClass());
+         filters.add(dev.morphia.query.filters.Filters.eq("_id", entity.getId()));
+         T stored = datastore.find(getPersistentClass())
+                 .filter(filters.toArray(new Filter[0]))
+                 .first();
+         if (stored == null) {
+             throw new SecurityException(
+                     "Entity is not available in the caller's governed scope; update rejected");
+         }
         for (String path : excluded) {
             try {
                 com.e2eq.framework.model.securityrules.FieldPolicyEnforcer.copyPath(stored, entity, path);
@@ -1668,8 +1915,49 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
                     + getPersistentClass().getSimpleName() + "; failing closed.", e);
             }
         }
-        return entity;
-    }
+         return entity;
+     }
+
+     protected T restorePolicyExcludedFields(MorphiaSession session, T entity) {
+         java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
+         if (excluded.isEmpty()) {
+             return entity;
+         }
+         if (entity.getId() == null) {
+             FieldPolicyEnforcer.assertUnset(entity, excluded);
+             return entity;
+         }
+         List<Filter> filters = securityFilterBuilder().buildSecuredFilters(
+                 new ArrayList<>(), getPersistentClass());
+         filters.add(dev.morphia.query.filters.Filters.eq("_id", entity.getId()));
+         T stored = session.find(getPersistentClass())
+                 .filter(filters.toArray(new Filter[0]))
+                 .first();
+         if (stored == null) {
+             throw new SecurityException(
+                     "Entity is not available in the caller's governed scope; update rejected");
+         }
+         for (String path : excluded) {
+             try {
+                 com.e2eq.framework.model.securityrules.FieldPolicyEnforcer.copyPath(stored, entity, path);
+             } catch (ReflectiveOperationException e) {
+                 throw new RuntimeException(
+                         "Field-level policy could not restore excluded path '" + path + "' on "
+                                 + getPersistentClass().getSimpleName() + "; failing closed.", e);
+             }
+         }
+         return entity;
+     }
+
+     private void assertFieldUpdateAllowed(String requestedPath) {
+         java.util.Set<String> excluded = securityFilterBuilder().buildExcludedFieldPaths();
+         for (String excludedPath : excluded) {
+             if (pathsOverlap(requestedPath, excludedPath)) {
+                 throw new SecurityException(
+                         "Field '" + requestedPath + "' is protected by field-level policy");
+             }
+         }
+     }
 
     @Override
     public T merge(@NotNull T entity){
@@ -1678,6 +1966,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public T merge(Datastore datastore, @NotNull T entity) {
+       entity = restorePolicyExcludedFields(datastore, entity);
        if (entity.getClass().getAnnotation(Stateful.class) != null) {
           try {
              validateStateTransitions(datastore, entity);
@@ -1685,12 +1974,12 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
              throw new RuntimeException("State transition validation failed", e);
           }
        }
-        entity = restorePolicyExcludedFields(datastore, entity);
         return datastore.merge(entity);
     }
 
     @Override
     public T merge(MorphiaSession session, @NotNull T entity) {
+       entity = restorePolicyExcludedFields(session, entity);
        if (entity.getClass().getAnnotation(Stateful.class) != null) {
           try {
              validateStateTransitions(session, entity);
@@ -1698,7 +1987,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
              throw new RuntimeException("State transition validation failed", e);
           }
        }
-        return session.merge(entity);
+         return session.merge(entity);
     }
 
     @Override
@@ -1708,11 +1997,17 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
 
     @Override
     public List<T> merge(Datastore datastore, List<T> entities) {
-        return datastore.merge(entities);
+         entities = entities.stream()
+                 .map(entity -> restorePolicyExcludedFields(datastore, entity))
+                 .collect(Collectors.toCollection(ArrayList::new));
+         return datastore.merge(entities);
     }
 
     @Override
     public List<T> merge(MorphiaSession session, List<T> entities) {
+        entities = entities.stream()
+                .map(entity -> restorePolicyExcludedFields(session, entity))
+                .collect(Collectors.toCollection(ArrayList::new));
        entities.forEach(entity -> {
           if (entity.getClass().getAnnotation(Stateful.class) != null) {
              try {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaUtils.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaUtils.java
@@ -130,9 +130,10 @@ public class MorphiaUtils {
    public static Map<String, String> createStandardVariableMapFrom(PrincipalContext pcontext, ResourceContext rcontext) {
       Map<String, String> variableMap = new HashMap<>();
       variableMap.put("principalId", pcontext.getUserId());
-      variableMap.put("pAccountId", pcontext.getDataDomain().getAccountNum());
-      variableMap.put("pTenantId", pcontext.getDataDomain().getTenantId());
-      variableMap.put("systemTenantId", pcontext.getDataDomain().getTenantId()); // fallback for legacy rules
+       variableMap.put("pAccountId", pcontext.getDataDomain().getAccountNum());
+       variableMap.put("pTenantId", pcontext.getDataDomain().getTenantId());
+       variableMap.put("pDataSegment", String.valueOf(pcontext.getDataDomain().getDataSegment()));
+       variableMap.put("systemTenantId", pcontext.getDataDomain().getTenantId()); // fallback for legacy rules
       variableMap.put("ownerId", pcontext.getDataDomain().getOwnerId());
       variableMap.put("orgRefName", pcontext.getDataDomain().getOrgRefName());
       variableMap.put("resourceId", rcontext.getResourceId());

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListener.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListener.java
@@ -4,6 +4,7 @@ import com.e2eq.framework.grammar.BIAPIQueryBaseListener;
 import com.e2eq.framework.grammar.BIAPIQueryParser;
 
 import com.e2eq.framework.model.persistent.base.BaseModel;
+import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
 import dev.morphia.annotations.Reference;
 import dev.morphia.query.filters.Filter;
@@ -16,6 +17,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.text.StringSubstitutor;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityContext;
 import org.bson.types.ObjectId;
 
 
@@ -52,6 +54,124 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
     StringSubstitutor sub = null;
 
     Class<? extends UnversionedBaseModel> modelClass=null;
+
+    /**
+     * Resolve the complete data-domain boundary used by ontology relationship predicates.
+     * A tenant id alone is not sufficient because a realm may contain multiple org/account
+     * domains and business refNames are not guaranteed to be globally unique.
+     */
+    private DataDomain resolveOntologyDataDomain(String requestedTenantId) {
+        Optional<PrincipalContext> principalContext = SecurityContext.getPrincipalContext();
+        if (principalContext.isPresent()) {
+            DataDomain principalDataDomain = principalContext.get().getDataDomain();
+            if (principalDataDomain == null) {
+                throw new IllegalStateException(
+                    "Ontology relationship predicates require a principal DataDomain");
+            }
+            if (requestedTenantId != null && !requestedTenantId.isBlank()
+                && !Objects.equals(requestedTenantId, principalDataDomain.getTenantId())) {
+                throw new SecurityException(
+                    "Ontology relationship tenant does not match the authenticated principal DataDomain");
+            }
+            return principalDataDomain;
+        }
+
+        String tenantId = firstNonBlank(requestedTenantId, variable("pTenantId"), variable("tenantId"));
+        String orgRefName = firstNonBlank(variable("orgRefName"), variable("dcOrgRefName"));
+        String accountNum = firstNonBlank(variable("pAccountId"), variable("dcAccountId"));
+        String dataSegmentValue = firstNonBlank(variable("pDataSegment"), variable("dcDataSegment"));
+        if (tenantId == null || orgRefName == null || accountNum == null || dataSegmentValue == null) {
+            throw new IllegalStateException(
+                "Ontology relationship predicates require tenantId, orgRefName, accountId, and dataSegment");
+        }
+
+        final int dataSegment;
+        try {
+            dataSegment = Integer.parseInt(dataSegmentValue);
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException(
+                "Ontology relationship dataSegment must be an integer", e);
+        }
+
+        DataDomain dataDomain = new DataDomain();
+        dataDomain.setTenantId(tenantId);
+        dataDomain.setOrgRefName(orgRefName);
+        dataDomain.setAccountNum(accountNum);
+        dataDomain.setDataSegment(dataSegment);
+        String ownerId = variable("ownerId");
+        if (ownerId != null && !ownerId.isBlank()) {
+            dataDomain.setOwnerId(ownerId);
+        }
+        return dataDomain;
+    }
+
+    private String variable(String name) {
+        return variableMap == null ? null : variableMap.get(name);
+    }
+
+    private static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> ontologySrcIdsByDst(DataDomain dataDomain, String predicate, String dst) {
+        try {
+            var cdi = jakarta.enterprise.inject.spi.CDI.current();
+            if (cdi == null) {
+                throw new IllegalStateException("CDI is not available");
+            }
+            Class<?> edgeRepoClass = Class.forName("com.e2eq.ontology.repo.OntologyEdgeRepo");
+            var selection = cdi.select(edgeRepoClass);
+            if (selection.isUnsatisfied()) {
+                throw new IllegalStateException("OntologyEdgeRepo bean is not available");
+            }
+            Object edgeRepo = selection.get();
+            java.lang.reflect.Method method = edgeRepoClass.getMethod(
+                "srcIdsByDst", DataDomain.class, String.class, String.class);
+            Object result = method.invoke(edgeRepo, dataDomain, predicate, dst);
+            if (!(result instanceof Set<?>)) {
+                throw new IllegalStateException("OntologyEdgeRepo returned an invalid source-id result");
+            }
+            return (Set<String>) result;
+        } catch (ReflectiveOperationException | IllegalStateException e) {
+            throw new IllegalStateException(
+                "Unable to enforce ontology outgoing-edge predicate for DataDomain", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> ontologyDstIdsBySrc(DataDomain dataDomain, String predicate, String src) {
+        try {
+            var cdi = jakarta.enterprise.inject.spi.CDI.current();
+            if (cdi == null) {
+                throw new IllegalStateException("CDI is not available");
+            }
+            Class<?> edgeRepoClass = Class.forName("com.e2eq.ontology.repo.OntologyEdgeRepo");
+            var selection = cdi.select(edgeRepoClass);
+            if (selection.isUnsatisfied()) {
+                throw new IllegalStateException("OntologyEdgeRepo bean is not available");
+            }
+            Object edgeRepo = selection.get();
+            java.lang.reflect.Method method = edgeRepoClass.getMethod(
+                "dstIdsBySrc", DataDomain.class, String.class, String.class);
+            Object result = method.invoke(edgeRepo, dataDomain, predicate, src);
+            if (!(result instanceof Set<?>)) {
+                throw new IllegalStateException("OntologyEdgeRepo returned an invalid destination-id result");
+            }
+            return (Set<String>) result;
+        } catch (ReflectiveOperationException | IllegalStateException e) {
+            throw new IllegalStateException(
+                "Unable to enforce ontology incoming-edge predicate for DataDomain", e);
+        }
+    }
 
 
     public QueryToFilterListener(Map<String, String> variableMap, StringSubstitutor sub, Class<? extends UnversionedBaseModel> modelClass) {
@@ -1059,26 +1179,8 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
             }
         } catch (Throwable ignored) { /* if ontology not wired, continue with best-effort behavior */ }
 
-        Set<String> ids = Collections.emptySet();
-        if (tenantId != null && !tenantId.isBlank()) {
-            try {
-                var cdi = jakarta.enterprise.inject.spi.CDI.current();
-                if (cdi != null) {
-                    Class<?> edgeIface = Class.forName("com.e2eq.ontology.repo.OntologyEdgeRepo");
-                    var sel = cdi.select(edgeIface);
-                    Object store = sel.isUnsatisfied() ? null : sel.get();
-                    if (store != null) {
-                        java.lang.reflect.Method m = edgeIface.getMethod("srcIdsByDst", String.class, String.class, String.class);
-                        Object result = m.invoke(store, tenantId, predicate, dst);
-                        if (result instanceof java.util.Set) {
-                            ids = (Set<String>) result;
-                        }
-                    }
-                }
-            } catch (Throwable t) {
-                // ignore and fail closed below
-            }
-        }
+        DataDomain dataDomain = resolveOntologyDataDomain(tenantId);
+        Set<String> ids = ontologySrcIdsByDst(dataDomain, predicate, dst);
         if (ids == null || ids.isEmpty()) {
             filterStack.push(Filters.eq("_id", "__none__"));
         } else {
@@ -1155,26 +1257,8 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
             }
         } catch (Throwable ignored) { /* if ontology not wired, continue with best-effort behavior */ }
 
-        Set<String> ids = Collections.emptySet();
-        if (tenantId != null && !tenantId.isBlank()) {
-            try {
-                var cdi = jakarta.enterprise.inject.spi.CDI.current();
-                if (cdi != null) {
-                    Class<?> edgeIface = Class.forName("com.e2eq.ontology.repo.OntologyEdgeRepo");
-                    var sel = cdi.select(edgeIface);
-                    Object store = sel.isUnsatisfied() ? null : sel.get();
-                    if (store != null) {
-                        java.lang.reflect.Method m = edgeIface.getMethod("srcIdsByDst", String.class, String.class, String.class);
-                        Object result = m.invoke(store, tenantId, predicate, dst);
-                        if (result instanceof java.util.Set) {
-                            ids = (Set<String>) result;
-                        }
-                    }
-                }
-            } catch (Throwable t) {
-                // ignore and fail closed below
-            }
-        }
+        DataDomain dataDomain = resolveOntologyDataDomain(tenantId);
+        Set<String> ids = ontologySrcIdsByDst(dataDomain, predicate, dst);
         if (ids == null || ids.isEmpty()) {
             filterStack.push(Filters.eq("_id", "__none__"));
         } else {
@@ -1253,57 +1337,8 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
             }
         } catch (Throwable ignored) { /* if ontology not wired, continue with best-effort behavior */ }
 
-        Set<String> ids = Collections.emptySet();
-        if (tenantId != null && !tenantId.isBlank()) {
-            try {
-                var cdi = jakarta.enterprise.inject.spi.CDI.current();
-                if (cdi != null) {
-                    Class<?> edgeIface = Class.forName("com.e2eq.ontology.repo.OntologyEdgeRepo");
-                    var sel = cdi.select(edgeIface);
-                    Object store = sel.isUnsatisfied() ? null : sel.get();
-                    if (store != null) {
-                        // Use dstIdsBySrc to get destination IDs where src has edges
-                        java.lang.reflect.Method m = edgeIface.getMethod("dstIdsBySrc",
-                            com.e2eq.framework.model.persistent.base.DataDomain.class, String.class, String.class);
-
-                        // Build DataDomain from tenantId - use defaults for testing
-                        com.e2eq.framework.model.persistent.base.DataDomain dd =
-                            new com.e2eq.framework.model.persistent.base.DataDomain();
-                        dd.setTenantId(tenantId);
-                        // Try to get org and account from security context
-                        try {
-                            var secCtxOpt = com.e2eq.framework.model.securityrules.SecurityContext.getPrincipalContext();
-                            if (secCtxOpt.isPresent()) {
-                                var pctx = secCtxOpt.get();
-                                if (pctx.getDataDomain() != null) {
-                                    dd = pctx.getDataDomain();
-                                }
-                            }
-                        } catch (Throwable ignored2) { }
-                        // Set fallback values if not set
-                        if (dd.getOrgRefName() == null) dd.setOrgRefName("ontology");
-                        if (dd.getAccountNum() == null) dd.setAccountNum("0000000000");
-                        if (dd.getTenantId() == null) dd.setTenantId(tenantId);
-                        dd.setDataSegment(0);
-
-                        if (Log.isDebugEnabled()) {
-                            Log.debugf("hasIncomingEdge: calling dstIdsBySrc with dd=%s, predicate=%s, src=%s", dd, predicate, src);
-                        }
-                        Object result = m.invoke(store, dd, predicate, src);
-                        if (result instanceof java.util.Set) {
-                            ids = (Set<String>) result;
-                            if (Log.isDebugEnabled()) {
-                                Log.debugf("hasIncomingEdge: dstIdsBySrc returned %d IDs: %s", ids.size(), ids);
-                            }
-                        }
-                    }
-                }
-            } catch (Throwable t) {
-                if (Log.isDebugEnabled()) {
-                    Log.debugf(t, "hasIncomingEdge: Exception while querying edges");
-                }
-            }
-        }
+        DataDomain dataDomain = resolveOntologyDataDomain(tenantId);
+        Set<String> ids = ontologyDstIdsBySrc(dataDomain, predicate, src);
         if (ids == null || ids.isEmpty()) {
             filterStack.push(Filters.eq("_id", "__none__"));
         } else {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RealmTenantMembershipRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RealmTenantMembershipRepo.java
@@ -1,8 +1,19 @@
 package com.e2eq.framework.model.persistent.morphia;
 
 import com.e2eq.framework.model.security.RealmTenantMembership;
+import dev.morphia.query.filters.Filters;
 import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
 
 @ApplicationScoped
 public class RealmTenantMembershipRepo extends MorphiaRepo<RealmTenantMembership> {
+    public List<RealmTenantMembership> findByRealmRefNameWithIgnoreRules(String systemRealmId, String realmRefName) {
+        try (var cursor = morphiaDataStoreWrapper.getDataStore(systemRealmId)
+                .find(RealmTenantMembership.class)
+                .filter(Filters.eq("realmRefName", realmRefName))
+                .iterator()) {
+            return cursor.toList();
+        }
+    }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RepoSecurityFilterBuilder.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RepoSecurityFilterBuilder.java
@@ -43,6 +43,9 @@ final class RepoSecurityFilterBuilder {
      * context. Fail-closed on missing context exactly like row filters.
      */
     java.util.Set<String> buildExcludedFieldPaths() {
+        if (SecurityContext.isIgnoringRules()) {
+            return java.util.Set.of();
+        }
         if (SecurityContext.getResourceContext().isEmpty() || SecurityContext.getPrincipalContext().isEmpty()) {
             securityContextResolver.ensureSecurityContextFromIdentity();
         }
@@ -51,12 +54,9 @@ final class RepoSecurityFilterBuilder {
                     SecurityContext.getPrincipalContext().get(),
                     SecurityContext.getResourceContext().get());
         }
-        // Field exclusions are principal-relative: with no principal on the
-        // thread (system-internal/ignore-rules reads — e.g. the ontology edge
-        // store) there is nothing to exclude. Row-level security separately
-        // fails loud on the paths that REQUIRE a principal; this must not
-        // turn principal-less infrastructure reads into failures.
-        return java.util.Set.of();
+        throw new IllegalStateException(
+                "SecurityContext is not set in thread; cannot resolve field-level policy. "
+                        + "Use an explicit ignore-rules scope only for authorized internal reads.");
     }
 
     Filter[] getFilterArray(List<Filter> filters, Class<? extends UnversionedBaseModel> modelClass) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserRealmRoleRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserRealmRoleRepo.java
@@ -11,6 +11,15 @@ import java.util.Optional;
 @ApplicationScoped
 public class UserRealmRoleRepo extends MorphiaRepo<UserRealmRole> {
 
+    public List<UserRealmRole> findByRealmRefNameWithIgnoreRules(String realmRefName, String systemRealmId) {
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(systemRealmId);
+        try (var cursor = ds.find(UserRealmRole.class)
+                .filter(Filters.eq("realmRefName", realmRefName))
+                .iterator()) {
+            return cursor.toList();
+        }
+    }
+
     /**
      * Active per-realm roles for a user, bypassing security rules — used by
      * the unauthenticated login path exactly like CredentialRepo.findByUserId

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/compiler/mongo/MongoAggregationCompiler.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/compiler/mongo/MongoAggregationCompiler.java
@@ -2,11 +2,16 @@ package com.e2eq.framework.model.persistent.morphia.compiler.mongo;
 
 import com.e2eq.framework.model.persistent.morphia.metadata.JoinSpec;
 import com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan;
+import dev.morphia.MorphiaDatastore;
+import dev.morphia.query.filters.Filter;
+import dev.morphia.query.filters.LogicalFilter;
+import dev.morphia.query.filters.RegexFilter;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Mongo aggregation compiler (v1 incremental):
@@ -14,6 +19,16 @@ import java.util.List;
  * - Builds per-expand $lookup/$set/$project stages
  */
 public class MongoAggregationCompiler {
+
+    private final MorphiaDatastore datastore;
+
+    public MongoAggregationCompiler() {
+        this(null);
+    }
+
+    public MongoAggregationCompiler(MorphiaDatastore datastore) {
+        this.datastore = datastore;
+    }
 
     public List<Bson> compile(LogicalPlan plan) {
         List<Bson> pipeline = new ArrayList<>();
@@ -53,11 +68,15 @@ public class MongoAggregationCompiler {
             String path = e.path;
             String temp = tempAlias(path);
 
-            // Prefer JoinSpec if available
             JoinSpec j = e.join;
-            String from = (j != null && j.fromCollection != null && !j.fromCollection.isBlank()) ? j.fromCollection : "__unknown__";
-            String localIdExpr = (j != null && j.localIdExpr != null) ? j.localIdExpr : (stripArrayMarkers(path) + ".entityId");
-            String tenantField = (j != null) ? j.tenantField : null;
+            if (j == null || j.fromCollection == null || j.fromCollection.isBlank()
+                    || j.localIdExpr == null || j.localIdExpr.isBlank()) {
+                throw new IllegalArgumentException(
+                        "Expand path '" + path + "' has no complete join metadata; aggregation denied");
+            }
+            String from = j.fromCollection;
+            String localIdExpr = j.localIdExpr;
+            String tenantField = j.tenantField;
 
             Document letDoc = new Document(e.array ? "ids" : "id", "$" + localIdExpr);
             if (tenantField != null && !tenantField.isBlank()) {
@@ -132,48 +151,71 @@ public class MongoAggregationCompiler {
         return pipeline;
     }
 
-    // Minimal translator for common Morphia Filter operators to $match
-    private Document toMatch(dev.morphia.query.filters.Filter filter) {
+    /**
+     * Compiles a Morphia filter into a Mongo {@code $match} document.
+     * Unsupported filter shapes fail closed; they are never silently dropped.
+     */
+    public Document compileMatch(Filter filter) {
+        return toMatch(filter);
+    }
+
+    private Document toMatch(Filter filter) {
         if (filter == null) return null;
-        try {
-            String name = filter.getName();
-            String field = filter.getField();
-            Object value = filter.getValue();
-            if (name == null) return new Document();
-            // Equality can be emitted as direct field match for simplicity
-            switch (name) {
-                case "$eq":
-                    return new Document(field, value);
-                case "$ne":
-                    return new Document(field, new Document("$ne", value));
-                case "$gt":
-                    return new Document(field, new Document("$gt", value));
-                case "$gte":
-                    return new Document(field, new Document("$gte", value));
-                case "$lt":
-                    return new Document(field, new Document("$lt", value));
-                case "$lte":
-                    return new Document(field, new Document("$lte", value));
-                case "$in":
-                    return new Document(field, new Document("$in", value));
-                case "$nin":
-                    return new Document(field, new Document("$nin", value));
-                case "$exists":
-                    return new Document(field, new Document("$exists", value));
-                default:
-                    // Special handling for RegexFilter (Morphia)
-                    if (filter instanceof dev.morphia.query.filters.RegexFilter rf) {
-                        String f = rf.getField();
-                        Object v = rf.getValue();
-                        return new Document(f, new Document("$regex", v));
-                    }
-                    // Fallback: return empty to avoid emitting an invalid $match
-                    return new Document();
-            }
-        } catch (Throwable t) {
-            // Be conservative: on any unexpected shape, skip $match
-            return new Document();
+        String name = filter.getName();
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Morphia filter has no operator; aggregation denied");
         }
+        if (filter instanceof LogicalFilter logical) {
+            List<Document> children = logical.filters().stream().map(this::toMatch).toList();
+            if (children.isEmpty()) {
+                throw new IllegalArgumentException("Logical filter " + name + " has no operands");
+            }
+            return new Document(name, children);
+        }
+
+        String field = datastore == null ? filter.getField() : filter.path(datastore.getMapper());
+        if (field == null || field.isBlank()) {
+            throw new IllegalArgumentException("Morphia filter " + name + " has no field; aggregation denied");
+        }
+        if (filter instanceof RegexFilter regex) {
+            Pattern pattern = regex.pattern();
+            if (pattern == null) {
+                throw new IllegalArgumentException("Regex filter for " + field + " has no pattern");
+            }
+            Document expression = new Document("$regex", pattern.pattern());
+            String options = regexOptions(pattern.flags());
+            if (!options.isEmpty()) {
+                expression.append("$options", options);
+            }
+            return new Document(field, filter.isNot() ? new Document("$not", expression) : expression);
+        }
+
+        Object value = datastore == null ? filter.getValue() : filter.getValue(datastore);
+        Document expression;
+        switch (name) {
+            case "$eq":
+                if (!filter.isNot()) {
+                    return new Document(field, value);
+                }
+                expression = new Document("$eq", value);
+                break;
+            case "$ne", "$gt", "$gte", "$lt", "$lte", "$in", "$nin", "$exists", "$size", "$all":
+                expression = new Document(name, value);
+                break;
+            default:
+                throw new IllegalArgumentException(
+                    "Unsupported Morphia filter operator '" + name + "' for aggregation; denied");
+        }
+        return new Document(field, filter.isNot() ? new Document("$not", expression) : expression);
+    }
+
+    private String regexOptions(int flags) {
+        StringBuilder options = new StringBuilder();
+        if ((flags & Pattern.CASE_INSENSITIVE) != 0) options.append('i');
+        if ((flags & Pattern.MULTILINE) != 0) options.append('m');
+        if ((flags & Pattern.DOTALL) != 0) options.append('s');
+        if ((flags & Pattern.COMMENTS) != 0) options.append('x');
+        return options.toString();
     }
 
     private static String tempAlias(String path) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/PermissionRuleInterceptor.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/PermissionRuleInterceptor.java
@@ -6,9 +6,7 @@ import dev.morphia.Datastore;
 import dev.morphia.EntityListener;
 import dev.morphia.annotations.PrePersist;
 import io.quarkus.logging.Log;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.bson.Document;
-import org.jboss.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -19,9 +17,6 @@ public class PermissionRuleInterceptor implements EntityListener {
 
    @Inject
    RuleContext ruleContext;
-
-   @ConfigProperty(name = "quantum.test.seeding", defaultValue = "false")
-   boolean testSeedingBypass;
 
    @Override
    public boolean hasAnnotation(Class type) {
@@ -36,13 +31,7 @@ public class PermissionRuleInterceptor implements EntityListener {
       // Check that we have the permission to write
       // should do the permission check here.
 
-      // Test-only bypass to allow seed import without full permission wiring
-      if (testSeedingBypass) {
-         if (Log.isDebugEnabled()) Log.debugf("[PermissionRuleInterceptor] test seeding bypass enabled; skipping check for %s", entity.getClass().getSimpleName());
-         return;
-      }
-
-      if (SecurityContext.isIgnoringRules()) {
+       if (SecurityContext.isIgnoringRules()) {
          if (Log.isDebugEnabled()) {
             Log.debugf("[PermissionRuleInterceptor] ignore-rules mode enabled; skipping check for %s", entity.getClass().getSimpleName());
          }
@@ -50,43 +39,37 @@ public class PermissionRuleInterceptor implements EntityListener {
       }
 
       if (SecurityContext.getResourceContext().isPresent()) {
-         // Bypass when a test seeder marks the operation explicitly as a seed write
-         ResourceContext rc = SecurityContext.getResourceContext().get();
-         if (rc.getAction() != null && rc.getAction().equalsIgnoreCase("seed")) {
-            if (Log.isDebugEnabled()) Log.debugf("[PermissionRuleInterceptor] bypass for action=seed for fd:%s, id:%s", rc.getFunctionalDomain(), rc.getResourceId());
-            return;
-         }
-         if (!(SecurityContext.getResourceContext().get().getAction().equalsIgnoreCase("save") ||
-                 SecurityContext.getResourceContext().get().getAction().equalsIgnoreCase("update") ||
-                 SecurityContext.getResourceContext().get().getAction().equalsIgnoreCase("delete") ||
-                  SecurityContext.getResourceContext().get().getAction().equalsIgnoreCase("write") ||
-                 SecurityContext.getResourceContext().get().getAction().equals("*"))) {
-            if (Log.isEnabled(Logger.Level.WARN))
-               //  throw new RuntimeException("Configuration error, post persist called but action expected to be save or update and is:" + SecurityContext.getResourceContext().get().getAction());
-               Log.debugf("pre persist called but action expected to be save or update and is:%s" , SecurityContext.getResourceContext().get().getAction());
-
-         }
-         doCheck();
-      } else {
-         Log.warnf("No Resource Context found there for no permission check executed for entity:%s" , entity.getClass().getName() + " Document:" + document.toJson());
-      }
+          ResourceContext rc = SecurityContext.getResourceContext().get();
+          String action = rc.getAction();
+           if (action == null || !(action.equalsIgnoreCase("create")
+                   || action.equalsIgnoreCase("save")
+                   || action.equalsIgnoreCase("update")
+                   || action.equalsIgnoreCase("delete")
+                   || action.equalsIgnoreCase("apply")
+                   || action.equalsIgnoreCase("write")
+                  || action.equals("*"))) {
+             throw new SecurityException("Persistence callback requires an explicit write action; received: " + action);
+          }
+          doCheck();
+       } else {
+          throw new SecurityException("Persistence callback has no ResourceContext for entity "
+                  + entity.getClass().getName() + "; use SecurityCallScope for privileged internal writes");
+       }
    }
 
    void doCheck() {
       Optional<PrincipalContext> opPrincipalContext = SecurityContext.getPrincipalContext();
       Optional<ResourceContext> opResourceContext = SecurityContext.getResourceContext();
-      if (opPrincipalContext.isPresent())
-      {
-         if (opResourceContext.isPresent()) {
-            PrincipalContext pContext = opPrincipalContext.get();
-            ResourceContext rContext = opResourceContext.get();
-            SecurityCheckResponse response = ruleContext.checkRules(pContext, rContext);
-            if (!response.getFinalEffect().equals(RuleEffect.ALLOW)) {
-               Log.error(response.toString());
-               throw new SecurityCheckException(response);
-            }
-         }
-      }
+       if (opPrincipalContext.isEmpty() || opResourceContext.isEmpty()) {
+          throw new SecurityException("Permission evaluation requires explicit principal and resource contexts");
+       }
+       PrincipalContext pContext = opPrincipalContext.get();
+       ResourceContext rContext = opResourceContext.get();
+       SecurityCheckResponse response = ruleContext.checkRules(pContext, rContext);
+       if (!response.getFinalEffect().equals(RuleEffect.ALLOW)) {
+          Log.error(response.toString());
+          throw new SecurityCheckException(response);
+       }
    }
 
   /* @Override

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/metadata/DefaultMetadataRegistry.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/metadata/DefaultMetadataRegistry.java
@@ -77,32 +77,44 @@ public class DefaultMetadataRegistry implements MetadataRegistry {
         }
         String localIdExpr = dottedPath + ".entityId"; // convention for EntityReference
         // Attempt to resolve collection from @ReferenceTarget on the final field
-        String fromCollection = resolveCollectionFromAnnotation(rootType, dottedPath);
-        return new JoinSpec(fromCollection, /*remoteIdField*/ "_id", localIdExpr, /*tenantField*/ "dataDomain.tenantId", rp.isArray);
+        com.e2eq.framework.model.persistent.base.ReferenceTarget referenceTarget =
+                resolveReferenceTarget(rootType, dottedPath);
+        if (referenceTarget == null || referenceTarget.target() == null
+                || referenceTarget.target() == void.class) {
+            throw new QueryMetadataException("expand path '" + dottedPath
+                    + "' must declare @ReferenceTarget(target=...) for governed expansion");
+        }
+        String fromCollection = resolveCollection(referenceTarget);
+        return new JoinSpec(fromCollection, /*remoteIdField*/ "_id", localIdExpr,
+                /*tenantField*/ "dataDomain.tenantId", rp.isArray, referenceTarget.target());
     }
 
-    private String resolveCollectionFromAnnotation(Class<? extends UnversionedBaseModel> rootType, String dottedPath) {
+    private com.e2eq.framework.model.persistent.base.ReferenceTarget resolveReferenceTarget(
+            Class<? extends UnversionedBaseModel> rootType, String dottedPath) {
         try {
             Field f = findFieldAlongPath(rootType, dottedPath);
             if (f == null) return null;
-            var ann = f.getAnnotation(com.e2eq.framework.model.persistent.base.ReferenceTarget.class);
-            if (ann == null) return null;
-            String collectionValue = ann.collection();
-            if (collectionValue != null && !collectionValue.isBlank()) {
-                return collectionValue;
-            }
-            Class<?> target = ann.target();
-            if (target == null || target == void.class) return null;
-            // Check Morphia @Entity value
-            dev.morphia.annotations.Entity e = target.getAnnotation(dev.morphia.annotations.Entity.class);
-            if (e != null && e.value() != null && !e.value().isBlank()) {
-                return e.value();
-            }
-            String simpleName = target.getSimpleName();
-            return (simpleName != null && !simpleName.isBlank()) ? simpleName : null;
+            return f.getAnnotation(com.e2eq.framework.model.persistent.base.ReferenceTarget.class);
         } catch (Exception ex) {
-            return null;
+            throw new QueryMetadataException("Failed to resolve @ReferenceTarget for '" + dottedPath + "'", ex);
         }
+    }
+
+    private String resolveCollection(com.e2eq.framework.model.persistent.base.ReferenceTarget ann) {
+        String collectionValue = ann.collection();
+        if (collectionValue != null && !collectionValue.isBlank()) {
+            return collectionValue;
+        }
+        Class<?> target = ann.target();
+        dev.morphia.annotations.Entity e = target.getAnnotation(dev.morphia.annotations.Entity.class);
+        if (e != null && e.value() != null && !e.value().isBlank()) {
+            return e.value();
+        }
+        String simpleName = target.getSimpleName();
+        if (simpleName == null || simpleName.isBlank()) {
+            throw new QueryMetadataException("Reference target has no resolvable collection name: " + target);
+        }
+        return simpleName;
     }
 
     private Field findFieldAlongPath(Class<?> type, String dottedPath) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/metadata/JoinSpec.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/metadata/JoinSpec.java
@@ -9,12 +9,19 @@ public class JoinSpec {
     public final String localIdExpr;
     public final String tenantField;
     public final boolean localIsArray;
+    public final Class<?> targetType;
 
     public JoinSpec(String fromCollection, String remoteIdField, String localIdExpr, String tenantField, boolean localIsArray) {
+        this(fromCollection, remoteIdField, localIdExpr, tenantField, localIsArray, null);
+    }
+
+    public JoinSpec(String fromCollection, String remoteIdField, String localIdExpr,
+                    String tenantField, boolean localIsArray, Class<?> targetType) {
         this.fromCollection = fromCollection;
         this.remoteIdField = remoteIdField;
         this.localIdExpr = localIdExpr;
         this.tenantField = tenantField;
         this.localIsArray = localIsArray;
+        this.targetType = targetType;
     }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/planner/QueryPlanner.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/planner/QueryPlanner.java
@@ -199,16 +199,9 @@ public class QueryPlanner {
         Filter rootFilter = null;
         String filterOnly = stripExpandAndProjection(query);
         if (filterOnly != null && !filterOnly.isBlank()) {
-            try {
-                rootFilter = (variableMap != null && !variableMap.isEmpty())
-                        ? MorphiaUtils.convertToFilter(filterOnly, variableMap, null, modelClass)
-                        : MorphiaUtils.convertToFilter(filterOnly, modelClass);
-            } catch (Exception ex) {
-                // If filter parsing fails, proceed without a root $match to avoid breaking behavior
-                if (Log.isDebugEnabled()) {
-                    Log.debugf("Root filter parse failed after stripping expansions/projection: %s", ex.getMessage());
-                }
-            }
+            rootFilter = (variableMap != null && !variableMap.isEmpty())
+                    ? MorphiaUtils.convertToFilter(filterOnly, variableMap, null, modelClass)
+                    : MorphiaUtils.convertToFilter(filterOnly, modelClass);
         }
         LogicalPlan plan = new LogicalPlan(modelClass, rootProj, expands, sort, page, rootFilter);
         MongoAggregationCompiler compiler = new MongoAggregationCompiler();
@@ -224,11 +217,8 @@ public class QueryPlanner {
         try {
             return md.resolveJoin(modelClass, path);
         } catch (RuntimeException ex) {
-            // Keep planning resilient in v1: log at debug and return null so compiler can fallback to placeholders
-            if (Log.isDebugEnabled()) {
-                Log.debugf("resolveJoin failed for path %s on %s: %s", path, modelClass.getName(), ex.getMessage());
-            }
-            return null;
+            throw new IllegalArgumentException(
+                "Cannot resolve governed expand path '" + path + "' on " + modelClass.getName(), ex);
         }
     }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/plugins/BaseAuthProvider.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/plugins/BaseAuthProvider.java
@@ -17,7 +17,7 @@ public class BaseAuthProvider implements UserManagementBase {
    CredentialRepo credentialRepo;
 
    @Inject
-   SecurityUtils securityUtils;
+   protected SecurityUtils securityUtils;
 
 
    @Override

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
@@ -193,6 +193,12 @@ public class RuleContext {
                 continue;
             }
             Rule rule = result.getRule();
+            // Field exclusions are a restriction attached to an ALLOW grant. A matched DENY
+            // rule must never contribute projection metadata to a separately winning ALLOW
+            // decision; doing so would make the effective field contract depend on losing rules.
+            if (rule.getEffect() != RuleEffect.ALLOW) {
+                continue;
+            }
             if (rule.getExcludedFields() == null || rule.getExcludedFields().isEmpty()) {
                 continue;
             }

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepoSortCollationTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepoSortCollationTest.java
@@ -2,6 +2,7 @@ package com.e2eq.framework.model.persistent.morphia;
 
 import com.e2eq.framework.model.persistent.base.SortField;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.CollationStrength;
 import dev.morphia.query.FindOptions;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -41,12 +43,14 @@ class MorphiaRepoSortCollationTest {
      */
     static class TestRepo extends MorphiaRepo<SortCollationTestModel> {
         TestRepo(String locale, int strength) {
-            this.sortCollationLocale = locale;
+            this.sortCollationLocale = Optional.ofNullable(locale);
             this.sortCollationStrength = strength;
         }
 
         FindOptions callBuildFindOptions(List<SortField> sortFields) {
-            return buildFindOptions(0, 0, sortFields, null);
+            try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+                return buildFindOptions(0, 0, sortFields, null);
+            }
         }
     }
 
@@ -64,7 +68,9 @@ class MorphiaRepoSortCollationTest {
         }
 
         FindOptions callBuildFindOptions(List<SortField> sortFields) {
-            return buildFindOptions(0, 0, sortFields, null);
+            try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+                return buildFindOptions(0, 0, sortFields, null);
+            }
         }
     }
 

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/PlannerDecisionTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/PlannerDecisionTest.java
@@ -1,8 +1,11 @@
 package com.e2eq.framework.model.persistent.morphia;
 
+import com.e2eq.framework.model.persistent.base.EntityReference;
+import com.e2eq.framework.model.persistent.base.ReferenceTarget;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
 import com.e2eq.framework.model.persistent.morphia.planner.PlannedQuery;
 import com.e2eq.framework.model.persistent.morphia.planner.PlannerResult;
+import dev.morphia.annotations.Entity;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
@@ -13,7 +16,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class PlannerDecisionTest {
 
+    @Entity("dummyCustomer")
+    public static class DummyCustomer extends UnversionedBaseModel {
+    }
+
     public static class DummyModel extends UnversionedBaseModel {
+        @ReferenceTarget(target = DummyCustomer.class)
+        EntityReference customer;
+
         @Override
         public String bmFunctionalArea() { return "test-area"; }
         @Override
@@ -35,8 +45,8 @@ public class PlannerDecisionTest {
         PlannedQuery planned = MorphiaUtils.convertToPlannedQuery(q, DummyModel.class);
         assertEquals(PlannerResult.Mode.AGGREGATION, planned.getMode());
         List<Bson> pipeline = planned.getAggregation();
-        assertFalse(pipeline.isEmpty(), "expected a placeholder pipeline");
-        // The first stage is a marker Document with planned paths (stub for now)
+        assertFalse(pipeline.isEmpty(), "expected a governed aggregation pipeline");
+        // The first stage records the paths resolved into concrete join metadata.
         assertTrue(pipeline.get(0) instanceof Document);
         Document d = (Document) pipeline.get(0);
         assertTrue(d.containsKey("$plannedExpandPaths"));

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/RepoSecurityFilterBuilderFieldPolicyTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/RepoSecurityFilterBuilderFieldPolicyTest.java
@@ -1,0 +1,37 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RepoSecurityFilterBuilderFieldPolicyTest {
+
+    @AfterEach
+    void clearSecurityState() {
+        SecurityContext.clear();
+        while (SecurityContext.isIgnoringRules()) {
+            SecurityContext.exitIgnoreRulesMode();
+        }
+    }
+
+    @Test
+    void missingPrincipalContextFailsClosed() {
+        RepoSecurityContextResolver resolver =
+                new RepoSecurityContextResolver(null, null, null, null, "test-realm");
+        RepoSecurityFilterBuilder builder = new RepoSecurityFilterBuilder(resolver, null);
+
+        assertThrows(IllegalStateException.class, builder::buildExcludedFieldPaths);
+    }
+
+    @Test
+    void explicitIgnoreRulesScopeBypassesFieldProjection() {
+        RepoSecurityFilterBuilder builder = new RepoSecurityFilterBuilder(null, null);
+
+        SecurityContext.enterIgnoreRulesMode();
+
+        assertTrue(builder.buildExcludedFieldPaths().isEmpty());
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/compiler/mongo/MongoAggregationCompilerTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/compiler/mongo/MongoAggregationCompilerTest.java
@@ -3,11 +3,13 @@ package com.e2eq.framework.model.persistent.morphia.compiler.mongo;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
 import com.e2eq.framework.model.persistent.morphia.metadata.JoinSpec;
 import com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan;
+import dev.morphia.query.filters.Filters;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -43,5 +45,49 @@ public class MongoAggregationCompilerTest {
         // Should drop the temp alias with $project
         boolean hasProject = pipeline.stream().anyMatch(b -> b instanceof Document && ((Document) b).containsKey("$project"));
         assertTrue(hasProject, "Expected a $project cleanup stage");
+    }
+
+    @Test
+    void compileMatchPreservesLogicalPolicyFilters() {
+        MongoAggregationCompiler compiler = new MongoAggregationCompiler();
+
+        Document match = compiler.compileMatch(Filters.and(
+                Filters.eq("status", "ACTIVE"),
+                Filters.in("dataDomain.tenantId", List.of("TENANT-A", "TENANT-B"))));
+
+        List<?> clauses = match.getList("$and", Object.class);
+        assertEquals(2, clauses.size());
+        assertEquals("ACTIVE", ((Document) clauses.get(0)).getString("status"));
+        assertEquals(List.of("TENANT-A", "TENANT-B"),
+                ((Document) ((Document) clauses.get(1)).get("dataDomain.tenantId")).get("$in"));
+    }
+
+    @Test
+    void compileMatchPreservesRegexFlags() {
+        MongoAggregationCompiler compiler = new MongoAggregationCompiler();
+
+        Document match = compiler.compileMatch(
+                Filters.regex("displayName", Pattern.compile("century", Pattern.CASE_INSENSITIVE)));
+
+        Document expression = (Document) match.get("displayName");
+        assertEquals("century", expression.getString("$regex"));
+        assertEquals("i", expression.getString("$options"));
+    }
+
+    @Test
+    void unsupportedPolicyFilterFailsClosed() {
+        MongoAggregationCompiler compiler = new MongoAggregationCompiler();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> compiler.compileMatch(Filters.mod("score", 5, 0)));
+    }
+
+    @Test
+    void expandWithoutJoinMetadataFailsClosed() {
+        LogicalPlan.Expand expansion = new LogicalPlan.Expand("customer", 1, null, false, null);
+        LogicalPlan plan = new LogicalPlan(Dummy.class, null, List.of(expansion), null, null);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new MongoAggregationCompiler().compile(plan));
     }
 }

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/PermissionRuleInterceptorTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/interceptors/PermissionRuleInterceptorTest.java
@@ -1,0 +1,63 @@
+package com.e2eq.framework.model.persistent.morphia.interceptors;
+
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
+import com.e2eq.framework.model.securityrules.SecurityContext;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PermissionRuleInterceptorTest {
+
+    private final PermissionRuleInterceptor interceptor = new PermissionRuleInterceptor();
+
+    @BeforeEach
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContext.clear();
+    }
+
+    @Test
+    void contextlessPersistenceFailsClosed() {
+        assertThrows(SecurityException.class,
+                () -> interceptor.prePersist(new Object(), new Document(), null));
+    }
+
+    @Test
+    void explicitIgnoreRulesScopeAllowsPrivilegedPersistence() {
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
+            assertDoesNotThrow(() -> interceptor.prePersist(new Object(), new Document(), null));
+        }
+    }
+
+    @Test
+    void seedActionIsNotAnImplicitAuthorizationBypass() {
+        ResourceContext seed = resource("seed");
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openResourceOnly(seed)) {
+            assertThrows(SecurityException.class,
+                    () -> interceptor.prePersist(new Object(), new Document(), null));
+        }
+    }
+
+    @Test
+    void writeActionWithoutPrincipalFailsClosed() {
+        ResourceContext write = resource("write");
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openResourceOnly(write)) {
+            assertThrows(SecurityException.class,
+                    () -> interceptor.prePersist(new Object(), new Document(), null));
+        }
+    }
+
+    private ResourceContext resource(String action) {
+        return new ResourceContext.Builder()
+                .withRealm("test-realm")
+                .withArea("test")
+                .withFunctionalDomain("persistence")
+                .withAction(action)
+                .build();
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/securityrules/RuleContextFieldPolicyTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/securityrules/RuleContextFieldPolicyTest.java
@@ -1,0 +1,59 @@
+package com.e2eq.framework.securityrules;
+
+import com.e2eq.framework.model.security.Rule;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.RuleDeterminedEffect;
+import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.RuleResult;
+import com.e2eq.framework.model.securityrules.SecurityCheckResponse;
+import com.e2eq.framework.security.runtime.RuleContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RuleContextFieldPolicyTest {
+
+    @Test
+    void exclusions_are_collected_only_from_applicable_allow_rules() {
+        PrincipalContext principal = new PrincipalContext.Builder().withUserId("field-policy-user").build();
+        ResourceContext resource = new ResourceContext.Builder()
+                .withArea("test")
+                .withFunctionalDomain("record")
+                .withAction("view")
+                .build();
+
+        Rule allow = new Rule.Builder()
+                .withName("allow-with-exclusion")
+                .withEffect(RuleEffect.ALLOW)
+                .withExcludedFields(List.of(" description ", "nested.secret"))
+                .build();
+        Rule deny = new Rule.Builder()
+                .withName("losing-deny-with-exclusion")
+                .withEffect(RuleEffect.DENY)
+                .withExcludedFields(List.of("must.not.apply"))
+                .build();
+
+        RuleResult allowResult = new RuleResult(allow);
+        allowResult.setDeterminedEffect(RuleDeterminedEffect.ALLOW);
+        RuleResult denyResult = new RuleResult(deny);
+        denyResult.setDeterminedEffect(RuleDeterminedEffect.DENY);
+
+        SecurityCheckResponse response = new SecurityCheckResponse(principal, resource);
+        response.setFinalEffect(RuleEffect.ALLOW);
+        response.setMatchedRuleResults(List.of(allowResult, denyResult));
+
+        RuleContext ruleContext = new RuleContext() {
+            @Override
+            public SecurityCheckResponse checkRules(PrincipalContext ignoredPrincipal, ResourceContext ignoredResource) {
+                return response;
+            }
+        };
+
+        assertEquals(Set.of("description", "nested.secret"),
+                ruleContext.getExcludedFieldPaths(principal, resource));
+    }
+}

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeRepo.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeRepo.java
@@ -108,24 +108,6 @@ public class OntologyEdgeRepo extends MorphiaRepo<OntologyEdge> {
     }
 
     /**
-     * Resolves the datastore realm from a bare tenantId (no DataDomain available).
-     *
-     * Mirrors {@link #resolveRealmId(DataDomain)}: the active security-context realm is
-     * authoritative when a principal has been established, otherwise fall back to the
-     * historical tenantId-to-realm conversion. Used by the grammar hasEdge(...) path,
-     * which only carries a tenantId (from pTenantId) and cannot supply org/account.
-     */
-    private String resolveRealmId(String tenantId) {
-        if (SecurityContext.getPrincipalContext().isPresent()) {
-            String realm = SecurityContext.getPrincipalContext().get().getDefaultRealm();
-            if (realm != null && !realm.isBlank()) {
-                return realm;
-            }
-        }
-        return tenantIdToRealmId(tenantId);
-    }
-
-    /**
      * Validates that the DataDomain has all required fields for scoping.
      * @throws IllegalArgumentException if any required field is missing
      */
@@ -794,25 +776,25 @@ public class OntologyEdgeRepo extends MorphiaRepo<OntologyEdge> {
     }
 
     /**
-     * Tenant/realm-scoped source lookup for the grammar {@code hasEdge(predicate, dst)} /
-     * {@code hasOutgoingEdge(predicate, dst)} path.
+     * Compatibility overload for callers that previously supplied only a tenant id.
+     * Relationship reads still require the authenticated principal's complete DataDomain;
+     * tenant-only edge scans are unsafe when org/account domains share ids or refNames.
      *
-     * The query-rewrite listener (QueryToFilterListener) only carries a tenantId — it has no
-     * full DataDomain, so it cannot scope by org/account. This resolves the realm from the
-     * tenant and matches edges by predicate + destination within that tenant realm, returning
-     * the source ids. Org/account isolation is still enforced by the outer collection query
-     * that consumes the resulting id/refName filter, so this does not widen the caller's scope.
+     * @deprecated pass the complete {@link DataDomain} to {@link #srcIdsByDst(DataDomain, String, String)}
      */
+    @Deprecated(forRemoval = true)
     public Set<String> srcIdsByDst(String tenantId, String p, String dst) {
-        Set<String> ids = new HashSet<>();
         if (tenantId == null || tenantId.isBlank()) {
-            return ids;
+            throw new IllegalArgumentException("tenantId must be provided");
         }
-        Query<OntologyEdge> q = ds(resolveRealmId(tenantId)).find(OntologyEdge.class);
-        for (OntologyEdge e : q.filter(Filters.eq("p", p)).filter(Filters.eq("dst", dst))) {
-            ids.add(e.getSrc());
+        DataDomain principalDataDomain = SecurityContext.getPrincipalDataDomain()
+            .orElseThrow(() -> new IllegalStateException(
+                "A principal DataDomain is required for ontology relationship reads"));
+        if (!tenantId.equals(principalDataDomain.getTenantId())) {
+            throw new SecurityException(
+                "Requested ontology tenant does not match the principal DataDomain");
         }
-        return ids;
+        return srcIdsByDst(principalDataDomain, p, dst);
     }
 
     /**

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
@@ -83,7 +83,11 @@ public class OntologyEdgeIngestQuarantineTest {
                 .withScope("AUTHENTICATED")
                 .build();
         SecurityContext.setPrincipalContext(principal);
-        SecurityContext.setResourceContext(ResourceContext.DEFAULT_ANONYMOUS_CONTEXT);
+        SecurityContext.setResourceContext(new ResourceContext.Builder()
+                .withRealm(REALM)
+                .withAction("WRITE")
+                .withDataDomain(principalDD)
+                .build());
 
         // Clean both collections in this realm.
         edgeRepo.deleteAll(REALM);

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeRepoTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeRepoTest.java
@@ -4,6 +4,7 @@ import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.security.DomainContext;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.ontology.exceptions.CardinalityViolationException;
 import com.e2eq.ontology.repo.OntologyEdgeRepo;
@@ -31,14 +32,22 @@ public class OntologyEdgeRepoTest {
     
     private DataDomain testDataDomain;
     private DataDomain testDataDomainOrgB;
+    private SecurityCallScope.Scope privilegedRepoScope;
 
     @AfterEach
     void clearSecurityContext() {
+        if (privilegedRepoScope != null) {
+            privilegedRepoScope.close();
+            privilegedRepoScope = null;
+        }
         SecurityContext.clear();
     }
 
     @BeforeEach
     void clean() {
+        // These tests exercise the repository contract directly, outside an authenticated
+        // resource request. Declare that privileged test boundary explicitly.
+        privilegedRepoScope = SecurityCallScope.openIgnoringRules();
         edgeRepo.deleteAll("types-test");
         // Create test DataDomains for isolation testing
         testDataDomain = new DataDomain();

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyMigrationServiceTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyMigrationServiceTest.java
@@ -1,6 +1,7 @@
 package com.e2eq.ontology.mongo;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.ontology.core.OntologyRegistry.*;
 import com.e2eq.ontology.model.OntologyMeta;
 import com.e2eq.ontology.model.OntologyTBox;
@@ -12,6 +13,7 @@ import com.e2eq.ontology.service.OntologyMigrationService;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
@@ -42,9 +44,11 @@ public class OntologyMigrationServiceTest {
 
     private DataDomain tenant1;
     private DataDomain tenant2;
+    private SecurityCallScope.Scope ignoredRulesScope;
 
     @BeforeEach
     void setup() {
+        ignoredRulesScope = SecurityCallScope.openIgnoringRules();
         // Clean all repositories
         globalMetaRepo.deleteAll();
         globalTBoxRepo.deleteAll();
@@ -53,6 +57,13 @@ public class OntologyMigrationServiceTest {
 
         tenant1 = new DataDomain("org1", "acc1", "tenant1", 0, "user1");
         tenant2 = new DataDomain("org1", "acc1", "tenant2", 0, "user2");
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (ignoredRulesScope != null) {
+            ignoredRulesScope.close();
+        }
     }
 
     @Test

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/TenantOntologyRegistryProviderTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/TenantOntologyRegistryProviderTest.java
@@ -1,6 +1,7 @@
 package com.e2eq.ontology.mongo;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.ontology.core.OntologyRegistry;
 import com.e2eq.ontology.core.OntologyRegistry.*;
 import com.e2eq.ontology.model.TenantOntologyTBox;
@@ -9,6 +10,7 @@ import com.e2eq.ontology.runtime.TenantOntologyRegistryProvider;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -29,14 +31,23 @@ public class TenantOntologyRegistryProviderTest {
 
     private DataDomain tenant1;
     private DataDomain tenant2;
+    private SecurityCallScope.Scope ignoredRulesScope;
 
     @BeforeEach
     void setup() {
+        ignoredRulesScope = SecurityCallScope.openIgnoringRules();
         tboxRepo.deleteAll();
         provider.clearCache();
         
         tenant1 = new DataDomain("org1", "acc1", "tenant1", 0, "user1");
         tenant2 = new DataDomain("org1", "acc1", "tenant2", 0, "user2");
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (ignoredRulesScope != null) {
+            ignoredRulesScope.close();
+        }
     }
 
     @Test

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/TenantOntologyServiceTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/TenantOntologyServiceTest.java
@@ -1,6 +1,7 @@
 package com.e2eq.ontology.mongo;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.ontology.core.OntologyRegistry.*;
 import com.e2eq.ontology.repo.TenantOntologyMetaRepo;
 import com.e2eq.ontology.repo.TenantOntologyTBoxRepo;
@@ -8,6 +9,7 @@ import com.e2eq.ontology.service.TenantOntologyService;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -30,13 +32,22 @@ public class TenantOntologyServiceTest {
     TenantOntologyTBoxRepo tboxRepo;
 
     private DataDomain tenant1;
+    private SecurityCallScope.Scope ignoredRulesScope;
 
     @BeforeEach
     void setup() {
+        ignoredRulesScope = SecurityCallScope.openIgnoringRules();
         metaRepo.deleteAll();
         tboxRepo.deleteAll();
         
         tenant1 = new DataDomain("org1", "acc1", "tenant1", 0, "user1");
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (ignoredRulesScope != null) {
+            ignoredRulesScope.close();
+        }
     }
 
     @Test

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/repo/TenantOntologyTBoxRepoTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/repo/TenantOntologyTBoxRepoTest.java
@@ -1,11 +1,13 @@
 package com.e2eq.ontology.repo;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.ontology.core.OntologyRegistry.*;
 import com.e2eq.ontology.model.TenantOntologyTBox;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -24,9 +26,11 @@ public class TenantOntologyTBoxRepoTest {
     private DataDomain tenant1;
     private DataDomain tenant2;
     private TBox sampleTBox;
+    private SecurityCallScope.Scope ignoredRulesScope;
 
     @BeforeEach
     void setup() {
+        ignoredRulesScope = SecurityCallScope.openIgnoringRules();
         repo.deleteAll();
         
         tenant1 = new DataDomain("org1", "acc1", "tenant1", 0, "user1");
@@ -42,6 +46,13 @@ public class TenantOntologyTBoxRepoTest {
             Map.of("knows", knowsProperty),
             List.of()
         );
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (ignoredRulesScope != null) {
+            ignoredRulesScope.close();
+        }
     }
 
     @Test

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
@@ -1,27 +1,24 @@
 package com.e2eq.ontology.policy.rest;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.persistent.base.ProjectionField;
+import com.e2eq.framework.model.persistent.base.SortField;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
 import com.e2eq.framework.model.persistent.morphia.BaseMorphiaRepo;
-import com.e2eq.framework.model.persistent.morphia.MorphiaDataStoreWrapper;
-import com.e2eq.framework.model.persistent.morphia.MorphiaUtils;
-import com.e2eq.framework.model.persistent.morphia.planner.PlannedQuery;
-import com.e2eq.framework.model.persistent.morphia.planner.PlannerResult;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.rest.models.Collection;
 import com.e2eq.framework.rest.resources.BaseResource;
+import com.e2eq.framework.rest.query.FilterUtils;
 import com.e2eq.ontology.mongo.OntologyContextEnricherMongo;
 import com.e2eq.ontology.policy.ListQueryRewriter;
 import com.mongodb.client.model.Collation;
-import dev.morphia.Datastore;
-import dev.morphia.annotations.Entity;
 import io.quarkus.logging.Log;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import org.bson.Document;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,9 +52,6 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
 
     @Inject
     OntologyContextEnricherMongo ontologyContextEnricher;
-
-    @Inject
-    MorphiaDataStoreWrapper morphiaDataStoreWrapper;
 
     @ConfigProperty(name = "feature.ontologyList.aggregation.enabled", defaultValue = "false")
     boolean ontologyListAggregationEnabled;
@@ -133,9 +127,35 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
 
         String fullFilter = buildFilterWithExpand(expand, filter);
         if (supportsExpandInOntologyList() && expand != null && !expand.isBlank() && ontologyListAggregationEnabled) {
-            return tryAggregationList(headers, skip, limit, fullFilter, sort, projection);
+            return getGovernedExpandedList(headers, skip, limit, fullFilter, sort, projection);
         }
         return super.getList(headers, skip, limit, fullFilter, sort, projection);
+    }
+
+    /**
+     * Executes an expand through the repository's governed aggregation contract.  The repository,
+     * rather than the REST layer, is responsible for applying the root entity policy and the row,
+     * relationship, and field policies for every joined entity before any document is returned.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Collection<T> getGovernedExpandedList(HttpHeaders headers,
+                                                   int skip,
+                                                   int limit,
+                                                   String query,
+                                                   String sort,
+                                                   String projection) {
+        String realmId = headers == null ? null : headers.getHeaderString("X-Realm");
+        List<SortField> sortFields = convertToSortField(sort);
+        List<ProjectionField> projectionFields = FilterUtils.convertProjectionFields(projection);
+        List<Document> rows = repo.getSecuredAggregationDocuments(
+                realmId, skip, limit, query, sortFields, projectionFields);
+
+        // Expanded rows are BSON documents because they may contain fields from related entity
+        // types that are not members of T.  Collection's generic parameter is erased at the REST
+        // boundary, so retain the existing endpoint signature while preserving the joined shape.
+        Collection<T> collection = new Collection((List) rows, skip, limit, query, (long) rows.size(), sortFields);
+        collection.setRealm(realmId == null ? repo.getDatabaseName() : realmId);
+        return collection;
     }
 
     /** Backward-compatible overload without expand. */
@@ -159,83 +179,6 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
         }
         String expandClause = "expand(" + paths + ")";
         return mergeFilters(expandClause, filter);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Collection<T> tryAggregationList(HttpHeaders headers, int skip, int limit, String query, String sort, String projection) {
-        List<com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field> sortFields = toPlannerSortFields(sort);
-        PlannedQuery planned = MorphiaUtils.convertToPlannedQuery(query, modelClass, limit, skip, sortFields);
-        if (planned.getMode() != PlannerResult.Mode.AGGREGATION) {
-            return super.getList(headers, skip, limit, query, sort, projection);
-        }
-        var pipeline = planned.getAggregation();
-        boolean hasUnknownFrom = pipeline.stream()
-                .filter(d -> d instanceof org.bson.Document)
-                .map(d -> (org.bson.Document) d)
-                .filter(doc -> doc.containsKey("$lookup"))
-                .map(doc -> doc.get("$lookup", org.bson.Document.class))
-                .anyMatch(lookup -> "__unknown__".equals(lookup != null ? lookup.getString("from") : null));
-        if (hasUnknownFrom) {
-            Log.warnf("Ontology list aggregation skipped: pipeline has unresolved $lookup.from for %s", modelClass.getSimpleName());
-            return super.getList(headers, skip, limit, query, sort, projection);
-        }
-        String realm = resolveRealm(headers);
-        Datastore ds = morphiaDataStoreWrapper.getDataStore(realm);
-        String rootCollection = resolveCollectionName(modelClass);
-        List<org.bson.conversions.Bson> clean = new ArrayList<>();
-        for (org.bson.conversions.Bson s : pipeline) {
-            if (s instanceof org.bson.Document d && d.containsKey("$plannedExpandPaths")) {
-                continue;
-            }
-            clean.add(s);
-        }
-        int effLimit = limit > 0 ? limit : 50;
-        int effSkip = Math.max(0, skip);
-        com.mongodb.client.AggregateIterable<org.bson.Document> aggregate = ds.getDatabase()
-                .getCollection(rootCollection)
-                .aggregate(clean, org.bson.Document.class);
-        Collation sortCollation = resolveAggregationSortCollation(sortFields);
-        if (sortCollation != null) {
-            aggregate = aggregate.collation(sortCollation);
-        }
-        List<org.bson.Document> rows = aggregate.into(new ArrayList<>());
-        Collection<org.bson.Document> col = new Collection<>(rows, effSkip, effLimit, query, (long) rows.size());
-        String realmId = headers.getHeaderString("X-Realm");
-        col.setRealm(realmId == null ? repo.getDatabaseName() : realmId);
-        @SuppressWarnings("unchecked")
-        Collection<T> result = (Collection<T>) (Collection<?>) col;
-        return result;
-    }
-
-    private List<com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field> toPlannerSortFields(String sort) {
-        if (sort == null || sort.isBlank()) return null;
-        List<com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field> out = new ArrayList<>();
-        for (String part : sort.split(",")) {
-            String p = part.trim();
-            if (p.isEmpty()) continue;
-            int dir = p.startsWith("-") ? -1 : 1;
-            String name = p.startsWith("-") || p.startsWith("+") ? p.substring(1) : p;
-            if (!name.isBlank()) {
-                out.add(new com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field(name, dir));
-            }
-        }
-        return out.isEmpty() ? null : out;
-    }
-
-    private String resolveRealm(HttpHeaders headers) {
-        String realm = headers.getHeaderString("X-Realm");
-        if (realm != null && !realm.isBlank()) return realm;
-        return SecurityContext.getPrincipalContext()
-                .map(pc -> pc.getDefaultRealm())
-                .orElse(repo.getDatabaseName());
-    }
-
-    private String resolveCollectionName(Class<? extends UnversionedBaseModel> root) {
-        Entity e = root.getAnnotation(Entity.class);
-        if (e != null && e.value() != null && !e.value().isBlank()) {
-            return e.value();
-        }
-        return root.getSimpleName();
     }
 
     /**
@@ -303,6 +246,9 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
     private String mergeFilters(String base, String clause) {
         if (base == null || base.isBlank()) {
             return clause;
+        }
+        if (clause == null || clause.isBlank()) {
+            return base;
         }
         return "(" + base + ") && " + clause;
     }

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/rest/OntologyAwareResource.java
@@ -1,26 +1,23 @@
 package com.e2eq.ontology.policy.rest;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.persistent.base.ProjectionField;
+import com.e2eq.framework.model.persistent.base.SortField;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
 import com.e2eq.framework.model.persistent.morphia.BaseMorphiaRepo;
-import com.e2eq.framework.model.persistent.morphia.MorphiaDataStoreWrapper;
-import com.e2eq.framework.model.persistent.morphia.MorphiaUtils;
-import com.e2eq.framework.model.persistent.morphia.planner.PlannedQuery;
-import com.e2eq.framework.model.persistent.morphia.planner.PlannerResult;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.rest.models.Collection;
 import com.e2eq.framework.rest.resources.BaseResource;
+import com.e2eq.framework.rest.query.FilterUtils;
 import com.e2eq.ontology.mongo.OntologyContextEnricherMongo;
 import com.e2eq.ontology.policy.ListQueryRewriter;
-import dev.morphia.Datastore;
-import dev.morphia.annotations.Entity;
 import io.quarkus.logging.Log;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import org.bson.Document;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -54,9 +51,6 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
 
     @Inject
     OntologyContextEnricherMongo ontologyContextEnricher;
-
-    @Inject
-    MorphiaDataStoreWrapper morphiaDataStoreWrapper;
 
     @ConfigProperty(name = "feature.ontologyList.aggregation.enabled", defaultValue = "false")
     boolean ontologyListAggregationEnabled;
@@ -113,9 +107,35 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
 
         String fullFilter = buildFilterWithExpand(expand, filter);
         if (supportsExpandInOntologyList() && expand != null && !expand.isBlank() && ontologyListAggregationEnabled) {
-            return tryAggregationList(headers, skip, limit, fullFilter, sort, projection);
+            return getGovernedExpandedList(headers, skip, limit, fullFilter, sort, projection);
         }
         return super.getList(headers, skip, limit, fullFilter, sort, projection);
+    }
+
+    /**
+     * Executes an expand through the repository's governed aggregation contract.  The repository,
+     * rather than the REST layer, is responsible for applying the root entity policy and the row,
+     * relationship, and field policies for every joined entity before any document is returned.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Collection<T> getGovernedExpandedList(HttpHeaders headers,
+                                                   int skip,
+                                                   int limit,
+                                                   String query,
+                                                   String sort,
+                                                   String projection) {
+        String realmId = headers == null ? null : headers.getHeaderString("X-Realm");
+        List<SortField> sortFields = convertToSortField(sort);
+        List<ProjectionField> projectionFields = FilterUtils.convertProjectionFields(projection);
+        List<Document> rows = repo.getSecuredAggregationDocuments(
+                realmId, skip, limit, query, sortFields, projectionFields);
+
+        // Expanded rows are BSON documents because they may contain fields from related entity
+        // types that are not members of T.  Collection's generic parameter is erased at the REST
+        // boundary, so retain the existing endpoint signature while preserving the joined shape.
+        Collection<T> collection = new Collection((List) rows, skip, limit, query, (long) rows.size(), sortFields);
+        collection.setRealm(realmId == null ? repo.getDatabaseName() : realmId);
+        return collection;
     }
 
     /** Backward-compatible overload without expand. */
@@ -139,79 +159,6 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
         }
         String expandClause = "expand(" + paths + ")";
         return mergeFilters(expandClause, filter);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Collection<T> tryAggregationList(HttpHeaders headers, int skip, int limit, String query, String sort, String projection) {
-        List<com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field> sortFields = toPlannerSortFields(sort);
-        PlannedQuery planned = MorphiaUtils.convertToPlannedQuery(query, modelClass, limit, skip, sortFields);
-        if (planned.getMode() != PlannerResult.Mode.AGGREGATION) {
-            return super.getList(headers, skip, limit, query, sort, projection);
-        }
-        var pipeline = planned.getAggregation();
-        boolean hasUnknownFrom = pipeline.stream()
-                .filter(d -> d instanceof org.bson.Document)
-                .map(d -> (org.bson.Document) d)
-                .filter(doc -> doc.containsKey("$lookup"))
-                .map(doc -> doc.get("$lookup", org.bson.Document.class))
-                .anyMatch(lookup -> "__unknown__".equals(lookup != null ? lookup.getString("from") : null));
-        if (hasUnknownFrom) {
-            Log.warnf("Ontology list aggregation skipped: pipeline has unresolved $lookup.from for %s", modelClass.getSimpleName());
-            return super.getList(headers, skip, limit, query, sort, projection);
-        }
-        String realm = resolveRealm(headers);
-        Datastore ds = morphiaDataStoreWrapper.getDataStore(realm);
-        String rootCollection = resolveCollectionName(modelClass);
-        List<org.bson.conversions.Bson> clean = new ArrayList<>();
-        for (org.bson.conversions.Bson s : pipeline) {
-            if (s instanceof org.bson.Document d && d.containsKey("$plannedExpandPaths")) {
-                continue;
-            }
-            clean.add(s);
-        }
-        int effLimit = limit > 0 ? limit : 50;
-        int effSkip = Math.max(0, skip);
-        List<org.bson.Document> rows = ds.getDatabase()
-                .getCollection(rootCollection)
-                .aggregate(clean, org.bson.Document.class)
-                .into(new ArrayList<>());
-        Collection<org.bson.Document> col = new Collection<>(rows, effSkip, effLimit, query, (long) rows.size());
-        String realmId = headers.getHeaderString("X-Realm");
-        col.setRealm(realmId == null ? repo.getDatabaseName() : realmId);
-        @SuppressWarnings("unchecked")
-        Collection<T> result = (Collection<T>) (Collection<?>) col;
-        return result;
-    }
-
-    private List<com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field> toPlannerSortFields(String sort) {
-        if (sort == null || sort.isBlank()) return null;
-        List<com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field> out = new ArrayList<>();
-        for (String part : sort.split(",")) {
-            String p = part.trim();
-            if (p.isEmpty()) continue;
-            int dir = p.startsWith("-") ? -1 : 1;
-            String name = p.startsWith("-") || p.startsWith("+") ? p.substring(1) : p;
-            if (!name.isBlank()) {
-                out.add(new com.e2eq.framework.model.persistent.morphia.planner.LogicalPlan.SortSpec.Field(name, dir));
-            }
-        }
-        return out.isEmpty() ? null : out;
-    }
-
-    private String resolveRealm(HttpHeaders headers) {
-        String realm = headers.getHeaderString("X-Realm");
-        if (realm != null && !realm.isBlank()) return realm;
-        return SecurityContext.getPrincipalContext()
-                .map(pc -> pc.getDefaultRealm())
-                .orElse(repo.getDatabaseName());
-    }
-
-    private String resolveCollectionName(Class<? extends UnversionedBaseModel> root) {
-        Entity e = root.getAnnotation(Entity.class);
-        if (e != null && e.value() != null && !e.value().isBlank()) {
-            return e.value();
-        }
-        return root.getSimpleName();
     }
 
     /**
@@ -279,6 +226,9 @@ public abstract class OntologyAwareResource<T extends UnversionedBaseModel, R ex
     private String mergeFilters(String base, String clause) {
         if (base == null || base.isBlank()) {
             return clause;
+        }
+        if (clause == null || clause.isBlank()) {
+            return base;
         }
         return "(" + base + ") && " + clause;
     }

--- a/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/it/HasEdgeGrammarIT.java
+++ b/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/it/HasEdgeGrammarIT.java
@@ -2,6 +2,7 @@ package com.e2eq.ontology.it;
 
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.morphia.QueryToFilterListener;
+import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.grammar.BIAPIQueryLexer;
 import com.e2eq.framework.grammar.BIAPIQueryParser;
 import com.e2eq.ontology.core.ForwardChainingReasoner;
@@ -47,11 +48,13 @@ public class HasEdgeGrammarIT {
     private static final String TENANT = "test-tenant";
     private ForwardChainingReasoner reasoner;
     private DataDomain testDataDomain;
+    private DataDomain otherOrgDataDomain;
 
     @BeforeEach
     public void setup() {
         reasoner = new ForwardChainingReasoner();
-        edgeRepo.deleteAll();
+        SecurityContext.clear();
+        edgeRepo.deleteAll(TENANT);
         datastore.getDatabase().getCollection("orders").drop();
         
         // Create test DataDomain
@@ -61,6 +64,13 @@ public class HasEdgeGrammarIT {
         testDataDomain.setTenantId(TENANT);
         testDataDomain.setOwnerId("system");
         testDataDomain.setDataSegment(0);
+
+        otherOrgDataDomain = new DataDomain();
+        otherOrgDataDomain.setOrgRefName("other-org");
+        otherOrgDataDomain.setAccountNum("9999999999");
+        otherOrgDataDomain.setTenantId(TENANT);
+        otherOrgDataDomain.setOwnerId("system");
+        otherOrgDataDomain.setDataSegment(0);
     }
 
     @Test
@@ -156,6 +166,25 @@ public class HasEdgeGrammarIT {
         assertEquals(0, results.size(), "Should return no results");
     }
 
+    @Test
+    public void testHasEdgeGrammar_DoesNotLeakAcrossDataDomainsInSameTenant() {
+        createOrder("ORDER-LOCAL", "OPEN");
+        createOrder("ORDER-FOREIGN", "OPEN");
+        edgeRepo.upsert(testDataDomain, "Order", "ORDER-LOCAL", "placedInOrg",
+                "Organization", "ORG-SHARED", false, null);
+        edgeRepo.upsert(otherOrgDataDomain, "Order", "ORDER-FOREIGN", "placedInOrg",
+                "Organization", "ORG-SHARED", false, null);
+
+        Filter grammarFilter = parseQuery("hasEdge(placedInOrg, ORG-SHARED)", TENANT);
+        List<TestOrder> results = datastore.find(TestOrder.class)
+                .filter(grammarFilter)
+                .iterator()
+                .toList();
+
+        assertEquals(List.of("ORDER-LOCAL"),
+                results.stream().map(TestOrder::getRefName).toList());
+    }
+
     private void createOrder(String refName, String status) {
         TestOrder order = new TestOrder();
         order.setRefName(refName);
@@ -170,7 +199,11 @@ public class HasEdgeGrammarIT {
         BIAPIQueryParser parser = new BIAPIQueryParser(tokens);
         BIAPIQueryParser.QueryContext tree = parser.query();
         
-        Map<String, String> vars = Map.of("pTenantId", tenantId);
+        Map<String, String> vars = Map.of(
+                "pTenantId", tenantId,
+                "orgRefName", testDataDomain.getOrgRefName(),
+                "pAccountId", testDataDomain.getAccountNum(),
+                "pDataSegment", String.valueOf(testDataDomain.getDataSegment()));
         QueryToFilterListener listener = new QueryToFilterListener(vars, null, null);
         ParseTreeWalker.DEFAULT.walk(listener, tree);
         return listener.getFilter();

--- a/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/rest/OntologyAwareResourceSecurityTest.java
+++ b/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/policy/rest/OntologyAwareResourceSecurityTest.java
@@ -1,0 +1,73 @@
+package com.e2eq.ontology.policy.rest;
+
+import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
+import com.e2eq.framework.model.persistent.morphia.BaseMorphiaRepo;
+import com.e2eq.framework.rest.models.Collection;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+class OntologyAwareResourceSecurityTest {
+
+    @Test
+    void aggregationExpandDelegatesToGovernedRepositoryContract() {
+        AtomicReference<String> executedQuery = new AtomicReference<>();
+        BaseMorphiaRepo<TestModel> repo = governedRepo(executedQuery);
+        TestResource resource = new TestResource(repo);
+
+        Collection<TestModel> result = resource.expand();
+
+        Assertions.assertEquals("expand(customer)", executedQuery.get());
+        Assertions.assertEquals(1, result.getRows().size());
+        Object firstRow = ((List<?>) result.getRows()).get(0);
+        Assertions.assertInstanceOf(Document.class, firstRow);
+        Document row = (Document) firstRow;
+        Assertions.assertEquals("ROOT-1", row.getString("refName"));
+        Assertions.assertEquals("test-realm", result.getRealm());
+    }
+
+    @SuppressWarnings("unchecked")
+    private BaseMorphiaRepo<TestModel> governedRepo(AtomicReference<String> executedQuery) {
+        return (BaseMorphiaRepo<TestModel>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{BaseMorphiaRepo.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getPersistentClass" -> TestModel.class;
+                    case "getDatabaseName" -> "test-realm";
+                    case "getSecuredAggregationDocuments" -> {
+                        executedQuery.set((String) args[3]);
+                        yield List.of(new Document("refName", "ROOT-1")
+                                .append("customer", new Document("refName", "CUSTOMER-1")));
+                    }
+                    case "toString" -> "GovernedTestRepo";
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> throw new AssertionError("Unexpected repository call: " + method);
+                });
+    }
+
+    static class TestModel extends UnversionedBaseModel {
+    }
+
+    static class TestResource
+            extends OntologyAwareResource<TestModel, BaseMorphiaRepo<TestModel>> {
+
+        TestResource(BaseMorphiaRepo<TestModel> repo) {
+            super(repo);
+            ontologyListAggregationEnabled = true;
+        }
+
+        @Override
+        protected boolean supportsExpandInOntologyList() {
+            return true;
+        }
+
+        Collection<TestModel> expand() {
+            return getOntologyList(null, 0, 10, null, null, null, "customer");
+        }
+    }
+}

--- a/quantum-system/src/main/java/com/e2eq/framework/api/tenant/RealmArchiveCollectionManifest.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/api/tenant/RealmArchiveCollectionManifest.java
@@ -1,0 +1,33 @@
+package com.e2eq.framework.api.tenant;
+
+import java.util.Objects;
+
+/** Verified collection inventory captured in a realm archive manifest. */
+public final class RealmArchiveCollectionManifest {
+    private final String collectionName;
+    private final long documentCount;
+    private final int indexCount;
+
+    public RealmArchiveCollectionManifest(String collectionName, long documentCount, int indexCount) {
+        this.collectionName = Objects.requireNonNull(collectionName, "collectionName cannot be null");
+        if (collectionName.isBlank()) {
+            throw new IllegalArgumentException("collectionName cannot be blank");
+        }
+        if (documentCount < 0) {
+            throw new IllegalArgumentException("documentCount cannot be negative");
+        }
+        if (indexCount < 0) {
+            throw new IllegalArgumentException("indexCount cannot be negative");
+        }
+        this.documentCount = documentCount;
+        this.indexCount = indexCount;
+    }
+
+    public String collectionName() { return collectionName; }
+    public long documentCount() { return documentCount; }
+    public int indexCount() { return indexCount; }
+
+    public String getCollectionName() { return collectionName; }
+    public long getDocumentCount() { return documentCount; }
+    public int getIndexCount() { return indexCount; }
+}

--- a/quantum-system/src/main/java/com/e2eq/framework/api/tenant/RealmArchiveManifest.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/api/tenant/RealmArchiveManifest.java
@@ -1,0 +1,111 @@
+package com.e2eq.framework.api.tenant;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Control-plane contract describing a verified realm archive.
+ *
+ * <p>The framework owns this provider-neutral contract; enterprise modules
+ * supply the object-storage and database implementation.</p>
+ */
+public final class RealmArchiveManifest {
+    private final String archiveRef;
+    private final String realmId;
+    private final String databaseName;
+    private final String applicationId;
+    private final String tenantId;
+    private final String objectUri;
+    private final String format;
+    private final String checksumAlgorithm;
+    private final String checksum;
+    private final String encryptionKeyRef;
+    private final long sizeBytes;
+    private final boolean objectVerified;
+    private final boolean restoreRehearsalVerified;
+    private final Instant createdAt;
+    private final Instant verifiedAt;
+    private final List<RealmArchiveCollectionManifest> collections;
+
+    public RealmArchiveManifest(
+        String archiveRef,
+        String realmId,
+        String databaseName,
+        String applicationId,
+        String tenantId,
+        String objectUri,
+        String format,
+        String checksumAlgorithm,
+        String checksum,
+        String encryptionKeyRef,
+        long sizeBytes,
+        boolean objectVerified,
+        boolean restoreRehearsalVerified,
+        Instant createdAt,
+        Instant verifiedAt,
+        List<RealmArchiveCollectionManifest> collections
+    ) {
+        this.archiveRef = required(archiveRef, "archiveRef");
+        this.realmId = required(realmId, "realmId");
+        this.databaseName = required(databaseName, "databaseName");
+        this.applicationId = required(applicationId, "applicationId");
+        this.tenantId = tenantId;
+        this.objectUri = required(objectUri, "objectUri");
+        this.format = required(format, "format");
+        this.checksumAlgorithm = required(checksumAlgorithm, "checksumAlgorithm");
+        this.checksum = required(checksum, "checksum");
+        this.encryptionKeyRef = required(encryptionKeyRef, "encryptionKeyRef");
+        if (sizeBytes < 0) {
+            throw new IllegalArgumentException("sizeBytes cannot be negative");
+        }
+        this.sizeBytes = sizeBytes;
+        this.objectVerified = objectVerified;
+        this.restoreRehearsalVerified = restoreRehearsalVerified;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt cannot be null");
+        this.verifiedAt = Objects.requireNonNull(verifiedAt, "verifiedAt cannot be null");
+        this.collections = collections == null ? List.of() : List.copyOf(collections);
+    }
+
+    private static String required(String value, String name) {
+        Objects.requireNonNull(value, name + " cannot be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " cannot be blank");
+        }
+        return value;
+    }
+
+    public String archiveRef() { return archiveRef; }
+    public String realmId() { return realmId; }
+    public String databaseName() { return databaseName; }
+    public String applicationId() { return applicationId; }
+    public String tenantId() { return tenantId; }
+    public String objectUri() { return objectUri; }
+    public String format() { return format; }
+    public String checksumAlgorithm() { return checksumAlgorithm; }
+    public String checksum() { return checksum; }
+    public String encryptionKeyRef() { return encryptionKeyRef; }
+    public long sizeBytes() { return sizeBytes; }
+    public boolean objectVerified() { return objectVerified; }
+    public boolean restoreRehearsalVerified() { return restoreRehearsalVerified; }
+    public Instant createdAt() { return createdAt; }
+    public Instant verifiedAt() { return verifiedAt; }
+    public List<RealmArchiveCollectionManifest> collections() { return collections; }
+
+    public String getArchiveRef() { return archiveRef; }
+    public String getRealmId() { return realmId; }
+    public String getDatabaseName() { return databaseName; }
+    public String getApplicationId() { return applicationId; }
+    public String getTenantId() { return tenantId; }
+    public String getObjectUri() { return objectUri; }
+    public String getFormat() { return format; }
+    public String getChecksumAlgorithm() { return checksumAlgorithm; }
+    public String getChecksum() { return checksum; }
+    public String getEncryptionKeyRef() { return encryptionKeyRef; }
+    public long getSizeBytes() { return sizeBytes; }
+    public boolean isObjectVerified() { return objectVerified; }
+    public boolean isRestoreRehearsalVerified() { return restoreRehearsalVerified; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getVerifiedAt() { return verifiedAt; }
+    public List<RealmArchiveCollectionManifest> getCollections() { return collections; }
+}

--- a/quantum-system/src/main/java/com/e2eq/framework/api/tenant/RealmArchiveProvider.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/api/tenant/RealmArchiveProvider.java
@@ -1,0 +1,59 @@
+package com.e2eq.framework.api.tenant;
+
+import java.util.Objects;
+
+/**
+ * Provider-neutral realm archive boundary used by governed lifecycle workflows.
+ * Implementations must create and verify archives before destructive work and
+ * must reject restore collisions.
+ */
+public interface RealmArchiveProvider {
+
+    RealmArchiveManifest createAndVerifyArchive(ArchiveRequest request);
+
+    RealmArchiveManifest inspectArchive(String archiveRef);
+
+    RealmArchiveManifest restoreAndVerify(RestoreRequest request);
+
+    record ArchiveRequest(
+        String executionRef,
+        String realmId,
+        String databaseName,
+        String applicationId,
+        String tenantId,
+        String archiveMountRef
+    ) {
+        public ArchiveRequest {
+            executionRef = required(executionRef, "executionRef");
+            realmId = required(realmId, "realmId");
+            databaseName = required(databaseName, "databaseName");
+            applicationId = required(applicationId, "applicationId");
+            archiveMountRef = required(archiveMountRef, "archiveMountRef");
+        }
+    }
+
+    record RestoreRequest(
+        String executionRef,
+        String realmId,
+        String databaseName,
+        String applicationId,
+        String tenantId,
+        String archiveRef
+    ) {
+        public RestoreRequest {
+            executionRef = required(executionRef, "executionRef");
+            realmId = required(realmId, "realmId");
+            databaseName = required(databaseName, "databaseName");
+            applicationId = required(applicationId, "applicationId");
+            archiveRef = required(archiveRef, "archiveRef");
+        }
+    }
+
+    private static String required(String value, String name) {
+        Objects.requireNonNull(value, name + " cannot be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/quantum-system/src/main/java/com/e2eq/framework/api/tenant/TenantLifecycle.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/api/tenant/TenantLifecycle.java
@@ -28,8 +28,12 @@ public interface TenantLifecycle {
     TenantProvisionResult provision(TenantProvisionRequest request);
 
     /**
-     * Delete a tenant's realm: catalog entry, database, credentials.
-     * Implementations refuse to delete system realms.
+     * Legacy compatibility boundary for tenant deletion.
+     *
+     * <p>The embedded open-source implementation must fail closed rather than
+     * deleting realm data synchronously. Soft decommission, verified archive,
+     * destructive approval, and restore belong to the governed system control
+     * plane workflow.</p>
      */
     TenantDeleteResult delete(String realmId);
 }

--- a/quantum-system/src/main/java/com/e2eq/framework/system/local/SystemDirectoryProducer.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/local/SystemDirectoryProducer.java
@@ -9,6 +9,7 @@ import com.e2eq.framework.util.EnvConfigUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.Optional;
@@ -38,6 +39,7 @@ public class SystemDirectoryProducer {
     @Inject CredentialRepo credentialRepo;
     @Inject EnvConfigUtils envConfigUtils;
     @Inject QuantumModeConfig quantumModeConfig;
+    @Inject JsonWebToken jwt;
 
     @ConfigProperty(name = "quantum.system.directory.mode")
     Optional<String> directoryModeOverride;
@@ -62,7 +64,18 @@ public class SystemDirectoryProducer {
                 return new com.e2eq.framework.system.remote.RemoteSystemDirectory(
                     quantumModeConfig.systemServiceBaseUrl().orElseThrow(() ->
                         new IllegalStateException("quantum.system-service.base-url is required for remote SystemDirectory")),
-                    serviceToken);
+                    () -> {
+                        try {
+                            String inboundToken = jwt.getRawToken();
+                            if (inboundToken != null && !inboundToken.isBlank()) {
+                                return Optional.of(inboundToken);
+                            }
+                        } catch (RuntimeException ignored) {
+                            // No active request context (for example, startup). A configured service
+                            // token is still allowed; otherwise the remote call fails closed.
+                        }
+                        return serviceToken;
+                    });
             default:
                 throw new IllegalStateException(
                     "Unknown quantum.system.directory.mode '" + directoryModeOverride.orElse(null)

--- a/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneRealmMapper.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneRealmMapper.java
@@ -1,0 +1,49 @@
+package com.e2eq.framework.system.remote;
+
+import com.e2eq.framework.controlplane.model.RealmCatalogEntry;
+import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.model.security.Realm;
+
+/** Shared typed mapping at the generated control-plane contract boundary. */
+public final class ControlPlaneRealmMapper {
+    private ControlPlaneRealmMapper() {
+    }
+
+    public static Realm fromEntry(RealmCatalogEntry entry) {
+        Realm realm = new Realm();
+        realm.setRefName(entry.getRefName());
+        realm.setDisplayName(entry.getDisplayName());
+        realm.setDatabaseName(entry.getDatabaseName());
+        realm.setEmailDomain(entry.getEmailDomain());
+        realm.setConnectionString(entry.getConnectionString());
+        if (hasText(entry.getTenantId()) && hasText(entry.getOrgRefName())
+                && hasText(entry.getAccountNumber())) {
+            realm.setDomainContext(DomainContext.builder()
+                .tenantId(entry.getTenantId())
+                .orgRefName(entry.getOrgRefName())
+                .accountId(entry.getAccountNumber())
+                .defaultRealm(entry.getRefName())
+                .build());
+        }
+        return realm;
+    }
+
+    public static RealmCatalogEntry toEntry(Realm realm) {
+        RealmCatalogEntry entry = new RealmCatalogEntry();
+        entry.setRefName(realm.getRefName());
+        entry.setDisplayName(realm.getDisplayName());
+        entry.setDatabaseName(realm.getDatabaseName());
+        entry.setEmailDomain(realm.getEmailDomain());
+        entry.setConnectionString(realm.getConnectionString());
+        if (realm.getDomainContext() != null) {
+            entry.setTenantId(realm.getDomainContext().getTenantId());
+            entry.setOrgRefName(realm.getDomainContext().getOrgRefName());
+            entry.setAccountNumber(realm.getDomainContext().getAccountId());
+        }
+        return entry;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/quantum-system/src/main/java/com/e2eq/framework/system/remote/RemoteSystemDirectory.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/remote/RemoteSystemDirectory.java
@@ -31,15 +31,26 @@ import java.util.function.Supplier;
 public class RemoteSystemDirectory implements SystemDirectory {
 
     private final DefaultEndpoint client;
+    private final String baseUrl;
+    private final Supplier<Optional<String>> bearerTokenSupplier;
 
     /** Production: build the SDK client (transport via MP Rest Client). */
     public RemoteSystemDirectory(String baseUrl, Optional<String> bearerToken) {
-        this(ControlPlaneClientFactory.build(baseUrl, bearerToken));
+        this(baseUrl, () -> bearerToken);
+    }
+
+    /** Production request-scoped bearer forwarding for authenticated catalog reads. */
+    public RemoteSystemDirectory(String baseUrl, Supplier<Optional<String>> bearerTokenSupplier) {
+        this.client = null;
+        this.baseUrl = baseUrl;
+        this.bearerTokenSupplier = bearerTokenSupplier;
     }
 
     /** Direct injection of the typed client (tests, alternate transports). */
     public RemoteSystemDirectory(DefaultEndpoint client) {
         this.client = client;
+        this.baseUrl = null;
+        this.bearerTokenSupplier = null;
     }
 
     @Override
@@ -52,18 +63,19 @@ public class RemoteSystemDirectory implements SystemDirectory {
 
     @Override
     public Optional<Realm> findRealmByEmailDomain(String emailDomain) {
-        return getRealm(() -> client.findRealmByEmailDomain(emailDomain), "realm by email domain " + emailDomain);
+        return getRealm(() -> client().findRealmByEmailDomain(emailDomain), "realm by email domain " + emailDomain);
     }
 
     @Override
     public Optional<Realm> findRealmByRefName(String refName) {
-        return getRealm(() -> client.findRealmByRefName(refName), "realm " + refName);
+        return getRealm(() -> client().findRealmByRefName(refName), "realm " + refName);
     }
 
     @Override
     public Realm registerRealm(Realm realm) {
         try {
-            return fromEntry(client.registerRealm(toEntry(realm)));
+            return ControlPlaneRealmMapper.fromEntry(
+                client().registerRealm(ControlPlaneRealmMapper.toEntry(realm)));
         } catch (WebApplicationException e) {
             throw new IllegalStateException("Control plane rejected realm registration for "
                 + realm.getRefName() + ": HTTP " + e.getResponse().getStatus(), e);
@@ -84,7 +96,7 @@ public class RemoteSystemDirectory implements SystemDirectory {
 
     private Optional<Realm> getRealm(Supplier<RealmCatalogEntry> call, String what) {
         try {
-            return Optional.of(fromEntry(call.get()));
+            return Optional.of(ControlPlaneRealmMapper.fromEntry(call.get()));
         } catch (NotFoundException e) {
             return Optional.empty();
         } catch (WebApplicationException e) {
@@ -93,6 +105,16 @@ public class RemoteSystemDirectory implements SystemDirectory {
         } catch (ProcessingException e) {
             throw unreachable(what, e);
         }
+    }
+
+    private DefaultEndpoint client() {
+        if (client != null) {
+            return client;
+        }
+        Optional<String> bearerToken = bearerTokenSupplier == null
+            ? Optional.empty()
+            : bearerTokenSupplier.get();
+        return ControlPlaneClientFactory.build(baseUrl, bearerToken);
     }
 
     private static IllegalStateException unreachable(String what, Throwable cause) {
@@ -107,24 +129,4 @@ public class RemoteSystemDirectory implements SystemDirectory {
             + "(realm-membership ADR / B4). Port the calling path to JWT-claims-based identity.");
     }
 
-    /** Contract mapping: RealmCatalogEntry <-> Realm (catalog fields only). */
-    static Realm fromEntry(RealmCatalogEntry entry) {
-        Realm realm = new Realm();
-        realm.setRefName(entry.getRefName());
-        realm.setDisplayName(entry.getDisplayName());
-        realm.setDatabaseName(entry.getDatabaseName());
-        realm.setEmailDomain(entry.getEmailDomain());
-        realm.setConnectionString(entry.getConnectionString());
-        return realm;
-    }
-
-    static RealmCatalogEntry toEntry(Realm realm) {
-        RealmCatalogEntry entry = new RealmCatalogEntry();
-        entry.setRefName(realm.getRefName());
-        entry.setDisplayName(realm.getDisplayName());
-        entry.setDatabaseName(realm.getDatabaseName());
-        entry.setEmailDomain(realm.getEmailDomain());
-        entry.setConnectionString(realm.getConnectionString());
-        return entry;
-    }
 }

--- a/quantum-system/src/test/java/com/e2eq/framework/system/TestRemoteSystemDirectoryClient.java
+++ b/quantum-system/src/test/java/com/e2eq/framework/system/TestRemoteSystemDirectoryClient.java
@@ -40,6 +40,9 @@ public class TestRemoteSystemDirectoryClient {
                 e.setDisplayName("Acme");
                 e.setDatabaseName("acme-com");
                 e.setEmailDomain("acme.com");
+                e.setTenantId("acme.com");
+                e.setOrgRefName("acme");
+                e.setAccountNumber("0000000001");
                 return e;
             }
         });
@@ -47,6 +50,11 @@ public class TestRemoteSystemDirectoryClient {
         Assertions.assertTrue(realm.isPresent());
         Assertions.assertEquals("acme-com", realm.get().getRefName());
         Assertions.assertEquals("acme-com", realm.get().getDatabaseName());
+        Assertions.assertNotNull(realm.get().getDomainContext());
+        Assertions.assertEquals("acme.com", realm.get().getDomainContext().getTenantId());
+        Assertions.assertEquals("acme", realm.get().getDomainContext().getOrgRefName());
+        Assertions.assertEquals("0000000001", realm.get().getDomainContext().getAccountId());
+        Assertions.assertEquals("acme-com", realm.get().getDomainContext().getDefaultRealm());
     }
 
     @Test


### PR DESCRIPTION
## What changed
- Merges tenant-aware authorization and lifecycle hardening into the 1.4.0 snapshot line.
- Preserves governed ontology expansion while retaining sort/collation support.
- Enforces field-level policy and fail-closed security context behavior.
- Adds provider-neutral realm archive contracts and related tests/docs.

## Root causes fixed
- Direct aggregation could bypass governed repository policy.
- Unset sort collation used an empty MicroProfile default, which caused CDI startup failure.
- Legacy tests invoked governed reads without an explicit authorized scope.

## Validation
- `mvn clean install`
- 20/20 reactor modules passed.
- Total time: 2:57.