### PR TITLE
Realm-scoped service tokens (ServiceTokenRequest.realm)

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/requests/ServiceTokenRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/requests/ServiceTokenRequest.java
@@ -16,11 +16,16 @@ import java.util.Set;
  *                          Data planes running delegated-claims validation reject tokens
  *                          without one, so service tokens intended for tenant-plane calls
  *                          (e.g. the Install provisioning callback) must be realm-scoped.
+ * @param audiences         optional application audiences ({@code aud}). Data planes that
+ *                          enforce an expected audience reject the legacy default audience,
+ *                          so service tokens intended for audience-enforcing applications
+ *                          must name them here.
  */
 @RegisterForReflection
 public record ServiceTokenRequest(
         @NotNull Set<String> roles,
         Long expirationSeconds,
         String description,
-        String realm
+        String realm,
+        Set<String> audiences
 ) {}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/requests/ServiceTokenRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/requests/ServiceTokenRequest.java
@@ -12,10 +12,15 @@ import java.util.Set;
  * @param roles             roles to embed in the token (required)
  * @param expirationSeconds seconds until expiry; null for non-expiring (100-year token)
  * @param description       optional human-readable description for the credential
+ * @param realm             optional realm to stamp as the token's signed {@code realm} claim.
+ *                          Data planes running delegated-claims validation reject tokens
+ *                          without one, so service tokens intended for tenant-plane calls
+ *                          (e.g. the Install provisioning callback) must be realm-scoped.
  */
 @RegisterForReflection
 public record ServiceTokenRequest(
         @NotNull Set<String> roles,
         Long expirationSeconds,
-        String description
+        String description,
+        String realm
 ) {}

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -115,8 +115,22 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
     * data domain from the realm (system realm requires the {@code system} role).
     */
    public String generateServiceToken(String subject, Set<String> roles, Long expirationSeconds, String realm) {
+      return generateServiceToken(subject, roles, expirationSeconds, realm, null);
+   }
+
+   /**
+    * Realm- and audience-scoped variant: additionally stamps {@code aud} with the target
+    * application ids so audience-enforcing data planes accept the token (the legacy
+    * default audience is rejected there).
+    */
+   public String generateServiceToken(String subject, Set<String> roles, Long expirationSeconds,
+                                      String realm, Set<String> audiences) {
       long duration = (expirationSeconds != null) ? expirationSeconds : 60L * 60 * 24 * 365 * 100;
       try {
+         if (audiences != null && !audiences.isEmpty()) {
+            return TokenUtils.generateUserToken(subject, null, roles, realm,
+                    null, null, null, audiences, null, TokenUtils.expiresAt(duration), issuer);
+         }
          if (realm == null || realm.isBlank()) {
             return TokenUtils.generateUserToken(subject, roles, TokenUtils.expiresAt(duration), issuer);
          }

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -105,9 +105,23 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
     * @return signed JWT token string
     */
    public String generateServiceToken(String subject, Set<String> roles, Long expirationSeconds) {
+      return generateServiceToken(subject, roles, expirationSeconds, null);
+   }
+
+   /**
+    * Realm-scoped variant: stamps the signed {@code realm} claim so data planes running
+    * delegated-claims validation (which fail closed on a missing realm claim) accept the
+    * token. No tenant data-domain claims are stamped — the consuming plane resolves the
+    * data domain from the realm (system realm requires the {@code system} role).
+    */
+   public String generateServiceToken(String subject, Set<String> roles, Long expirationSeconds, String realm) {
       long duration = (expirationSeconds != null) ? expirationSeconds : 60L * 60 * 24 * 365 * 100;
       try {
-         return TokenUtils.generateUserToken(subject, roles, TokenUtils.expiresAt(duration), issuer);
+         if (realm == null || realm.isBlank()) {
+            return TokenUtils.generateUserToken(subject, roles, TokenUtils.expiresAt(duration), issuer);
+         }
+         return TokenUtils.generateUserToken(subject, null, roles, realm,
+                 null, null, null, TokenUtils.expiresAt(duration), issuer);
       } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
          throw new RuntimeException("Failed to generate service token", e);
       }

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
@@ -42,6 +42,22 @@ class ServiceTokenRealmClaimTest {
     }
 
     @Test
+    void audienceScopedServiceTokenCarriesApplicationAudiences() throws Exception {
+        TokenUtils.configure("privateKey.pem", "publicKey.pem");
+
+        String jwt = TokenUtils.generateUserToken(
+                "svc-install-2", null, Set.of("helixorq-system"),
+                "system-helixorq-com", null, null, null,
+                Set.of("helixor-scheduler"), null,
+                TokenUtils.expiresAt(3600), "https://auth.example.com");
+
+        String claims = payloadJson(jwt);
+        assertTrue(claims.contains("helixor-scheduler"), claims);
+        assertFalse(claims.contains("b2bi-api-client"), claims);
+        assertTrue(claims.contains("\"realm\":\"system-helixorq-com\""), claims);
+    }
+
+    @Test
     void realmBlindServiceTokenOmitsRealmClaim() throws Exception {
         TokenUtils.configure("privateKey.pem", "publicKey.pem");
 

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
@@ -1,0 +1,54 @@
+package com.e2eq.framework.model.auth.provider.jwtToken;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Service tokens intended for tenant-plane calls must carry a signed realm
+ * claim: SecurityFilter's delegated-claims path fails closed on a missing
+ * realm, so a realm-blind service token is rejected with 403 by every data
+ * plane running delegated validation (the Install-callback incident).
+ */
+class ServiceTokenRealmClaimTest {
+
+    @AfterEach
+    void reset() {
+        TokenUtils.configure("privateKey.pem", "publicKey.pem");
+    }
+
+    private static String payloadJson(String jwt) {
+        String[] parts = jwt.split("\\.");
+        return new String(Base64.getUrlDecoder().decode(parts[1]));
+    }
+
+    @Test
+    void realmScopedServiceTokenCarriesRealmClaim() throws Exception {
+        TokenUtils.configure("privateKey.pem", "publicKey.pem");
+
+        String jwt = TokenUtils.generateUserToken(
+                "svc-install-1", null, Set.of("helixorq-system", "system"),
+                "system-helixorq-com", null, null, null,
+                TokenUtils.expiresAt(3600), "https://auth.example.com");
+
+        String claims = payloadJson(jwt);
+        assertTrue(claims.contains("\"realm\":\"system-helixorq-com\""), claims);
+        assertFalse(claims.contains("\"tenantId\""), claims);
+    }
+
+    @Test
+    void realmBlindServiceTokenOmitsRealmClaim() throws Exception {
+        TokenUtils.configure("privateKey.pem", "publicKey.pem");
+
+        String jwt = TokenUtils.generateUserToken(
+                "svc-legacy-1", Set.of("admin"),
+                TokenUtils.expiresAt(3600), "https://auth.example.com");
+
+        assertFalse(payloadJson(jwt).contains("\"realm\""), payloadJson(jwt));
+    }
+}


### PR DESCRIPTION
Delegated-claims validation fails closed on a missing signed `realm` claim, so service tokens minted by `ServiceTokenResource` (realm-blind until now) are rejected with 403 by every tenant plane running delegated validation. Found live: the application-registration Install callback (quantum-system-service → helixor-di `/internal/realms`).

- `ServiceTokenRequest` gains an optional `realm`.
- `CustomTokenAuthProvider.generateServiceToken` overload stamps the realm claim via the tenant-aware `TokenUtils.generateUserToken` (no tenant data-domain claims; the consuming plane resolves the domain — system realm requires the `system` role).
- Old signature delegates with null realm — fully backward compatible.

Verified live: with a realm-scoped installer token, the full Install run completes (validate → instance → callback CREATED → datastore verified → instance active).

Tests: ServiceTokenRealmClaimTest + quantum-jwt-provider suite 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)