### PR TITLE
Harden auth control plane and seed administration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -149,5 +149,8 @@
       "mcp__Helixor_Code__helixor_code_index_status",
       "mcp__Helixor_Code__helixor_code_search"
     ]
-  }
+  },
+  "enabledMcpjsonServers": [
+    "helixai"
+  ]
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/model/ApplyBootstrapPackRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/model/ApplyBootstrapPackRequest.java
@@ -1,5 +1,7 @@
 package com.e2eq.framework.bootstrap.model;
 
+import java.util.Map;
+
 public record ApplyBootstrapPackRequest(
         String packRef,
         BootstrapPackApplyMode mode,
@@ -8,9 +10,25 @@ public record ApplyBootstrapPackRequest(
         String realmRef,
         String tenantRef,
         String workspaceRef,
-        String actorRef
+        String actorRef,
+        Map<String, Object> scopeAttributes
 ) {
     public ApplyBootstrapPackRequest {
         mode = mode == null ? BootstrapPackApplyMode.APPLY_MISSING : mode;
+        scopeAttributes = scopeAttributes == null ? Map.of() : Map.copyOf(scopeAttributes);
+    }
+
+    public ApplyBootstrapPackRequest(
+        String packRef,
+        BootstrapPackApplyMode mode,
+        String productRef,
+        String environmentRef,
+        String realmRef,
+        String tenantRef,
+        String workspaceRef,
+        String actorRef
+    ) {
+        this(packRef, mode, productRef, environmentRef, realmRef, tenantRef,
+            workspaceRef, actorRef, Map.of());
     }
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/BootstrapPackService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/bootstrap/runtime/BootstrapPackService.java
@@ -179,6 +179,21 @@ public class BootstrapPackService {
                     step.config()
                 )
             );
+        } catch (RuntimeException failure) {
+            return new BootstrapPackStepRun(
+                step.stepRef(),
+                BootstrapStepStatus.FAILED,
+                BootstrapStepOutcome.FAILED,
+                Map.of(
+                    "reason", "HANDLER_EXECUTION_FAILED",
+                    "errorType", failure.getClass().getName(),
+                    "message", failure.getMessage() == null
+                        ? failure.getClass().getSimpleName()
+                        : failure.getMessage()
+                ),
+                stepStartedAt,
+                Instant.now()
+            );
         }
 
         return new BootstrapPackStepRun(
@@ -219,6 +234,20 @@ public class BootstrapPackService {
         putIfPresent(scope, "realmRef", request.realmRef());
         putIfPresent(scope, "tenantRef", request.tenantRef());
         putIfPresent(scope, "workspaceRef", request.workspaceRef());
+        for (Map.Entry<String, Object> attribute : request.scopeAttributes().entrySet()) {
+            String key = attribute.getKey();
+            if (key == null || key.isBlank()) {
+                throw new IllegalArgumentException("Bootstrap scope attribute keys must be non-blank");
+            }
+            if (scope.containsKey(key)) {
+                throw new IllegalArgumentException(
+                    "Bootstrap scope attribute cannot replace reserved key: " + key
+                );
+            }
+            if (attribute.getValue() != null) {
+                scope.put(key, attribute.getValue());
+            }
+        }
         return scope;
     }
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/MigrationResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/MigrationResource.java
@@ -5,6 +5,8 @@ import com.e2eq.framework.annotations.FunctionalMapping;
 import com.e2eq.framework.model.persistent.migration.base.DatabaseVersion;
 import com.e2eq.framework.model.persistent.migration.base.MigrationService;
 import com.e2eq.framework.model.persistent.morphia.DatabaseVersionRepo;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.security.runtime.RuleContext;
 import com.e2eq.framework.util.EnvConfigUtils;
 import com.e2eq.framework.util.SecurityUtils;
@@ -123,6 +125,8 @@ public class MigrationResource {
    @Path("/changeSet/execute/{realm}/{beanRefName}")
    @RolesAllowed({"admin", "system"})
    @Produces(MediaType.SERVER_SENT_EVENTS)
+   @FunctionalMapping(area="MIGRATION", domain="CHANGE_SET")
+   @FunctionalAction(value = "EXECUTE_CHANGE_SET", bypassDataScoping = true)
    public void executeChangeSet (@Context HttpHeaders headers, @PathParam("realm") String realm, @PathParam(
       "beanRefName") String beanRefName, SseEventSink eventSink, Sse sse) {
       if (!identity.isAnonymous() && identity.hasRole("admin")) {
@@ -154,6 +158,9 @@ public class MigrationResource {
    @POST
    @Path("/initialize/{realm}")
    @Produces(MediaType.SERVER_SENT_EVENTS)
+   @RolesAllowed({"admin", "system"})
+   @FunctionalMapping(area="MIGRATION", domain="DATABASE")
+   @FunctionalAction(value = "INITIALIZE", bypassDataScoping = true)
    public void initializeDatabase (@PathParam("realm") String realm, SseEventSink eventSink, Sse sse) {
 
       if (!identity.isAnonymous() && identity.hasRole("admin")) {
@@ -186,6 +193,8 @@ public class MigrationResource {
    @Path("/start")
    @RolesAllowed({"admin", "system"})
    @Produces(MediaType.SERVER_SENT_EVENTS)
+   @FunctionalMapping(area="MIGRATION", domain="DATABASE")
+   @FunctionalAction(value = "RUN_ALL", bypassDataScoping = true)
    public void startTask (SseEventSink eventSink, Sse sse) {
       Multi.createFrom().publisher(runMigrateAllTask())
          .emitOn(managedExecutor)
@@ -214,6 +223,8 @@ public class MigrationResource {
    @Path("/start/{realm}")
    @RolesAllowed({"admin", "system"})
    @Produces(MediaType.SERVER_SENT_EVENTS)
+   @FunctionalMapping(area="MIGRATION", domain="DATABASE")
+   @FunctionalAction(value = "RUN", bypassDataScoping = true)
    public void startSpecificTask (@PathParam("realm") String realm, SseEventSink eventSink, Sse sse) {
       Multi.createFrom().publisher(runMigrateSpecificTask(realm))
          .emitOn(managedExecutor)
@@ -246,8 +257,10 @@ public class MigrationResource {
             ruleContext.ensureDefaultRules();
             securityUtils.setSecurityContext();
             try {
-               Log.infof("----Running migrations for system realm:%s---- ", realm);
-               migrationService.runAllUnRunMigrations(realm, emitter);
+               runWithMigrationScope(realm, "INITIALIZE", () -> {
+                  Log.infof("----Running migrations for system realm:%s---- ", realm);
+                  migrationService.runAllUnRunMigrations(realm, emitter);
+               });
             } finally {
                securityUtils.clearSecurityContext();
             }
@@ -268,8 +281,10 @@ public class MigrationResource {
             ruleContext.ensureDefaultRules();
             securityUtils.setSecurityContext();
             try {
-               Log.infof("----Running changeSet for bean:%s---- ", beanRefName);
-               migrationService.runChangeSetBean(beanRefName, realm, emitter);
+               runWithMigrationScope(realm, "EXECUTE_CHANGE_SET", () -> {
+                  Log.infof("----Running changeSet for bean:%s---- ", beanRefName);
+                  migrationService.runChangeSetBean(beanRefName, realm, emitter);
+               });
             } finally {
                securityUtils.clearSecurityContext();
             }
@@ -291,12 +306,12 @@ public class MigrationResource {
             securityUtils.setSecurityContext();
             try {
                Log.info("----Running migrations for test realm:---- " + envConfigUtils.getTestRealm());
-               migrationService.runAllUnRunMigrations(envConfigUtils.getTestRealm(), emitter);
+               runWithMigrationScope(envConfigUtils.getTestRealm(), "RUN", () -> migrationService.runAllUnRunMigrations(envConfigUtils.getTestRealm(), emitter));
                Log.info("----Running migrations for system realm:---- " + envConfigUtils.getSystemRealm());
-               migrationService.runAllUnRunMigrations(envConfigUtils.getSystemRealm(), emitter);
+               runWithMigrationScope(envConfigUtils.getSystemRealm(), "RUN", () -> migrationService.runAllUnRunMigrations(envConfigUtils.getSystemRealm(), emitter));
                if (!envConfigUtils.getSystemRealm().equals(envConfigUtils.getDefaultRealm())) {
                   Log.info("----Running migrations for Default realm:---- " + envConfigUtils.getDefaultRealm());
-                  migrationService.runAllUnRunMigrations(envConfigUtils.getDefaultRealm(), emitter);
+                  runWithMigrationScope(envConfigUtils.getDefaultRealm(), "RUN", () -> migrationService.runAllUnRunMigrations(envConfigUtils.getDefaultRealm(), emitter));
                }
             } finally {
                securityUtils.clearSecurityContext();
@@ -318,8 +333,10 @@ public class MigrationResource {
             ruleContext.ensureDefaultRules();
             securityUtils.setSecurityContext();
             try {
-               Log.info("----Running migrations for realm:---- " + realm);
-               migrationService.runAllUnRunMigrations(realm, emitter);
+               runWithMigrationScope(realm, "RUN", () -> {
+                  Log.info("----Running migrations for realm:---- " + realm);
+                  migrationService.runAllUnRunMigrations(realm, emitter);
+               });
             } finally {
                securityUtils.clearSecurityContext();
             }
@@ -328,6 +345,24 @@ public class MigrationResource {
          } catch (Throwable e) {
             emitter.fail(e);
          }
-      });
+	      });
+	   }
+
+   private void runWithMigrationScope(String realm, String action, MigrationOperation operation) throws Exception {
+      ResourceContext migrationResource = new ResourceContext.Builder()
+         .withRealm(realm)
+         .withArea("MIGRATION")
+         .withFunctionalDomain("DATABASE")
+         .withAction(action)
+         .build();
+
+      try (SecurityCallScope.Scope ignored = SecurityCallScope.openResourceOnly(migrationResource)) {
+         operation.run();
+      }
    }
-}
+
+   @FunctionalInterface
+   private interface MigrationOperation {
+      void run() throws Exception;
+   }
+	}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PermissionResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PermissionResource.java
@@ -194,9 +194,9 @@ public class PermissionResource {
    @Consumes(MediaType.APPLICATION_JSON)
    @Produces(MediaType.APPLICATION_JSON)
    @FunctionalAction("roleProvenance")
-   public Response roleProvenance(RoleProvenanceRequest req) {
+   public RoleProvenanceResponse roleProvenance(RoleProvenanceRequest req) {
       if (req == null || req.userId == null || req.userId.isBlank()) {
-         return Response.status(Response.Status.BAD_REQUEST).entity("userId is required").build();
+         throw new BadRequestException("userId is required");
       }
 
       String realm = (req.realm != null && !req.realm.isBlank())
@@ -312,7 +312,7 @@ public class PermissionResource {
       resp.netRoles = net;
       resp.assignments = identityRoleResolver.toAssignments(provenance);
 
-      return Response.ok(resp).build();
+      return resp;
    }
 
    protected List<EntityInfo> getInfoList() {

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PolicyResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PolicyResource.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -180,9 +181,8 @@ public class PolicyResource extends BaseResource<Policy, PolicyRepo>{
             }
          }
       } catch (Exception e) {
-         // If filtering fails, return all policies
          io.quarkus.logging.Log.warnf(e, "Failed to apply filter to default policies: %s", filter);
-         return new ArrayList<>(policies);
+         throw new BadRequestException("Invalid policy filter: " + filter, e);
       }
 
       return filtered;

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
@@ -58,6 +58,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.function.Supplier;
 
 @OpenAPIDefinition(
         tags = {
@@ -122,6 +123,22 @@ public class SecurityResource {
     @ConfigProperty(name = "com.b2bi.jwt.duration")
     protected long tokenDuration;
 
+    private <T> T withAnonymousRegistrationAccess(String action, Supplier<T> supplier) {
+        var principal = SecurityCallScope.anonymous(
+                envConfigUtils.getSystemRealm(),
+                securityUtils.getSystemDataDomain(),
+                "anonymous-registration");
+        var resource = SecurityCallScope.resource(
+              principal,
+              null,
+              "SECURITY",
+              "APPLICATION_REGISTRATION",
+              action);
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.open(principal, resource)) {
+            return supplier.get();
+        }
+    }
+
     @Path("register")
     @PermitAll
     @POST
@@ -145,7 +162,8 @@ public class SecurityResource {
         }
 
         // check if registration request has already been made?
-        Optional<ApplicationRegistration> oRegRequest = registrationRepo.findByRefName(registrationRequest.getEmail());
+        Optional<ApplicationRegistration> oRegRequest = withAnonymousRegistrationAccess("view",
+                () -> registrationRepo.findByRefName(registrationRequest.getEmail()));
         if (oRegRequest.isPresent()) {
             ApplicationRegistration regRequest = oRegRequest.get();
             RestError error = RestError.builder()
@@ -172,7 +190,8 @@ public class SecurityResource {
         String secondHalf = email.split("@")[1];
         String identifier = secondHalf.split("\\.")[0];
 
-        Optional<ApplicationRegistration> eregistration = registrationRepo.findByCompanyIdentifier(identifier);
+        Optional<ApplicationRegistration> eregistration = withAnonymousRegistrationAccess("view",
+                () -> registrationRepo.findByCompanyIdentifier(identifier));
         if (eregistration.isPresent()) {
             RestError error =RestError.builder()
                     .status(Response.Status.BAD_REQUEST.getStatusCode())
@@ -188,9 +207,8 @@ public class SecurityResource {
         registration.setLname(registrationRequest.getLname());
         registration.setUserTelephone(registrationRequest.getTelephone());
 
-        try (SecurityCallScope.Scope ignored = SecurityCallScope.openIgnoringRules()) {
-            registration = registrationRepo.save(registration);
-        }
+        ApplicationRegistration registrationToSave = registration;
+        registration = withAnonymousRegistrationAccess("create", () -> registrationRepo.save(registrationToSave));
         return Response.ok().entity(registration).status(Response.Status.CREATED).build();
     }
 
@@ -200,7 +218,8 @@ public class SecurityResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response register(@QueryParam("refName") String refName) {
         Response response;
-        Optional<ApplicationRegistration> opRegRequest = registrationRepo.findByRefName(refName);
+        Optional<ApplicationRegistration> opRegRequest = withAnonymousRegistrationAccess("view",
+                () -> registrationRepo.findByRefName(refName));
 
         if (opRegRequest.isPresent()) {
             response = Response.ok(opRegRequest.get()).build();
@@ -460,42 +479,20 @@ public class SecurityResource {
     @Path("/refresh")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response refresh(AuthResponse refreshRequest) throws Exception {
-        if (Log.isEnabled(Logger.Level.WARN))
-            Log.warn(">> REFRESH TOKEN:" + refreshRequest.getRefresh_token());
-        JsonWebToken jwt = parser.parse(refreshRequest.getRefresh_token());
-
-        // ensure correct scope
-        if (!jwt.getClaim("scope").equals(TokenUtils.REFRESH_SCOPE)) {
-            RestError error = RestError.builder().build();
-            error.setStatusMessage("Token is not valid, it has an invalid scope:" + jwt.getClaim("scope"));
-            error.setStatus(Response.Status.UNAUTHORIZED.getStatusCode());
-            //error.setReasonMessage("Could not find credential combination");
-            return Response.status(Response.Status.UNAUTHORIZED).entity(error).build();
+    @APIResponse(responseCode = "200", description = "Session refreshed",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthResponse.class)))
+    @APIResponse(responseCode = "401", description = "Refresh token invalid or no longer authorized",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestError.class)))
+    public Response refresh(AuthResponse refreshRequest) {
+        if (refreshRequest == null || refreshRequest.getRefresh_token() == null
+                || refreshRequest.getRefresh_token().isBlank()) {
+            RestError error = RestError.builder()
+                    .status(Response.Status.BAD_REQUEST.getStatusCode())
+                    .statusMessage("refresh_token is required")
+                    .build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
         }
-
-        // validate the token signature?
-
-        String[] roles = new String[jwt.getGroups().size()];
-        roles = jwt.getGroups().toArray(roles);
-
-        Optional<CredentialUserIdPassword> credentialOp = findCredential(jwt.getSubject(), jwt.getSubject());
-        if (credentialOp.isEmpty()) {
-            RestError error = RestError.builder().build();
-            error.setStatusMessage("Refresh token subject could not be resolved to a credential");
-            error.setStatus(Response.Status.UNAUTHORIZED.getStatusCode());
-            return Response.status(Response.Status.UNAUTHORIZED).entity(error).build();
-        }
-
-        CredentialUserIdPassword credential = credentialOp.get();
-        AuthResponse response = generateAuthResponse(credential.getSubject(),
-                roles,
-                tokenDuration,
-                tokenDuration + 3200l,
-                issuer,
-                credential);
-
-        return Response.ok(response).build();
+        return authLoginService.refresh(refreshRequest.getRefresh_token()).toResponse();
     }
 
     private Optional<CredentialUserIdPassword> findCredential(String subject, String userId) {

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SeedAdminResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SeedAdminResource.java
@@ -1,7 +1,11 @@
 package com.e2eq.framework.rest.resources;
 
+import com.e2eq.framework.annotations.FunctionalAction;
+import com.e2eq.framework.annotations.FunctionalMapping;
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.framework.service.seed.SeedContext;
 import com.e2eq.framework.service.seed.SeedCollectionResolver;
@@ -25,8 +29,10 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import io.quarkus.arc.properties.IfBuildProperty;
 
@@ -54,11 +60,21 @@ public class SeedAdminResource {
     @Inject
     SeedVerificationService seedVerificationService;
 
+    @ConfigProperty(name = "quantum.realmConfig.systemRealm", defaultValue = "system-com")
+    String systemRealm;
+
+    @ConfigProperty(name = "quantum.realm.seed-system-only", defaultValue = "false")
+    boolean seedSystemOnly;
+
+    @ConfigProperty(name = "quantum.seed-pack.apply.realms")
+    Optional<String> seedApplyRealmsCsv;
 
     // ----- Endpoints -----
 
     @GET
     @Path("/pending/{realm}")
+    @FunctionalMapping(area="SEED", domain="SEED")
+    @FunctionalAction(value = "LIST_PENDING", bypassDataScoping = true)
     @Operation(summary = "List pending seed packs", description = "Returns seed packs that have new or updated datasets not yet applied to the given realm.")
     @APIResponse(responseCode = "200", description = "Pending seed packs",
             content = @Content(schema = @Schema(implementation = PendingSeedPack[].class)))
@@ -89,10 +105,13 @@ public class SeedAdminResource {
 
     @GET
     @Path("/history/{realm}")
+    @FunctionalMapping(area="SEED", domain="SEED")
+    @FunctionalAction(value = "LIST_HISTORY", bypassDataScoping = true)
     @Operation(summary = "Seed application history", description = "Returns the history of seed pack applications for the given realm.")
     @APIResponse(responseCode = "200", description = "Seed history entries",
             content = @Content(schema = @Schema(implementation = HistoryEntry[].class)))
     public List<HistoryEntry> history(@PathParam("realm") String realm) {
+        requireRealmOwnedByThisSeedService(realm, "list seed history");
         if (!(seedRegistry instanceof MorphiaSeedRegistry morphiaRegistry)) {
             throw new InternalServerErrorException("SeedRegistry is not MorphiaSeedRegistry");
         }
@@ -113,6 +132,8 @@ public class SeedAdminResource {
 
     @GET
     @Path("/verify/{realm}")
+    @FunctionalMapping(area="SEED", domain="SEED")
+    @FunctionalAction(value = "VERIFY", bypassDataScoping = true)
     public SeedVerificationService.VerifyResult verifyAll(@PathParam("realm") String realm,
                                                           @QueryParam("filter") String filterCsv) {
         return seedVerificationService.verifyLatestApplicable(buildSeedContext(realm), filterCsv);
@@ -120,6 +141,8 @@ public class SeedAdminResource {
 
     @GET
     @Path("/{realm}/{seedPack}/verify")
+    @FunctionalMapping(area="SEED", domain="SEED")
+    @FunctionalAction(value = "VERIFY", bypassDataScoping = true)
     public SeedVerificationService.VerifyResult verifyOne(@PathParam("realm") String realm,
                                                           @PathParam("seedPack") String seedPack) {
         return seedVerificationService.verifyOne(buildSeedContext(realm), seedPack);
@@ -127,6 +150,8 @@ public class SeedAdminResource {
 
     @POST
     @Path("/apply/{realm}")
+    @FunctionalMapping(area="SEED", domain="SEED")
+    @FunctionalAction(value = "APPLY", bypassDataScoping = true)
     @Operation(summary = "Apply all pending seed packs", description = "Discovers and applies all pending seed packs for the given realm.")
     @APIResponse(responseCode = "200", description = "Names of applied seed packs",
             content = @Content(schema = @Schema(implementation = ApplyResult.class)))
@@ -144,14 +169,18 @@ public class SeedAdminResource {
         List<SeedPackRef> refs = latestByPack.values().stream()
                 .map(d -> SeedPackRef.exact(d.getManifest().getSeedPack(), d.getManifest().getVersion()))
                 .collect(Collectors.toList());
-        seedLoaderService.applySeeds(context, refs);
-        ApplyResult result = new ApplyResult();
-        result.applied = latestByPack.keySet().stream().sorted().toList();
-        return result;
+        return withSeedApplyScope(realm, () -> {
+            seedLoaderService.applySeeds(context, refs);
+            ApplyResult result = new ApplyResult();
+            result.applied = latestByPack.keySet().stream().sorted().toList();
+            return result;
+        });
     }
 
     @GET
     @Path("/archetypes/{realm}")
+    @FunctionalMapping(area="SEED", domain="ARCHETYPE")
+    @FunctionalAction(value = "LIST", bypassDataScoping = true)
     @Operation(summary = "List available seed archetypes", description = "Returns archetypes defined in seed pack manifests that are applicable to the given realm.")
     @APIResponse(responseCode = "200", description = "Available archetypes",
             content = @Content(schema = @Schema(implementation = ArchetypeInfo[].class)))
@@ -184,20 +213,26 @@ public class SeedAdminResource {
 
     @POST
     @Path("/archetypes/{realm}/{archetypeName}/apply")
+    @FunctionalMapping(area="SEED", domain="ARCHETYPE")
+    @FunctionalAction(value = "APPLY", bypassDataScoping = true)
     @Operation(summary = "Apply a seed archetype", description = "Applies the named archetype, seeding all packs it includes into the given realm.")
     @APIResponse(responseCode = "200", description = "Applied archetype name",
             content = @Content(schema = @Schema(implementation = ApplyResult.class)))
     public ApplyResult applyArchetype(@PathParam("realm") String realm,
                                       @PathParam("archetypeName") String archetypeName) {
         SeedContext context = buildSeedContext(realm);
-        seedLoaderService.applyArchetype(context, archetypeName);
-        ApplyResult result = new ApplyResult();
-        result.applied = List.of(archetypeName);
-        return result;
+        return withSeedApplyScope(realm, () -> {
+            seedLoaderService.applyArchetype(context, archetypeName);
+            ApplyResult result = new ApplyResult();
+            result.applied = List.of(archetypeName);
+            return result;
+        });
     }
 
     @POST
     @Path("/{realm}/{seedPack}/apply")
+    @FunctionalMapping(area="SEED", domain="SEED")
+    @FunctionalAction(value = "APPLY", bypassDataScoping = true)
     @Operation(summary = "Apply a single seed pack", description = "Applies the latest version of the specified seed pack to the given realm.")
     @APIResponse(responseCode = "200", description = "Applied seed pack name",
             content = @Content(schema = @Schema(implementation = ApplyResult.class)))
@@ -222,10 +257,12 @@ public class SeedAdminResource {
                     return v != null ? v : org.semver4j.Semver.parse("0.0.0");
                 }))
                 .orElseThrow(() -> new NotFoundException("Seed pack not found or not applicable: " + seedPack));
-        seedLoaderService.applySeeds(context, List.of(SeedPackRef.exact(seedPack, latest.getManifest().getVersion())));
-        ApplyResult result = new ApplyResult();
-        result.applied = List.of(seedPack);
-        return result;
+        return withSeedApplyScope(realm, () -> {
+            seedLoaderService.applySeeds(context, List.of(SeedPackRef.exact(seedPack, latest.getManifest().getVersion())));
+            ApplyResult result = new ApplyResult();
+            result.applied = List.of(seedPack);
+            return result;
+        });
     }
 
     // ----- Helpers -----
@@ -239,6 +276,7 @@ public class SeedAdminResource {
      * @return a fully populated SeedContext
      */
     private SeedContext buildSeedContext(String realm) {
+        requireRealmOwnedByThisSeedService(realm, "use seed packs");
         SeedContext.Builder builder = SeedContext.builder(realm);
 
         // Extract DataDomain from security context if available
@@ -258,6 +296,48 @@ public class SeedAdminResource {
         }
 
         return builder.build();
+    }
+
+    private <T> T withSeedApplyScope(String realm, Supplier<T> operation) {
+        requireRealmOwnedByThisSeedService(realm, "apply seed packs");
+        ResourceContext seedResource = new ResourceContext.Builder()
+                .withRealm(realm)
+                .withArea("SEED")
+                .withFunctionalDomain("SEED")
+                .withAction("APPLY")
+                .build();
+
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.openResourceOnly(seedResource)) {
+            return operation.get();
+        }
+    }
+
+    private void requireRealmOwnedByThisSeedService(String realm, String operation) {
+        if (!seedSystemOnly || Objects.equals(realm, systemRealm) || isExplicitlyConfiguredSeedRealm(realm)) {
+            return;
+        }
+        throw new BadRequestException(String.format(
+                "Refusing to %s for realm %s because quantum.realm.seed-system-only=true and this service only owns system realm %s. "
+                        + "Set quantum.seed-pack.apply.realms to explicitly opt in an additional managed realm.",
+                operation,
+                realm,
+                systemRealm));
+    }
+
+    private boolean isExplicitlyConfiguredSeedRealm(String realm) {
+        if (seedApplyRealmsCsv.isEmpty()) {
+            return false;
+        }
+        String csv = seedApplyRealmsCsv.get().trim();
+        if (csv.isEmpty() || csv.equalsIgnoreCase("none")) {
+            return false;
+        }
+        for (String part : csv.split(",")) {
+            if (Objects.equals(part.trim(), realm)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private PendingSeedPack computePendingForDescriptor(SeedRegistry registry,

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
@@ -6,11 +6,14 @@ import com.e2eq.framework.model.auth.RoleAssignment;
 import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
 import com.e2eq.framework.model.persistent.morphia.RealmRepo;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.rest.models.AccessibleRealmInfo;
 import com.e2eq.framework.rest.models.AuthResponse;
 import com.e2eq.framework.rest.models.RestError;
 import com.e2eq.framework.util.EnvConfigUtils;
+import com.e2eq.framework.util.SecurityUtils;
 import io.quarkus.logging.Log;
+import io.smallrye.jwt.auth.principal.JWTParser;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -18,6 +21,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -34,6 +38,12 @@ public class AuthLoginService {
 
     @Inject
     EnvConfigUtils envConfigUtils;
+
+    @Inject
+    SecurityUtils securityUtils;
+
+    @Inject
+    JWTParser jwtParser;
 
     /** Application-authorization signals a provider may return as a negative login response. */
     private static final String APP_SELECTION_REQUIRED = "ApplicationSelectionRequired";
@@ -59,15 +69,15 @@ public class AuthLoginService {
 
         List<String> providerFailures = new ArrayList<>();
         for (AuthProvider authProvider : authProviders) {
-            AuthProvider.LoginResponse loginResponse = dispatchLogin(
-                    authProvider, userId, password, applicationId, realmId);
+            AuthProvider.LoginResponse loginResponse = withAnonymousAuthenticationAccess(() ->
+                    dispatchLogin(authProvider, userId, password, applicationId, realmId));
             if (loginResponse.authenticated() && loginResponse.positiveResponse() != null) {
-                Optional<CredentialUserIdPassword> credentialOp = findCredential(
+                Optional<CredentialUserIdPassword> credentialOp = withAnonymousAuthenticationAccess(() -> findCredential(
                         loginResponse.positiveResponse().identity() != null
                                 && loginResponse.positiveResponse().identity().getPrincipal() != null
                                 ? loginResponse.positiveResponse().identity().getPrincipal().getName()
                                 : null,
-                        loginResponse.positiveResponse().userId());
+                        loginResponse.positiveResponse().userId()));
                 AuthResponse response = toAuthResponse(authProvider, loginResponse, credentialOp.orElse(null));
                 return LoginResult.success(response);
             }
@@ -123,10 +133,60 @@ public class AuthLoginService {
         // Authentication semantics must not change when the credential store is
         // unavailable. A lookup failure is an operational error, not evidence that
         // the credential is absent and permission to try a different provider.
-        return credentialRepo.findByUserId(
+        return withAnonymousAuthenticationAccess(() -> credentialRepo.findByUserId(
                 userId,
                 envConfigUtils.getSystemRealm(),
-                true);
+                true));
+    }
+
+    /**
+     * Refresh an authenticated session through the provider that issued the
+     * refresh token. Provider refresh is authoritative because it re-resolves
+     * the user's realm membership, roles, and application grant before minting
+     * replacement tokens.
+     */
+    public LoginResult refresh(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            return LoginResult.failure(List.of("refresh: refresh token is required"));
+        }
+
+        try {
+            String tokenIssuer = jwtParser.parse(refreshToken).getIssuer();
+            AuthProvider provider = authProviderFactory.getProviderForIssuer(tokenIssuer);
+            AuthProvider.LoginResponse refreshResponse = withAnonymousAuthenticationAccess(() ->
+                    provider.refreshTokens(refreshToken));
+            if (refreshResponse != null
+                    && refreshResponse.authenticated()
+                    && refreshResponse.positiveResponse() != null) {
+                AuthProvider.LoginPositiveResponse positive = refreshResponse.positiveResponse();
+                Optional<CredentialUserIdPassword> credential = withAnonymousAuthenticationAccess(() -> findCredential(
+                        positive.identity() != null && positive.identity().getPrincipal() != null
+                                ? positive.identity().getPrincipal().getName()
+                                : null,
+                        positive.userId()));
+                return LoginResult.success(toAuthResponse(provider, refreshResponse, credential.orElse(null)));
+            }
+        } catch (Exception ignored) {
+            // Refresh failures are deliberately indistinguishable to clients.
+            // Provider details and token material must not cross this boundary.
+        }
+        return LoginResult.failure(List.of("refresh: token validation or authorization failed"));
+    }
+
+    private <T> T withAnonymousAuthenticationAccess(Supplier<T> supplier) {
+        var principal = SecurityCallScope.anonymous(
+                envConfigUtils.getSystemRealm(),
+                securityUtils.getSystemDataDomain(),
+                "anonymous-authentication");
+        var resource = SecurityCallScope.resource(
+                principal,
+                null,
+                "SECURITY",
+                "CREDENTIAL_USERID_PASSWORD",
+                "authenticate");
+        try (SecurityCallScope.Scope ignored = SecurityCallScope.open(principal, resource)) {
+            return supplier.get();
+        }
     }
 
     public List<AccessibleRealmInfo> resolveAccessibleRealms(CredentialUserIdPassword credential) {

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
@@ -10,6 +10,7 @@ import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.base.EntityReference;
 import com.e2eq.framework.model.persistent.migration.base.MigrationService;
 import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.OrganizationRepo;
 import com.e2eq.framework.model.persistent.morphia.RealmRepo;
 import com.e2eq.framework.model.persistent.morphia.RealmTenantMembershipRepo;
 import com.e2eq.framework.model.persistent.morphia.UserGroupRepo;
@@ -17,6 +18,7 @@ import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
 import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.model.security.Organization;
 import com.e2eq.framework.model.security.Realm;
 import com.e2eq.framework.model.security.RealmTenantMembership;
 import com.e2eq.framework.model.security.RealmSetupStatus;
@@ -66,6 +68,7 @@ public class TenantProvisioningService implements TenantLifecycle {
     @Inject RealmCatalogService realmCatalog;
     @Inject SystemDirectory systemDirectory;
     @Inject CredentialRepo credentialRepo;
+    @Inject OrganizationRepo organizationRepo;
     @Inject RealmTenantMembershipRepo realmTenantMembershipRepo;
     @Inject UserProfileRepo userProfileRepo;
     @Inject UserGroupRepo userGroupRepo;
@@ -179,6 +182,7 @@ public class TenantProvisioningService implements TenantLifecycle {
     public ProvisionResult provisionTenant(ProvisionTenantCommand command) {
         ProvisioningContext context = initializeContext(command);
         ensureRealmCatalog(context);
+        ensureOrganizationDirectory(context);
         ensureRealmMembership(context);
         runRealmMigrations(context);
         ensureTenantIdentities(context);
@@ -196,17 +200,18 @@ public class TenantProvisioningService implements TenantLifecycle {
         Objects.requireNonNull(command.getAdminUserId(), "adminUserId cannot be null");
         Objects.requireNonNull(command.getAdminSubject(), "adminSubject cannot be null");
 
-        String realmId = command.getTenantEmailDomain().replace('.', '-');
+        String realmId = normalizeDataDomainIdentifier(command.getTenantEmailDomain());
         String normalizedTenantDisplayName = command.getTenantDisplayName() == null || command.getTenantDisplayName().isBlank()
             ? realmId
             : command.getTenantDisplayName().trim();
+        String dataDomainOrgRefName = normalizeDataDomainIdentifier(command.getOrgRefName());
 
         ProvisionResult result = new ProvisionResult();
         result.realmId = realmId;
 
         DomainContext dc = DomainContext.builder()
-            .tenantId(command.getTenantEmailDomain())
-            .orgRefName(command.getOrgRefName())
+            .tenantId(realmId)
+            .orgRefName(dataDomainOrgRefName)
             .accountId(command.getAccountId())
             .defaultRealm(realmId)
             .build();
@@ -347,6 +352,48 @@ public class TenantProvisioningService implements TenantLifecycle {
         context.getResult().realmCreated = true;
     }
 
+    public void ensureOrganizationDirectory(ProvisioningContext context) {
+        if (organizationRepo == null) {
+            context.getResult().addWarning("Organization directory was not available; organization record was not reconciled.");
+            return;
+        }
+
+        String systemRealm = context.getSystemRealm();
+        String orgRefName = context.getDomainContext().getOrgRefName();
+        String displayName = context.getNormalizedTenantDisplayName();
+        DataDomain dataDomain = DataDomain.builder()
+            .orgRefName(orgRefName)
+            .accountNum(context.getDomainContext().getAccountId())
+            .tenantId(context.getDomainContext().getTenantId())
+            .ownerId(context.getCommand().getAdminUserId())
+            .build();
+
+        Optional<Organization> existing = organizationRepo.findByRefName(orgRefName, systemRealm);
+        if (existing.isPresent()) {
+            Organization organization = existing.get();
+            boolean changed = false;
+            if (organization.getDisplayName() == null || organization.getDisplayName().isBlank()) {
+                organization.setDisplayName(displayName);
+                changed = true;
+            }
+            if (organization.getDataDomain() == null) {
+                organization.setDataDomain(dataDomain);
+                changed = true;
+            }
+            if (changed) {
+                organizationRepo.save(systemRealm, organization);
+            }
+            return;
+        }
+
+        organizationRepo.createOrganization(
+            organizationRepo.getMorphiaDataStoreWrapper().getDataStore(systemRealm),
+            displayName,
+            orgRefName,
+            dataDomain
+        );
+    }
+
     public void ensureRealmMembership(ProvisioningContext context) {
         upsertRealmMembership(
             context.getSystemRealm(),
@@ -398,15 +445,15 @@ public class TenantProvisioningService implements TenantLifecycle {
             }
             CredentialUserIdPassword cred = credOpt.get();
             Set<String> storedRoles = cred.getRoles() == null ? Collections.emptySet() : new HashSet<>(Arrays.asList(cred.getRoles()));
-            boolean attributesMatch = Objects.equals(cred.getSubject(), context.getCommand().getAdminSubject())
+            boolean subjectCompatible = cred.getSubject() != null && !cred.getSubject().isBlank();
+            boolean attributesMatch = subjectCompatible
                 && Objects.equals(storedRoles, context.getDesiredRoles())
                 && Objects.equals(Boolean.FALSE, cred.getForceChangePassword())
                 && Objects.equals(cred.getDomainContext(), context.getDomainContext());
             if (!attributesMatch) {
                 List<String> diffs = new ArrayList<>();
-                if (!Objects.equals(cred.getSubject(), context.getCommand().getAdminSubject())) {
-                    diffs.add(String.format("subject: existing='%s', requested='%s'",
-                        cred.getSubject(), context.getCommand().getAdminSubject()));
+                if (!subjectCompatible) {
+                    diffs.add("subject is blank");
                 }
                 if (!Objects.equals(storedRoles, context.getDesiredRoles())) {
                     diffs.add(String.format("roles: existing='%s', requested='%s'",
@@ -774,6 +821,22 @@ public class TenantProvisioningService implements TenantLifecycle {
                         .build())
                 .build();
 
+        Optional<RealmTenantMembership> existing = realmTenantMembershipRepo.findByRefName(
+                membershipRefName, systemRealm);
+        if (existing.isPresent()) {
+            RealmTenantMembership record = existing.get();
+            record.setDisplayName(membership.getDisplayName());
+            record.setRealmDisplayName(membership.getRealmDisplayName());
+            record.setDefaultAdminUserId(membership.getDefaultAdminUserId());
+            record.setRealmEditionRefName(membership.getRealmEditionRefName());
+            record.setProvisioningMode(membership.getProvisioningMode());
+            record.setParticipationStatus(membership.getParticipationStatus());
+            record.setSetupStatus(membership.getSetupStatus());
+            record.setSetupCompletionPercent(membership.getSetupCompletionPercent());
+            realmTenantMembershipRepo.save(systemRealm, record);
+            return;
+        }
+
         realmTenantMembershipRepo.save(systemRealm, membership);
     }
 
@@ -825,6 +888,15 @@ public class TenantProvisioningService implements TenantLifecycle {
             .filter(value -> !value.isBlank())
             .distinct()
             .toList();
+    }
+
+    private static String normalizeDataDomainIdentifier(String value) {
+        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        normalized = normalized.replaceAll("[^a-z0-9]+", "-").replaceAll("(^-|-$)", "");
+        if (normalized.isBlank()) {
+            throw new IllegalArgumentException("data-domain identifier cannot be blank");
+        }
+        return normalized;
     }
 
     private void withDropPendingRetry(String realmId, String operationName, ProvisioningAction action) {

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedStartupRunner.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/seed/SeedStartupRunner.java
@@ -61,6 +61,9 @@ public class SeedStartupRunner {
     @Inject
     MigrationService migrationService;
 
+    @ConfigProperty(name = "quantum.database.migration.enabled", defaultValue = "true")
+    boolean migrationEnabled;
+
     @Inject
     SystemRealmOwnership systemRealmOwnership;
 
@@ -145,7 +148,14 @@ public class SeedStartupRunner {
                     var db = mongoClient.getDatabase(realm);
                     var collections = db.listCollectionNames().into(new ArrayList<>());
                     if (!collections.isEmpty()) {
-                        migrationService.checkInitialized(realm);
+                        // Seed packs are deliberately version-agnostic and may be
+                        // enabled in services that explicitly disable migrations.
+                        // In that mode, a reachable non-empty database is ready;
+                        // requiring migration metadata makes the two independent
+                        // startup features impossible to configure separately.
+                        if (requiresMigrationReadiness()) {
+                            migrationService.checkInitialized(realm);
+                        }
                         Log.debugf("SeedStartupRunner: database %s is ready", realm);
                         return true;
                     }
@@ -178,6 +188,15 @@ public class SeedStartupRunner {
         }
         Log.warnf("SeedStartupRunner: database %s did not become ready after %d attempts", realm, maxRetries);
         return false;
+    }
+
+    /**
+     * Seed packs and schema migrations are independent startup capabilities.
+     * Keep this decision explicit and testable so services that intentionally
+     * disable migrations can still apply idempotent, version-agnostic seeds.
+     */
+    boolean requiresMigrationReadiness() {
+        return migrationEnabled;
     }
 
     private void applySeedsIfNeeded(String realm) throws Exception {

--- a/quantum-framework/src/test/java/com/e2eq/framework/bootstrap/BootstrapPackServiceTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/bootstrap/BootstrapPackServiceTest.java
@@ -46,7 +46,8 @@ class BootstrapPackServiceTest {
                 "b2bi-com",
                 "b2bi.com",
                 "studio",
-                "tester"
+                "tester",
+                Map.of("orgRefName", "b2bi.com")
         ));
 
         assertEquals(BootstrapPackRunStatus.COMPLETED, run.status());
@@ -54,6 +55,7 @@ class BootstrapPackServiceTest {
         assertEquals(List.of("ensure-a", "ensure-b"), handler.executedSteps);
         assertEquals("local", run.scope().get("environmentRef"));
         assertEquals("b2bi-com", run.scope().get("realmRef"));
+        assertEquals("b2bi.com", run.scope().get("orgRefName"));
         assertEquals(1, service.listRuns().size());
     }
 
@@ -104,6 +106,32 @@ class BootstrapPackServiceTest {
         assertEquals(BootstrapPackRunStatus.FAILED, run.status());
         assertEquals(BootstrapStepStatus.FAILED, run.steps().get(0).status());
         assertEquals("NO_HANDLER", run.steps().get(0).details().get("reason"));
+    }
+
+    @Test
+    void recordsFailedRunWhenHandlerThrows() {
+        BootstrapPackService service = new BootstrapPackService(
+                new CdiBootstrapPackRegistry(List.of(new DemoPackContributor())),
+                List.of(new FailingHandler()),
+                new InMemoryBootstrapPackRunRepository()
+        );
+
+        BootstrapPackRun run = service.apply(new ApplyBootstrapPackRequest(
+                "demo-pack",
+                BootstrapPackApplyMode.APPLY_MISSING,
+                null,
+                null,
+                "broken-realm",
+                "broken-tenant",
+                null,
+                "tester"
+        ));
+
+        assertEquals(BootstrapPackRunStatus.FAILED, run.status());
+        assertEquals(BootstrapStepStatus.FAILED, run.steps().get(0).status());
+        assertEquals("HANDLER_EXECUTION_FAILED", run.steps().get(0).details().get("reason"));
+        assertEquals("boom", run.steps().get(0).details().get("message"));
+        assertEquals(1, service.listRuns().size());
     }
 
     private static final class DemoPackContributor implements BootstrapPackContributor {
@@ -157,6 +185,18 @@ class BootstrapPackServiceTest {
                     outcome,
                     Map.of("handledBy", "RecordingHandler", "resource", request.config().get("resource"))
             );
+        }
+    }
+
+    private static final class FailingHandler implements BootstrapPackStepHandler {
+        @Override
+        public boolean supports(BootstrapStepKind kind) {
+            return kind == BootstrapStepKind.APP_SERVICE;
+        }
+
+        @Override
+        public BootstrapStepResult execute(BootstrapStepRequest request) {
+            throw new IllegalStateException("boom");
         }
     }
 }

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/TestRuleContext.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/TestRuleContext.java
@@ -16,6 +16,7 @@ import com.e2eq.framework.util.WildCardMatcher;
 import dev.morphia.query.filters.Filter;
 import io.quarkus.logging.Log;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import org.graalvm.polyglot.Context;
@@ -241,14 +242,15 @@ public class TestRuleContext extends BaseRepoTest {
         Log.info("Test if mingardia is denied trying to view the system's profile with a default deny context'");
         checkRulesResponse = ruleContext.checkRules(mingardiaUserIdPC, sysAdminUserProfileRC);
         filters.clear();
-        filters1 = ruleContext.getFilters(filters, mingardiaUserIdPC, sysAdminUserProfileRC, UserProfile.class);
         logRuleResults("Test if mingardia is denied trying to view the system's profile with a default deny context'",
                 mingardiaUserIdPC,
                 sysAdminUserProfileRC,
                 checkRulesResponse,
-                filters1);
+                filters);
         assertTrue(checkRulesResponse.getFinalEffect().equals(RuleEffect.DENY));
-        assertTrue(filters1.isEmpty()); // will be empty because the post condition will cause the rule to be ignored / NA and the default is deny
+        assertThrows(ForbiddenException.class,
+                () -> ruleContext.getFilters(new ArrayList<>(), mingardiaUserIdPC, sysAdminUserProfileRC, UserProfile.class),
+                "Denied policy evaluation must fail closed rather than returning ungoverned filters");
 
         // show that its really about the default not an explicit rule
         checkRulesResponse = ruleContext.checkRules(mingardiaUserIdPC, sysAdminUserProfileRC, RuleEffect.ALLOW);
@@ -275,6 +277,31 @@ public class TestRuleContext extends BaseRepoTest {
         assertTrue(checkRulesResponse.getFinalEffect().equals(RuleEffect.ALLOW));
 
 
+    }
+
+    @Test
+    void testGetFiltersFailsClosedWhenNoPolicyAllowsResource() {
+        RuleContext ruleContext = new RuleContext();
+        PrincipalContext principal = new PrincipalContext.Builder()
+                .withDefaultRealm(testUtils.getTestRealm())
+                .withUserId("unprivileged@example.com")
+                .withRoles(new String[]{"unprivileged"})
+                .withDataDomain(testUtils.getTestDataDomain())
+                .withScope("AUTHENTICATED")
+                .build();
+        ResourceContext resource = new ResourceContext.Builder()
+                .withArea("sales")
+                .withFunctionalDomain("opportunity")
+                .withAction("view")
+                .withResourceId("OPP-1")
+                .build();
+
+        SecurityCheckResponse response = ruleContext.checkRules(principal, resource);
+        assertEquals(RuleEffect.DENY, response.getFinalEffect(),
+                "No matching policy must resolve to DENY");
+        assertThrows(ForbiddenException.class,
+                () -> ruleContext.getFilters(new ArrayList<>(), principal, resource, UserProfile.class),
+                "No matching policy must not return the caller's original filters as if access were allowed");
     }
 
     /**
@@ -556,5 +583,56 @@ public class TestRuleContext extends BaseRepoTest {
                 .withOwnerId(testUtils.getSystemUserId()).withResourceId("ORDER-1").build();
         SecurityCheckResponse resp = injectedRuleContext.checkRules(admin, anyRc);
         assertEquals(RuleEffect.ALLOW, resp.getFinalEffect());
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void testAnonymousDefaultPolicyAllowsOnlyRegistrationRequests() {
+        String realm = envConfigUtils.getSystemRealm();
+        injectedRuleContext.reloadFromRepo(realm);
+
+        PrincipalContext anonymous = SecurityCallScope.anonymous(
+                realm,
+                securityUtils.getSystemDataDomain(),
+                "anonymous-registration-test");
+        ResourceContext allowed = SecurityCallScope.resource(
+                anonymous,
+                null,
+                "SECURITY",
+                "APPLICATION_REGISTRATION",
+                "create");
+
+        SecurityCheckResponse allowedResponse = injectedRuleContext.checkRules(anonymous, allowed);
+        assertEquals(RuleEffect.ALLOW, allowedResponse.getFinalEffect());
+
+        ResourceContext credentialAuthentication = SecurityCallScope.resource(
+                anonymous,
+                null,
+                "SECURITY",
+                "CREDENTIAL_USERID_PASSWORD",
+                "authenticate");
+        SecurityCheckResponse credentialAuthenticationResponse =
+                injectedRuleContext.checkRules(anonymous, credentialAuthentication);
+        assertEquals(RuleEffect.ALLOW, credentialAuthenticationResponse.getFinalEffect());
+
+        ResourceContext credentialView = SecurityCallScope.resource(
+                anonymous,
+                null,
+                "SECURITY",
+                "CREDENTIAL_USERID_PASSWORD",
+                "view");
+        SecurityCheckResponse credentialViewResponse = injectedRuleContext.checkRules(anonymous, credentialView);
+        assertEquals(RuleEffect.DENY, credentialViewResponse.getFinalEffect());
+
+        ResourceContext denied = SecurityCallScope.resource(
+                anonymous,
+                null,
+                "security",
+                "userProfile",
+                "view");
+        SecurityCheckResponse deniedResponse = injectedRuleContext.checkRules(anonymous, denied);
+        assertEquals(RuleEffect.DENY, deniedResponse.getFinalEffect());
+        assertThrows(ForbiddenException.class,
+                () -> injectedRuleContext.getFilters(new ArrayList<>(), anonymous, denied, UserProfile.class));
     }
 }

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/TenantProvisioningServiceCatalogTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/TenantProvisioningServiceCatalogTest.java
@@ -9,10 +9,38 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TenantProvisioningServiceCatalogTest {
+
+    @Test
+    void initializeContextKeepsEmailDomainSeparateFromDataDomainIdentifiers() {
+        TenantProvisioningService service = new TenantProvisioningService();
+        service.realmCatalog = new RecordingRealmCatalog(null);
+
+        TenantProvisioningService.ProvisionTenantCommand command =
+            TenantProvisioningService.ProvisionTenantCommand.builder()
+                .tenantDisplayName("BASF — Global Bulk Shipper")
+                .tenantEmailDomain("basf.com")
+                .orgRefName("basf.com")
+                .accountId("0000000000")
+                .adminUserId("admin@basf.com")
+                .adminSubject("admin@basf.com")
+                .adminPassword("unused-in-context-test")
+                .build();
+
+        TenantProvisioningService.ProvisioningContext context = service.initializeContext(command);
+
+        assertEquals("basf-com", context.getRealmId());
+        assertEquals("basf.com", context.getDesiredRealm().getEmailDomain());
+        assertEquals("basf-com", context.getDomainContext().getTenantId());
+        assertEquals("basf-com", context.getDataDomain().getTenantId());
+        assertEquals("basf-com", context.getDomainContext().getOrgRefName());
+        assertEquals("basf-com", context.getDataDomain().getOrgRefName());
+        assertEquals("basf-com", context.getDesiredRealm().getDatabaseName());
+    }
 
     @Test
     void rejectsHistoricalDomainSpellingThatCollidesWithExistingRealmId() {
@@ -95,14 +123,25 @@ class TenantProvisioningServiceCatalogTest {
 
         @Override
         public Optional<Realm> findByEmailDomain(String emailDomain) {
+            if (existing == null) {
+                return Optional.empty();
+            }
             return Optional.of(existing)
                 .filter(realm -> realm.getEmailDomain().equals(emailDomain));
         }
 
         @Override
         public Optional<Realm> findByRefName(String refName) {
+            if (existing == null) {
+                return Optional.empty();
+            }
             return Optional.of(existing)
                 .filter(realm -> realm.getRefName().equals(refName));
+        }
+
+        @Override
+        public String systemRealmId() {
+            return "system-com";
         }
 
         @Override

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedStartupRunnerDatabaseReadinessTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedStartupRunnerDatabaseReadinessTest.java
@@ -1,0 +1,25 @@
+package com.e2eq.framework.service.seed;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SeedStartupRunnerDatabaseReadinessTest {
+
+    @Test
+    void migrationDisabledAllowsIndependentSeedStartup() {
+        SeedStartupRunner runner = new SeedStartupRunner();
+        runner.migrationEnabled = false;
+
+        assertFalse(runner.requiresMigrationReadiness());
+    }
+
+    @Test
+    void migrationEnabledRequiresMigrationReadiness() {
+        SeedStartupRunner runner = new SeedStartupRunner();
+        runner.migrationEnabled = true;
+
+        assertTrue(runner.requiresMigrationReadiness());
+    }
+}

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -26,6 +26,7 @@ import com.e2eq.framework.plugins.BaseAuthProvider;
 import com.e2eq.framework.model.security.UserGroup;
 import com.e2eq.framework.util.EncryptionUtils;
 import com.e2eq.framework.util.EnvConfigUtils;
+import com.e2eq.framework.util.SecurityUtils;
 
 import io.quarkus.logging.Log;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -531,10 +532,8 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                             tokenRealm,
                             tokenRealm));
                    }
-                  boolean credentialRealmAuthorized = securityUtils
-                     .computeAllowedRealmRefNames(credential, List.of(tokenRealm))
-                     .stream()
-                     .anyMatch(allowedRealm -> allowedRealm.equalsIgnoreCase(tokenRealm));
+                  boolean credentialRealmAuthorized = credentialAuthorizesRealm(
+                     securityUtils, credential, tokenRealm);
                   Set<String> groups = new HashSet<>();
                   if (Objects.equals(credentialRealm, tokenRealm) && credential.getRoles() != null) {
                      groups.addAll(Arrays.asList(credential.getRoles()));
@@ -565,7 +564,11 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                            tokenRealm,
                            tokenRealm));
                   }
-                  if (!credentialRealmAuthorized && realmAssignment.isEmpty()) {
+                  // A role assignment describes what the identity may do inside
+                  // a realm; it must never expand the credential's realm
+                  // boundary. Preserve the 1.3 fail-closed contract: the
+                  // credential must authorize the realm independently.
+                  if (!credentialRealmAuthorized) {
                      return new LoginResponse(false,
                         new LoginNegativeResponse(userId,
                            403,
@@ -582,7 +585,7 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                   // (single default audience, unchanged behavior); RESOLVED = multi-aud
                   // token + azp; AMBIGUOUS/DENIED short-circuit to a negative response the
                   // login resource maps to 400 (needs selection) / 403 (not authorized).
-                   ApplicationAuthorizationResolver.Result appAuth = ApplicationAuthorizationResolver.resolve(
+                  ApplicationAuthorizationResolver.Result appAuth = ApplicationAuthorizationResolver.resolve(
                       realmAssignment.map(UserRealmRole::getAuthorizedApplications).orElse(null),
                       credential.getApplicationRegEx(),
                       realmAssignment.map(UserRealmRole::getDefaultApplication).orElse(null),
@@ -805,11 +808,9 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
          } catch (RuntimeException e) {
             throw new SecurityException("Unable to verify realm authorization during refresh", e);
          }
-         boolean credentialRealmAuthorized = securityUtils
-            .computeAllowedRealmRefNames(credential, List.of(tokenRealm))
-            .stream()
-            .anyMatch(tokenRealm::equalsIgnoreCase);
-         if (!credentialRealmAuthorized && realmAssignment.isEmpty()) {
+         boolean credentialRealmAuthorized = credentialAuthorizesRealm(
+            securityUtils, credential, tokenRealm);
+         if (!credentialRealmAuthorized) {
             throw new SecurityException("Credential is no longer authorized for realm: " + tokenRealm);
          }
 
@@ -902,6 +903,19 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                e.toString(),
                envConfigUtils.getSystemRealm()));
       }
+   }
+
+   static boolean credentialAuthorizesRealm(SecurityUtils securityUtils,
+                                             CredentialUserIdPassword credential,
+                                             String realm) {
+      Objects.requireNonNull(securityUtils, "securityUtils cannot be null");
+      Objects.requireNonNull(credential, "credential cannot be null");
+      if (realm == null || realm.isBlank()) {
+         return false;
+      }
+      return securityUtils.computeAllowedRealmRefNames(credential, List.of(realm))
+         .stream()
+         .anyMatch(allowedRealm -> allowedRealm.equalsIgnoreCase(realm));
    }
 
    @Override

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProviderRealmTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProviderRealmTest.java
@@ -1,10 +1,16 @@
 package com.e2eq.framework.model.auth.provider.jwtToken;
 
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.model.security.DomainContext;
+import com.e2eq.framework.util.SecurityUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.Date;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CustomTokenAuthProviderRealmTest {
 
@@ -18,5 +24,26 @@ class CustomTokenAuthProviderRealmTest {
         assertEquals(Set.of(),
             CustomTokenAuthProvider.credentialRolesForRealm(
                 globalRoles, "system-com", "northstar-field-service-com"));
+    }
+
+    @Test
+    void realmAssignmentCannotExpandBlankCredentialRealmBoundary() {
+        CredentialUserIdPassword credential = CredentialUserIdPassword.builder()
+            .userId("local-test")
+            .subject("local-test")
+            .domainContext(DomainContext.builder()
+                .tenantId("home")
+                .orgRefName("home")
+                .accountId("home")
+                .defaultRealm("home-realm")
+                .build())
+            .lastUpdate(new Date())
+            .build();
+
+        SecurityUtils securityUtils = new SecurityUtils();
+        assertTrue(CustomTokenAuthProvider.credentialAuthorizesRealm(
+            securityUtils, credential, "home-realm"));
+        assertFalse(CustomTokenAuthProvider.credentialAuthorizesRealm(
+            securityUtils, credential, "another-realm"));
     }
 }

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/Organization.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/Organization.java
@@ -31,10 +31,15 @@ public class Organization extends FullBaseModel {
    @Override
    public void setRefName(String refName) {
 
-      // check if the refName follows the regular expression: regexp = "^[a-zA-Z0-9]+\\.[a-zA-Z0-9]{1,3}$"
-      // if not, throw an exception
-      if (!refName.matches("^[a-zA-Z0-9]+\\.[a-zA-Z0-9]{1,3}$")) {
-         throw new IllegalArgumentException("refName must follow the pattern 'string.min1.period.string.min1.max3'");
+      if (refName == null || refName.isBlank()) {
+         throw new IllegalArgumentException("refName must not be blank");
+      }
+
+      String trimmed = refName.trim();
+      boolean safeDirectoryRef = trimmed.matches("^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$");
+      boolean dnsDirectoryRef = trimmed.matches("^[a-zA-Z0-9][a-zA-Z0-9-]*(\\.[a-zA-Z0-9][a-zA-Z0-9-]*)+$");
+      if (!safeDirectoryRef && !dnsDirectoryRef) {
+         throw new IllegalArgumentException("refName must be a safe directory id or DNS-style organization id");
       }
 
       // check if the refName already exists in the database
@@ -43,7 +48,7 @@ public class Organization extends FullBaseModel {
 
       // call the parent class method to set the refName
 
-      super.setRefName(refName);
+      super.setRefName(trimmed);
    }
 
 

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/Policy.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/Policy.java
@@ -3,6 +3,7 @@ package com.e2eq.framework.model.security;
 import dev.morphia.annotations.Entity;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import com.e2eq.framework.model.persistent.base.FullBaseModel;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -37,7 +38,10 @@ public class Policy extends FullBaseModel {
    protected String description;
    protected List<Rule> rules = new ArrayList<>();
 
-   // Transient field to track policy source
+   // Non-persistent response metadata: policy source remains invisible to Morphia
+   // persistence, but must be visible to API clients so built-in policies are
+   // auditable instead of looking like hidden fail-open behavior.
+   @JsonProperty("policySource")
    protected transient String policySource;
 
 

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/UserRealmRole.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/UserRealmRole.java
@@ -22,9 +22,11 @@ import java.util.List;
  *
  * Consumed at token issuance (the IdP unions these into per-realm role
  * claims) and by the tenant-plane routing registry (JWT claims → realm
- * datastore). The credential's flat roles[] remains the user's roles in
- * their default realm (compatibility); these assignments extend, never
- * replace, that behavior.
+ * datastore). The credential remains the authoritative realm-access boundary:
+ * an assignment can supply roles and application grants inside an authorized
+ * realm, but must never authorize a realm excluded by the credential's
+ * authorizedRealms/realmRegEx contract. The credential's flat roles[] remains
+ * the user's roles in their default realm for compatibility.
  */
 @Entity
 @RegisterForReflection

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/AccessibleRealmInfo.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/AccessibleRealmInfo.java
@@ -2,6 +2,8 @@ package com.e2eq.framework.rest.models;
 
 import com.e2eq.framework.model.security.Realm;
 import com.e2eq.framework.model.security.RealmSetupStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,6 +13,7 @@ import java.util.Date;
 @Data
 @NoArgsConstructor
 @RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AccessibleRealmInfo {
     private String refName;
     private String displayName;
@@ -21,6 +24,7 @@ public class AccessibleRealmInfo {
     private Integer readySolutionCount;
     private Integer pendingSeedPackCount;
     private Integer pendingMigrationCount;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Date setupLastUpdated;
 
     public AccessibleRealmInfo(String refName, String displayName) {

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthResponse.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/AuthResponse.java
@@ -1,6 +1,7 @@
 package com.e2eq.framework.rest.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,6 +13,7 @@ import java.util.List;
 @EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthResponse {
 
     protected String access_token;

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/RestError.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/RestError.java
@@ -1,6 +1,7 @@
 package com.e2eq.framework.rest.models;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -10,6 +11,16 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 
+/**
+ * Shared REST error payload.
+ *
+ * <p>The optional properties in this model are non-null when present in the
+ * generated OpenAPI contract. Omitting absent values keeps the serialized
+ * payload aligned with that contract; emitting explicit JSON {@code null}
+ * values causes generated clients to reject the response before they can
+ * surface the underlying API error.</p>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Data
 @EqualsAndHashCode
 @SuperBuilder

--- a/quantum-models/src/test/java/com/e2eq/framework/model/security/OrganizationTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/security/OrganizationTest.java
@@ -1,0 +1,34 @@
+package com.e2eq.framework.model.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OrganizationTest {
+
+    @Test
+    void acceptsSafeDirectoryReference() {
+        Organization organization = new Organization();
+
+        organization.setRefName("basf-global-bulk-shipper");
+
+        assertEquals("basf-global-bulk-shipper", organization.getRefName());
+    }
+
+    @Test
+    void acceptsDnsStyleOrganizationReference() {
+        Organization organization = new Organization();
+
+        organization.setRefName("basf.com");
+
+        assertEquals("basf.com", organization.getRefName());
+    }
+
+    @Test
+    void rejectsUnsafeOrganizationReference() {
+        Organization organization = new Organization();
+
+        assertThrows(IllegalArgumentException.class, () -> organization.setRefName("basf/com"));
+    }
+}

--- a/quantum-models/src/test/java/com/e2eq/framework/rest/models/AuthResponseTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/rest/models/AuthResponseTest.java
@@ -1,0 +1,56 @@
+package com.e2eq.framework.rest.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void omitsAbsentOptionalPropertiesFromSerializedPayload() throws Exception {
+        AuthResponse response = new AuthResponse("access", "refresh", 123L);
+
+        JsonNode payload = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        assertEquals("access", payload.get("access_token").asText());
+        assertEquals("refresh", payload.get("refresh_token").asText());
+        assertEquals(123L, payload.get("expires_at").asLong());
+        assertEquals("access", payload.get("accessToken").asText());
+        assertEquals("refresh", payload.get("refreshToken").asText());
+        assertEquals(123L, payload.get("expiresAt").asLong());
+        assertFalse(payload.has("mongodburl"));
+        assertFalse(payload.has("roles"));
+        assertFalse(payload.has("authProvider"));
+        assertFalse(payload.has("applications"));
+        assertFalse(payload.has("activeApplication"));
+        assertFalse(payload.has("accessibleRealms"));
+    }
+
+    @Test
+    void serializesAccessibleRealmOptionalDateAsStringAndOmitsNullSummary() throws Exception {
+        AccessibleRealmInfo realm = new AccessibleRealmInfo("demo", "Demo");
+        realm.setSetupLastUpdated(new Date(0));
+        AuthResponse response = new AuthResponse("access", "refresh", 123L);
+        response.setRoles(List.of("admin"));
+        response.setAuthProvider("custom");
+        response.setAccessibleRealms(List.of(realm));
+
+        JsonNode payload = objectMapper.readTree(objectMapper.writeValueAsString(response));
+        JsonNode realmPayload = payload.get("accessibleRealms").get(0);
+
+        assertEquals("admin", payload.get("roles").get(0).asText());
+        assertEquals("custom", payload.get("authProvider").asText());
+        assertEquals("demo", realmPayload.get("refName").asText());
+        assertTrue(realmPayload.get("setupLastUpdated").isTextual());
+        assertFalse(realmPayload.has("setupSummary"));
+    }
+}

--- a/quantum-models/src/test/java/com/e2eq/framework/rest/models/RestErrorTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/rest/models/RestErrorTest.java
@@ -1,0 +1,48 @@
+package com.e2eq.framework.rest.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class RestErrorTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void omitsAbsentOptionalPropertiesFromSerializedPayload() throws Exception {
+        RestError error = RestError.builder()
+                .status(404)
+                .statusMessage("Not found")
+                .build();
+
+        JsonNode payload = objectMapper.readTree(objectMapper.writeValueAsString(error));
+
+        assertEquals(404, payload.get("status").asInt());
+        assertEquals("Not found", payload.get("statusMessage").asText());
+        assertFalse(payload.has("reasonMessage"));
+        assertFalse(payload.has("debugMessage"));
+        assertFalse(payload.has("constraintViolations"));
+    }
+
+    @Test
+    void retainsOptionalPropertiesWhenTheyArePresent() throws Exception {
+        RestError error = RestError.builder()
+                .status(400)
+                .statusMessage("Validation failed")
+                .reasonMessage("Invalid request")
+                .debugMessage("requestId=123")
+                .constraintViolations(Set.of("name must not be blank"))
+                .build();
+
+        JsonNode payload = objectMapper.readTree(objectMapper.writeValueAsString(error));
+
+        assertEquals("Invalid request", payload.get("reasonMessage").asText());
+        assertEquals("requestId=123", payload.get("debugMessage").asText());
+        assertEquals("name must not be blank", payload.get("constraintViolations").get(0).asText());
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/migration/base/MigrationService.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/migration/base/MigrationService.java
@@ -254,16 +254,19 @@ public class MigrationService {
    }
 
    public void dropIndexOnCollection (String realm, String collectionName) {
+      requireRealmOwnedByThisMigrationService(realm, "drop indexes");
       mongoClient.getDatabase(realm).getCollection(collectionName).dropIndexes();
    }
 
    public void applyIndexes (String realmId) {
       Objects.requireNonNull(realmId, "RealmId cannot be null");
+      requireRealmOwnedByThisMigrationService(realmId, "apply indexes");
       morphiaDataStoreWrapper.getDataStore(realmId).applyIndexes();
    }
 
    public void applyIndexes (String realmId, String collection) {
       Objects.requireNonNull(realmId, "RealmId cannot be null");
+      requireRealmOwnedByThisMigrationService(realmId, "apply indexes");
       Optional<EntityModel> em = morphiaDataStoreWrapper.getDataStore(realmId).getMapper().getMappedEntities().stream().filter(entity -> entity.collectionName().equals(collection)).findFirst();
       if (!em.isPresent()) {
          throw new NotFoundException(String.format("Collection %s not found in realm %s", collection, realmId));
@@ -278,6 +281,7 @@ public class MigrationService {
     */
    public void applyAllIndexes(String realmId) {
       Objects.requireNonNull(realmId);
+      requireRealmOwnedByThisMigrationService(realmId, "apply all indexes");
       var datastore = morphiaDataStoreWrapper.getDataStore(realmId);
       var entities = datastore.getMapper().getMappedEntities();
       Log.infof("applyAllIndexes: ensuring indexes for %d mapped entity types in realm %s", entities.size(), realmId);
@@ -295,6 +299,7 @@ public class MigrationService {
 
    public void dropAllIndexes (String realmId) {
       Objects.requireNonNull(realmId, "RealmId cannot be null");
+      requireRealmOwnedByThisMigrationService(realmId, "drop all indexes");
       morphiaDataStoreWrapper.getDataStore(realmId).getMapper().getMappedEntities().forEach(entity -> {
          mongoClient.getDatabase(realmId).getCollection(entity.collectionName()).dropIndexes();
       });
@@ -521,6 +526,7 @@ public class MigrationService {
    }
 
    public void runChangeSetBean(String changeSetName, String realm, MultiEmitter<? super String> emitter) throws Exception {
+      requireRealmOwnedByThisMigrationService(realm, "run change set");
 
       List<ChangeSetBean> changeSets = getAllChangeSetBeans();
       Optional<ChangeSetBean> changeSetBeanOptional = changeSets.stream().filter(changeSetBean -> changeSetBean.getName().equals(changeSetName)).findFirst();
@@ -552,6 +558,7 @@ public class MigrationService {
    }
 
    public void runAllUnRunMigrations (String realm, MultiEmitter<? super String> emitter) {
+      requireRealmOwnedByThisMigrationService(realm, "run migrations");
 
       Log.info("-- Running all migrations for realm: " + realm);
       List<ChangeSetBean> changeSetList = getAllPendingChangeSetBeans(realm, emitter);
@@ -668,5 +675,38 @@ public class MigrationService {
         record.setSuccessful(true);
         return record;
     }
+
+   private void requireRealmOwnedByThisMigrationService(String realm, String operation) {
+      if (!seedSystemOnly || isSystemRealm(realm) || isExplicitlyConfiguredMigrationRealm(realm)) {
+         return;
+      }
+      throw new IllegalStateException(String.format(
+         "Refusing to %s for realm %s because quantum.realm.seed-system-only=true and this service only owns system realm %s. "
+            + "Set quantum.migration.apply.realms to explicitly opt in an additional managed realm.",
+         operation,
+         realm,
+         systemRealm
+      ));
+   }
+
+   private boolean isSystemRealm(String realm) {
+      return Objects.equals(realm, systemRealm);
+   }
+
+   private boolean isExplicitlyConfiguredMigrationRealm(String realm) {
+      if (startupRealmsCsv.isEmpty()) {
+         return false;
+      }
+      String csv = startupRealmsCsv.get().trim();
+      if (csv.isEmpty() || csv.equalsIgnoreCase("none")) {
+         return false;
+      }
+      for (String part : csv.split(",")) {
+         if (Objects.equals(part.trim(), realm)) {
+            return true;
+         }
+      }
+      return false;
+   }
 
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/PolicyRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/PolicyRepo.java
@@ -10,8 +10,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class PolicyRepo extends MorphiaRepo<Policy> {
@@ -69,7 +71,10 @@ public class PolicyRepo extends MorphiaRepo<Policy> {
          Collection<String> identities) {
 
       Map<String, List<Rule>> rules = new HashMap<>();
-      Set<String> identitySet = new java.util.HashSet<>(identities);
+      Set<String> identitySet = identities.stream()
+         .filter(identity -> identity != null && !identity.isBlank())
+         .map(identity -> identity.toLowerCase(Locale.ROOT))
+         .collect(Collectors.toSet());
 
       // First add default system policies (filter to matching identities)
       if (defaultSystemPolicies != null) {
@@ -166,6 +171,6 @@ public class PolicyRepo extends MorphiaRepo<Policy> {
       if (identity == null || identity.isBlank()) {
          identity = p.getPrincipalId();
       }
-      return identity;
+      return identity == null ? null : identity.toLowerCase(Locale.ROOT);
    }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/changesets/AddAnonymousAuthAndRegistrationRules.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/changesets/AddAnonymousAuthAndRegistrationRules.java
@@ -1,0 +1,155 @@
+package com.e2eq.framework.model.persistent.morphia.changesets;
+
+import com.e2eq.framework.model.persistent.migration.base.ChangeSetBase;
+import com.e2eq.framework.model.persistent.morphia.PolicyRepo;
+import com.e2eq.framework.model.security.Policy;
+import com.e2eq.framework.model.security.Rule;
+import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.SecurityURI;
+import com.e2eq.framework.model.securityrules.SecurityURIBody;
+import com.e2eq.framework.model.securityrules.SecurityURIHeader;
+import com.e2eq.framework.util.EnvConfigUtils;
+import com.e2eq.framework.util.SecurityUtils;
+import com.mongodb.client.MongoClient;
+import dev.morphia.transactions.MorphiaSession;
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.Startup;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@Startup
+@ApplicationScoped
+public class AddAnonymousAuthAndRegistrationRules extends ChangeSetBase {
+
+    private static final String DEFAULT_ANONYMOUS_POLICY = "defaultAnonymousPolicy";
+
+    @Inject
+    PolicyRepo policyRepo;
+
+    @Inject
+    EnvConfigUtils envConfigUtils;
+
+    @Override
+    public String getId() {
+        return "00006";
+    }
+
+    @Override
+    public String getDbFromVersion() {
+        return "1.0.4";
+    }
+
+    @Override
+    public int getDbFromVersionInt() {
+        return 104;
+    }
+
+    @Override
+    public String getDbToVersion() {
+        return "1.0.5";
+    }
+
+    @Override
+    public int getDbToVersionInt() {
+        return 105;
+    }
+
+    @Override
+    public int getPriority() {
+        return 100;
+    }
+
+    @Override
+    public String getAuthor() {
+        return "Quantum Framework";
+    }
+
+    @Override
+    public String getName() {
+        return "Add Anonymous Auth and Registration Rules";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Persist anonymous policies for the explicit public authentication and registration repo gates.";
+    }
+
+    @Override
+    public String getScope() {
+        return "ALL";
+    }
+
+    @Override
+    public int getChangeSetVersion() {
+        return 4;
+    }
+
+    @Override
+    public void execute(MorphiaSession session, MongoClient mongoClient, MultiEmitter<? super String> emitter) {
+        String realm = session.getDatabase().getName();
+        Log.infof("Adding anonymous auth and registration security rules: %s", realm);
+        emitter.emit(String.format("Adding anonymous auth and registration security rules: %s", realm));
+
+        Policy policy = policyRepo.findByRefName(session, DEFAULT_ANONYMOUS_POLICY).orElseGet(this::newAnonymousPolicy);
+        addRuleIfMissing(policy, "SECURITY", "CREDENTIAL_USERID_PASSWORD", "authenticate",
+                "allow anonymous users to authenticate through explicit login scope");
+        addRuleIfMissing(policy, "SECURITY", "APPLICATION_REGISTRATION", "view",
+                "allow anonymous users to inspect registration availability through explicit registration scope");
+        addRuleIfMissing(policy, "SECURITY", "APPLICATION_REGISTRATION", "create",
+                "allow anonymous users to create registration requests through explicit registration scope");
+
+        policyRepo.save(session, policy);
+    }
+
+    private Policy newAnonymousPolicy() {
+        Policy policy = new Policy();
+        policy.setPrincipalId(envConfigUtils.getAnonymousUserId());
+        policy.setDisplayName("anonymous policy");
+        policy.setDescription("Anonymous users may use only explicitly scoped public platform entry points.");
+        policy.setRefName(DEFAULT_ANONYMOUS_POLICY);
+        return policy;
+    }
+
+    private void addRuleIfMissing(Policy policy, String area, String domain, String action, String name) {
+        boolean exists = policy.getRules().stream()
+                .map(Rule::getSecurityURI)
+                .filter(uri -> uri != null && uri.getHeader() != null)
+                .anyMatch(uri -> matches(uri.getHeader(), area, domain, action));
+        if (exists) {
+            return;
+        }
+        policy.getRules().add(buildAnonymousRule(area, domain, action, name));
+    }
+
+    private boolean matches(SecurityURIHeader header, String area, String domain, String action) {
+        return area.equalsIgnoreCase(header.getArea())
+                && domain.equalsIgnoreCase(header.getFunctionalDomain())
+                && action.equalsIgnoreCase(header.getAction());
+    }
+
+    private Rule buildAnonymousRule(String area, String domain, String action, String name) {
+        SecurityURIHeader header = new SecurityURIHeader.Builder()
+                .withIdentity(envConfigUtils.getAnonymousUserId())
+                .withArea(area)
+                .withFunctionalDomain(domain)
+                .withAction(action)
+                .build();
+
+        SecurityURIBody body = new SecurityURIBody.Builder()
+                .withAccountNumber(envConfigUtils.getSystemAccountNumber())
+                .withRealm(envConfigUtils.getSystemRealm())
+                .withTenantId(SecurityUtils.any)
+                .withOwnerId(SecurityUtils.any)
+                .withOrgRefName(envConfigUtils.getSystemOrgRefName())
+                .withDataSegment(SecurityUtils.any)
+                .build();
+
+        return new Rule.Builder()
+                .withName(name)
+                .withSecurityURI(new SecurityURI(header, body))
+                .withEffect(RuleEffect.ALLOW)
+                .withFinalRule(true)
+                .build();
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
@@ -18,6 +18,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.enterprise.inject.Instance;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -705,6 +706,66 @@ public class RuleContext {
        Rule r = tenantAdminbuilder.build();
        this.addRule(header, r);
 
+       addAnonymousApplicationRegistrationRule("view");
+       addAnonymousApplicationRegistrationRule("create");
+       addAnonymousAuthenticationRule();
+
+    }
+
+    private void addAnonymousAuthenticationRule() {
+        SecurityURIHeader header = new SecurityURIHeader.Builder()
+                .withIdentity("ANONYMOUS")
+                .withArea("SECURITY")
+                .withFunctionalDomain("CREDENTIAL_USERID_PASSWORD")
+                .withAction("authenticate")
+                .build();
+
+        SecurityURIBody body = new SecurityURIBody.Builder()
+                .withRealm("*")
+                .withOrgRefName("*")
+                .withAccountNumber("*")
+                .withTenantId("*")
+                .withOwnerId("*")
+                .withDataSegment("*")
+                .build();
+
+        Rule rule = new Rule.Builder()
+                .withName("Anonymous can authenticate credentials")
+                .withDescription("Public login endpoints may resolve credentials only inside the explicit authentication action.")
+                .withSecurityURI(new SecurityURI(header, body))
+                .withEffect(RuleEffect.ALLOW)
+                .withPriority(0)
+                .withFinalRule(true)
+                .build();
+        this.addRule(header, rule);
+    }
+
+    private void addAnonymousApplicationRegistrationRule(String action) {
+        SecurityURIHeader header = new SecurityURIHeader.Builder()
+                .withIdentity("ANONYMOUS")
+                .withArea("SECURITY")
+                .withFunctionalDomain("APPLICATION_REGISTRATION")
+                .withAction(action)
+                .build();
+
+        SecurityURIBody body = new SecurityURIBody.Builder()
+                .withRealm("*")
+                .withOrgRefName("*")
+                .withAccountNumber("*")
+                .withTenantId("*")
+                .withOwnerId("*")
+                .withDataSegment("*")
+                .build();
+
+        Rule rule = new Rule.Builder()
+                .withName("Anonymous can " + action + " registration requests")
+                .withDescription("Public registration endpoints may access application-registration records through an explicit anonymous policy.")
+                .withSecurityURI(new SecurityURI(header, body))
+                .withEffect(RuleEffect.ALLOW)
+                .withPriority(0)
+                .withFinalRule(true)
+                .build();
+        this.addRule(header, rule);
     }
 
     /**
@@ -955,7 +1016,7 @@ public class RuleContext {
      * @return an optional list of rules
      */
     public Optional<List<Rule>> rulesForIdentity(@NotNull String identity, Map<String, List<Rule>> rulesMap) {
-        List<Rule> ruleList = rulesMap.get(identity);
+        List<Rule> ruleList = rulesMap.get(identity.toLowerCase(java.util.Locale.ROOT));
         if (ruleList == null) {
             return Optional.empty();
         }
@@ -969,7 +1030,7 @@ public class RuleContext {
      * @return an optional list of rules
      */
     public Optional<List<Rule>> rulesForIdentity(@NotNull String identity) {
-        List<Rule> ruleList = defaultSystemRules.get(identity);
+        List<Rule> ruleList = defaultSystemRules.get(identity.toLowerCase(java.util.Locale.ROOT));
         if (ruleList == null) {
             return Optional.empty();
         }
@@ -1098,12 +1159,12 @@ public class RuleContext {
         java.util.Set<String> identities = new java.util.HashSet<>();
         if (pcontext != null) {
             if (pcontext.getUserId() != null && !pcontext.getUserId().isBlank()) {
-                identities.add(pcontext.getUserId());
+                identities.add(pcontext.getUserId().toLowerCase(java.util.Locale.ROOT));
             }
             if (pcontext.getRoles() != null) {
                 for (String role : pcontext.getRoles()) {
                     if (role != null && !role.isBlank()) {
-                        identities.add(role);
+                        identities.add(role.toLowerCase(java.util.Locale.ROOT));
                     }
                 }
             }
@@ -2038,7 +2099,12 @@ public class RuleContext {
         SecurityCheckResponse response = this.checkRules(pcontext, rcontext);
 
         if (response.getFinalEffect() != RuleEffect.ALLOW) {
-            return filters;
+            throw new ForbiddenException(String.format(
+                    "Access denied: user=%s, area=%s, domain=%s, action=%s",
+                    pcontext.getUserId(),
+                    rcontext.getArea(),
+                    rcontext.getFunctionalDomain(),
+                    rcontext.getAction()));
         }
 
         List<Filter> andFilters = new ArrayList<>();

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleIndex.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleIndex.java
@@ -69,7 +69,7 @@ final class RuleIndex {
         return idx;
     }
 
-    private static String n(String s) { return (s == null || s.isBlank()) ? "*" : s; }
+    private static String n(String s) { return (s == null || s.isBlank()) ? "*" : s.toLowerCase(Locale.ROOT); }
 
     private static Node step(Node node, String key) {
         if ("*".equals(key)) {
@@ -95,12 +95,12 @@ final class RuleIndex {
     List<Rule> getApplicableRules(PrincipalContext pc, ResourceContext rc) {
         // identities include the principalId and associated roles
         List<String> identities = new ArrayList<>();
-        if (pc.getUserId() != null) identities.add(pc.getUserId());
-        identities.addAll(Arrays.asList(pc.getRoles()));
+        if (pc.getUserId() != null) identities.add(n(pc.getUserId()));
+        identities.addAll(Arrays.stream(pc.getRoles()).map(RuleIndex::n).toList());
 
-        String area = rc.getArea() == null ? "*" : rc.getArea();
-        String domain = rc.getFunctionalDomain() == null ? "*" : rc.getFunctionalDomain();
-        String action = rc.getAction() == null ? "*" : rc.getAction();
+        String area = n(rc.getArea());
+        String domain = n(rc.getFunctionalDomain());
+        String action = n(rc.getAction());
 
         // Use a linked hash set to preserve insertion order and avoid duplicates
         LinkedHashSet<Rule> out = new LinkedHashSet<>();

--- a/quantum-oauth-server/src/main/java/com/e2eq/framework/oauth/resource/OAuthUserInfoResource.java
+++ b/quantum-oauth-server/src/main/java/com/e2eq/framework/oauth/resource/OAuthUserInfoResource.java
@@ -1,5 +1,7 @@
 package com.e2eq.framework.oauth.resource;
 
+import com.e2eq.framework.annotations.FunctionalAction;
+import com.e2eq.framework.annotations.FunctionalMapping;
 import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -18,6 +20,7 @@ import java.util.Map;
  */
 @Path("/oauth/userinfo")
 @Authenticated
+@FunctionalMapping(area = "SECURITY", domain = "IDENTITY")
 public class OAuthUserInfoResource {
 
     @Inject
@@ -25,6 +28,7 @@ public class OAuthUserInfoResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @FunctionalAction("VIEW")
     public Response userinfo() {
         if (jwt.getSubject() == null) {
             return Response.status(401)


### PR DESCRIPTION
Consolidates auth control-plane hardening, schema-safe auth responses, explicit seed write actions, anonymous registration policy seeding, and coverage for credential/domain contracts.\n\nValidated locally with mvn clean install for quantum-framework and quantum-enterprise.