### PR TITLE
Add application-owned realms, contract hash, and tenant entity isolation

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/ApplicationResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/ApplicationResource.java
@@ -1,0 +1,19 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.annotations.FunctionalMapping;
+import com.e2eq.framework.model.persistent.morphia.ApplicationRepo;
+import com.e2eq.framework.model.security.Application;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/security/application")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@FunctionalMapping(area = "security", domain = "application")
+public class ApplicationResource extends BaseResource<Application, ApplicationRepo>{
+   protected ApplicationResource (ApplicationRepo repo) {
+      super(repo);
+   }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/ContractHashResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/ContractHashResource.java
@@ -1,0 +1,107 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.service.contract.CanonicalSpecHash;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.quarkus.logging.Log;
+import jakarta.annotation.security.PermitAll;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Serves this application's contract identity for generated-SDK drift checks.
+ *
+ * <p>Generated clients embed the canonical hash of the OpenAPI document they
+ * were generated from ({@code GeneratedContract.SPEC_SHA256}); at handshake
+ * they compare it against this endpoint and fail fast on mismatch — the
+ * generated code is out of date and must be regenerated.
+ *
+ * <p>{@code quantum.contract.openapi-location} names the authoritative
+ * checked-in contract document (classpath resource, or a filesystem path for
+ * dev), the SAME document SDK generation consumes — e.g.
+ * {@code contracts/quantum-auth-service.openapi.yaml} packaged as a resource.
+ * Unset → 404 (this service declares no generated contract). Configured but
+ * unreadable or unhashable → 500, never a silent fallback.
+ */
+@Path("/contract-hash")
+@ApplicationScoped
+public class ContractHashResource {
+
+    @ConfigProperty(name = "quantum.contract.openapi-location")
+    Optional<String> openapiLocation;
+
+    private volatile Map<String, String> cached;
+
+    @GET
+    @PermitAll
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response get() {
+        if (openapiLocation.isEmpty() || openapiLocation.get().isBlank()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                .entity(Map.of(
+                    "statusMessage",
+                    "This service does not declare a generated contract (quantum.contract.openapi-location is unset)"))
+                .build();
+        }
+        Map<String, String> body = cached;
+        if (body == null) {
+            body = computeContractIdentity(openapiLocation.get().trim());
+            cached = body;
+        }
+        return Response.ok(body).build();
+    }
+
+    private Map<String, String> computeContractIdentity(String location) {
+        try {
+            JsonNode spec = readSpec(location);
+            String hash = CanonicalSpecHash.sha256(spec);
+            JsonNode version = spec.path("info").path("version");
+            if (!version.isTextual() || version.textValue().isBlank()) {
+                throw new IllegalStateException(
+                    "Contract document has no info.version (required for the semver compatibility handshake): " + location);
+            }
+            Log.infof("Contract identity: location=%s algorithm=%s spec_sha256=%s contract_version=%s",
+                location, CanonicalSpecHash.ALGORITHM, hash, version.textValue());
+            return Map.of(
+                "spec_sha256", hash,
+                "algorithm", CanonicalSpecHash.ALGORITHM,
+                "contract_version", version.textValue(),
+                "source", location);
+        } catch (IOException | RuntimeException e) {
+            // Configured but unusable is a deployment defect; surface it, don't mask it.
+            throw new IllegalStateException(
+                "Unable to compute contract hash from configured quantum.contract.openapi-location=" + location, e);
+        }
+    }
+
+    private JsonNode readSpec(String location) throws IOException {
+        byte[] raw;
+        java.nio.file.Path file = java.nio.file.Path.of(location);
+        if (Files.isRegularFile(file)) {
+            raw = Files.readAllBytes(file);
+        } else {
+            try (InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(location)) {
+                if (stream == null) {
+                    throw new IOException("Contract document not found on filesystem or classpath: " + location);
+                }
+                raw = stream.readAllBytes();
+            }
+        }
+        ObjectMapper mapper = location.endsWith(".json")
+            ? new ObjectMapper()
+            : new ObjectMapper(new YAMLFactory());
+        return mapper.readTree(raw);
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/TenantProvisioningResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/TenantProvisioningResource.java
@@ -48,6 +48,7 @@ public class TenantProvisioningResource {
         public String adminUsername;               // legacy display field; not used for subject identity
         public String adminSubject;                // optional stable subject override; defaults to adminUserId
         @NotBlank public String adminPassword;     // plaintext; hashed in service
+        public String applicationId;               // owning application; falls back to quantum.tenant.provisioning.default-application
         public List<String> archetypes;            // legacy alias for seedArchetypes
         public List<String> seedArchetypes;        // optional list of seed-framework archetype names
     }
@@ -84,6 +85,7 @@ public class TenantProvisioningResource {
                     .adminUserId(req.adminUserId)
                     .adminSubject(resolveAdminSubject(req))
                     .adminPassword(req.adminPassword)
+                    .applicationId(req.applicationId)
                     .archetypes(archetypes)
                     .overwriteAll(true)
                     .build()

--- a/quantum-framework/src/main/java/com/e2eq/framework/security/IdentityAssembler.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/security/IdentityAssembler.java
@@ -72,23 +72,16 @@ public class IdentityAssembler {
             if (cred.getRoles() != null) {
                 for (String r : cred.getRoles()) if (r != null && !r.isBlank()) mergedRoles.add(r);
             }
-            // merge user group roles via profile
-            // Use the credential's realm context instead of hardcoded system realm
+            // Merge user group roles through the central auth/system realm first.
+            // Tenant-local lookup remains only as a compatibility fallback for embedded auth mode.
             String credentialRealm = (cred.getDomainContext() != null)
                 ? cred.getDomainContext().getDefaultRealm()
                 : systemRealm;
             try {
-                var userProfileOpt = userProfileRepo.getBySubject(credentialRealm, cred.getSubject());
-                if (userProfileOpt.isPresent()) {
-                    var groups = userGroupRepo.findByUserProfileRef(userProfileOpt.get().createEntityReference());
-                    if (groups != null) {
-                        for (UserGroup g : groups) {
-                            if (g != null && g.getRoles() != null) {
-                                for (String r : g.getRoles()) if (r != null && !r.isBlank()) mergedRoles.add(r);
-                            }
-                        }
-                    }
-                } else {
+                boolean foundCentralProfile = mergeUserGroupRoles(mergedRoles, systemRealm, cred.getSubject());
+                boolean foundTenantProfile = systemRealm.equalsIgnoreCase(credentialRealm)
+                        || mergeUserGroupRoles(mergedRoles, credentialRealm, cred.getSubject());
+                if (!foundCentralProfile && !foundTenantProfile) {
                     Log.warnf("No user profile found for credential subject=%s when trying to resolve roles / user groups", cred.getSubject());
                 }
             } catch (Exception e) {
@@ -114,5 +107,25 @@ public class IdentityAssembler {
         builder.addAttribute("auth_time", System.currentTimeMillis());
 
         return builder.build();
+    }
+
+    private boolean mergeUserGroupRoles(Set<String> mergedRoles, String realm, String subject) {
+        if (realm == null || realm.isBlank() || subject == null || subject.isBlank()) {
+            return false;
+        }
+        var userProfileOpt = userProfileRepo.getBySubject(realm, subject);
+        if (userProfileOpt.isEmpty()) {
+            return false;
+        }
+        var groups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
+                realm, userProfileOpt.get().createEntityReference());
+        if (groups != null) {
+            for (UserGroup g : groups) {
+                if (g != null && g.getRoles() != null) {
+                    for (String r : g.getRoles()) if (r != null && !r.isBlank()) mergedRoles.add(r);
+                }
+            }
+        }
+        return true;
     }
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
@@ -9,6 +9,7 @@ import com.e2eq.framework.system.catalog.RealmCatalogService;
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.base.EntityReference;
 import com.e2eq.framework.model.persistent.migration.base.MigrationService;
+import com.e2eq.framework.model.persistent.morphia.ApplicationRepo;
 import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
 import com.e2eq.framework.model.persistent.morphia.OrganizationRepo;
 import com.e2eq.framework.model.persistent.morphia.RealmRepo;
@@ -19,6 +20,7 @@ import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
 import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.DomainContext;
 import com.e2eq.framework.model.security.Organization;
+import com.e2eq.framework.model.security.Application;
 import com.e2eq.framework.model.security.Realm;
 import com.e2eq.framework.model.security.RealmTenantMembership;
 import com.e2eq.framework.model.security.RealmSetupStatus;
@@ -42,6 +44,7 @@ import jakarta.inject.Inject;
 import lombok.Builder;
 import lombok.Data;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.io.IOException;
 import java.util.*;
@@ -77,6 +80,26 @@ public class TenantProvisioningService implements TenantLifecycle {
 
     @Inject SeedDiscoveryService seedDiscoveryService;
 
+    /**
+     * Compatibility escape hatch for legacy embedded deployments that projected
+     * user profile/group records into tenant realms. Default is false because
+     * credentials, organizations, groups, policies, and realm assignments are
+     * system-plane resources owned by the auth/system control plane.
+     */
+    @ConfigProperty(name = "quantum.tenant.provisioning.create-tenant-identity-projections", defaultValue = "false")
+    boolean createTenantIdentityProjections;
+
+    /**
+     * Every realm belongs to exactly one application; the realm catalog doubles
+     * as the application-usage registry. When a provision command names no
+     * application this default applies; with neither set, provisioning fails
+     * fast rather than creating an unowned realm.
+     */
+    @ConfigProperty(name = "quantum.tenant.provisioning.default-application")
+    Optional<String> defaultApplicationId;
+
+    @Inject ApplicationRepo applicationRepo;
+
     public static class ProvisionResult {
         public String realmId;
         public boolean realmCreated;
@@ -105,6 +128,8 @@ public class TenantProvisioningService implements TenantLifecycle {
         private String adminUserId;
         private String adminSubject;
         private String adminPassword;
+        /** Owning application for the realm; falls back to quantum.tenant.provisioning.default-application. */
+        private String applicationId;
         @Builder.Default
         private List<String> archetypes = List.of();
         @Builder.Default
@@ -223,6 +248,9 @@ public class TenantProvisioningService implements TenantLifecycle {
             .ownerId(command.getAdminUserId())
             .build();
 
+        // NOTE: the owning application is resolved and attached in
+        // ensureRealmCatalog (the persistence step) so context initialization
+        // stays a pure computation.
         Realm desiredRealm = Realm.builder()
             .refName(realmId)
             .displayName(normalizedTenantDisplayName)
@@ -288,6 +316,44 @@ public class TenantProvisioningService implements TenantLifecycle {
             .build();
     }
 
+    /** Command applicationId, else the configured platform default, else null. */
+    private String resolveApplicationIdOrNull(ProvisionTenantCommand command) {
+        if (command.getApplicationId() != null && !command.getApplicationId().isBlank()) {
+            return command.getApplicationId().trim();
+        }
+        Optional<String> fallback = defaultApplicationId == null ? Optional.empty() : defaultApplicationId;
+        return fallback.map(String::trim).filter(value -> !value.isEmpty()).orElse(null);
+    }
+
+    private String requireApplicationId(ProvisionTenantCommand command) {
+        String applicationId = resolveApplicationIdOrNull(command);
+        if (applicationId == null) {
+            throw new IllegalArgumentException(
+                "applicationId is required: every realm belongs to exactly one application. "
+                    + "Pass applicationId in the provision command or configure "
+                    + "quantum.tenant.provisioning.default-application.");
+        }
+        return applicationId;
+    }
+
+    /** Idempotently registers the owning application in the global registry. */
+    private Application registerOwningApplication(String applicationId, String ownerUserId) {
+        return applicationRepo.ensureRegistered(
+            applicationId,
+            DataDomain.builder()
+                .orgRefName(envConfigUtils.getSystemOrgRefName())
+                .accountNum(envConfigUtils.getSystemAccountNumber())
+                .tenantId(envConfigUtils.getSystemTenantId())
+                .ownerId(ownerUserId)
+                .build());
+    }
+
+    private static String applicationRefName(Realm realm) {
+        return realm == null || realm.getApplicationRef() == null
+            ? null
+            : realm.getApplicationRef().getEntityRefName();
+    }
+
     public void ensureRealmCatalog(ProvisioningContext context) {
         Log.infof("  computed realmId: %s", context.getRealmId());
         Optional<Realm> existingByEmailDomain = realmCatalog.findByEmailDomain(
@@ -338,17 +404,44 @@ public class TenantProvisioningService implements TenantLifecycle {
                 diffs.add(String.format("defaultPerspective: existing='%s', requested='%s'",
                     existing.getDefaultPerspective(), context.getDesiredRealm().getDefaultPerspective()));
             }
+            // A realm belongs to exactly ONE application: re-provisioning under a
+            // different application is a conflict, but a legacy realm without an
+            // application is backfilled below, not rejected.
+            String desiredApplication = resolveApplicationIdOrNull(context.getCommand());
+            String existingApplication = applicationRefName(existing);
+            if (existingApplication != null && desiredApplication != null
+                    && !existingApplication.equalsIgnoreCase(desiredApplication)) {
+                diffs.add(String.format("application: existing='%s', requested='%s'",
+                    existingApplication, desiredApplication));
+            }
 
             if (!diffs.isEmpty()) {
                 throw new IllegalStateException("Realm already exists; differences detected: " + String.join("; ", diffs));
+            }
+            if (existingApplication == null && desiredApplication != null) {
+                Application application = registerOwningApplication(
+                    desiredApplication, context.getCommand().getAdminUserId());
+                existing.setApplicationRef(application.createEntityReference());
+                realmCatalog.register(existing);
+                context.getResult().addWarning(
+                    "Realm existed without an owning application; linked to '" + desiredApplication + "'.");
+                Log.infof("Backfilled application '%s' onto existing realm %s", desiredApplication, context.getRealmId());
+                return;
             }
             Log.warnf("Realm %s already exists in system catalog; proceeding idempotently.", context.getRealmId());
             context.getResult().addWarning("Realm already exists; no catalog changes were made.");
             return;
         }
 
+        // New realm: resolve and register the owning application (fail-fast when
+        // neither the command nor the platform default names one), then attach it.
+        Application application = registerOwningApplication(
+            requireApplicationId(context.getCommand()),
+            context.getCommand().getAdminUserId());
+        context.getDesiredRealm().setApplicationRef(application.createEntityReference());
         realmCatalog.register(context.getDesiredRealm());
-        Log.infof("Created realm catalog entry for %s in system realm %s", context.getRealmId(), context.getSystemRealm());
+        Log.infof("Created realm catalog entry for %s in system realm %s (application %s)",
+            context.getRealmId(), context.getSystemRealm(), application.getRefName());
         context.getResult().realmCreated = true;
     }
 
@@ -480,7 +573,7 @@ public class TenantProvisioningService implements TenantLifecycle {
             context.getResult().addWarning("Admin user already exists; no user changes were made.");
         }
 
-        ensureUserProfileInRealm(
+        ensureUserProfileProjectionIfEnabled(
             context.getRealmId(),
             context.getCommand().getAdminUserId(),
             context.getCommand().getAdminUserId(),
@@ -505,7 +598,7 @@ public class TenantProvisioningService implements TenantLifecycle {
                 context.getResult(),
                 "Baseline tenant admin user"
             );
-            ensureUserProfileInRealm(
+            ensureUserProfileProjectionIfEnabled(
                 context.getRealmId(),
                 context.getBaselineAdminUserId(),
                 context.getBaselineAdminUserId(),
@@ -530,7 +623,7 @@ public class TenantProvisioningService implements TenantLifecycle {
             context.getResult(),
             "Demo tenant user"
         );
-        ensureUserProfileInRealm(
+        ensureUserProfileProjectionIfEnabled(
             context.getRealmId(),
             context.getDemoUserId(),
             context.getDemoUserId(),
@@ -545,7 +638,7 @@ public class TenantProvisioningService implements TenantLifecycle {
             context.getDomainContext()
         );
 
-        ensureTenantAdminMemberships(
+        ensureTenantAdminMembershipsIfEnabled(
             context.getRealmId(),
             context.getDomainContext(),
             context.getBaselineAdminUserId(),
@@ -634,6 +727,36 @@ public class TenantProvisioningService implements TenantLifecycle {
             .variable("baselineAdminUserId", context.getBaselineAdminUserId())
             .variable("demoUserId", context.getDemoUserId())
             .build();
+    }
+
+    private void ensureUserProfileProjectionIfEnabled(String realmId,
+                                                      String userId,
+                                                      String email,
+                                                      Set<String> roles,
+                                                      DomainContext domainContext) {
+        if (!createTenantIdentityProjections) {
+            Log.debugf(
+                "Tenant identity projections are disabled; skipping UserProfile projection for user %s in tenant realm %s",
+                userId,
+                realmId
+            );
+            return;
+        }
+        ensureUserProfileInRealm(realmId, userId, email, roles, domainContext);
+    }
+
+    private void ensureTenantAdminMembershipsIfEnabled(String realmId,
+                                                       DomainContext domainContext,
+                                                       String baselineAdminUserId,
+                                                       String requestedAdminUserId) {
+        if (!createTenantIdentityProjections) {
+            Log.debugf(
+                "Tenant identity projections are disabled; skipping tenant-local admin UserGroup projection in realm %s",
+                realmId
+            );
+            return;
+        }
+        ensureTenantAdminMemberships(realmId, domainContext, baselineAdminUserId, requestedAdminUserId);
     }
 
     private void ensureUserProfileInRealm(String realmId,

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/application/AudiencePolicy.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/application/AudiencePolicy.java
@@ -9,10 +9,19 @@ import java.util.Set;
  * deployment opts into strict mode; a token WITH an {@code aud} claim that does
  * not name this application is always rejected — no silent fallback).
  *
+ * A token whose {@code aud} contains the literal {@code "*"} is admitted by
+ * every application (decision 2026-07-20): wildcard-entitled principals
+ * (bootstrap/ops) carry an explicit, signed, auditable any-app audience instead
+ * of an unmarked legacy token. The admission rule is exactly:
+ * {@code ownAppId ∈ aud OR "*" ∈ aud}.
+ *
  * Pure logic so the decision table is unit-testable without container
  * scaffolding; {@code SecurityFilter} owns the wiring.
  */
 public final class AudiencePolicy {
+
+   /** Literal audience minted for wildcard application entitlements. */
+   public static final String WILDCARD_AUDIENCE = "*";
 
    public enum Decision {
       /** No expected audience configured, or the token satisfies the policy. */
@@ -42,6 +51,7 @@ public final class AudiencePolicy {
          return audienceRequired ? Decision.REJECT_MISSING_AUDIENCE : Decision.ALLOW;
       }
       return tokenAudience.contains(expectedAudience.get().trim())
+              || tokenAudience.contains(WILDCARD_AUDIENCE)
               ? Decision.ALLOW
               : Decision.REJECT_WRONG_AUDIENCE;
    }

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/contract/CanonicalSpecHash.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/contract/CanonicalSpecHash.java
@@ -1,0 +1,138 @@
+package com.e2eq.framework.service.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Canonical OpenAPI contract hashing for SDK drift detection.
+ *
+ * <p>Must produce byte-identical output to helixor-sdk-gen's Python
+ * canonicalization ({@code json.dumps(spec, sort_keys=True,
+ * separators=(",", ":"), ensure_ascii=True)}): recursively sorted object keys,
+ * compact separators, ASCII-escaped strings with lowercase {@code \\uXXXX}
+ * escapes. The algorithm identifier is part of the wire contract — bump it in
+ * BOTH implementations together if the canonicalization ever changes.
+ *
+ * <p>v1 deliberately rejects non-integral number literals: none of the
+ * platform's OpenAPI contracts contain them, and Java/Python float formatting
+ * differs in ways that would produce silent hash mismatches. Failing fast at
+ * hash time is the correct posture; extend the algorithm version if a contract
+ * legitimately needs float literals.
+ */
+public final class CanonicalSpecHash {
+
+    public static final String ALGORITHM = "sha256-canonical-json-v1";
+
+    private CanonicalSpecHash() {
+    }
+
+    public static String sha256(JsonNode spec) {
+        String canonical = canonicalize(spec);
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(canonical.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+                hex.append(Character.forDigit(b & 0xF, 16));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    public static String canonicalize(JsonNode node) {
+        StringBuilder out = new StringBuilder();
+        write(node, out);
+        return out.toString();
+    }
+
+    private static void write(JsonNode node, StringBuilder out) {
+        if (node == null || node.isNull()) {
+            out.append("null");
+            return;
+        }
+        if (node.isObject()) {
+            List<String> names = new ArrayList<>();
+            node.fieldNames().forEachRemaining(names::add);
+            names.sort(null);
+            out.append('{');
+            boolean first = true;
+            for (String name : names) {
+                if (!first) {
+                    out.append(',');
+                }
+                first = false;
+                writeString(name, out);
+                out.append(':');
+                write(node.get(name), out);
+            }
+            out.append('}');
+            return;
+        }
+        if (node.isArray()) {
+            out.append('[');
+            for (int i = 0; i < node.size(); i++) {
+                if (i > 0) {
+                    out.append(',');
+                }
+                write(node.get(i), out);
+            }
+            out.append(']');
+            return;
+        }
+        if (node.isTextual()) {
+            writeString(node.textValue(), out);
+            return;
+        }
+        if (node.isBoolean()) {
+            out.append(node.booleanValue() ? "true" : "false");
+            return;
+        }
+        if (node.isNumber()) {
+            if (node.isIntegralNumber()) {
+                out.append(node.bigIntegerValue().toString());
+                return;
+            }
+            throw new IllegalArgumentException(
+                "Contract canonicalization " + ALGORITHM + " does not support non-integral number literal "
+                    + node.asText()
+                    + "; platform OpenAPI contracts must not contain float literals (extend the algorithm version if one is required)");
+        }
+        throw new IllegalArgumentException(
+            "Contract canonicalization " + ALGORITHM + " cannot serialize node type " + node.getNodeType());
+    }
+
+    private static void writeString(String value, StringBuilder out) {
+        out.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> out.append("\\\"");
+                case '\\' -> out.append("\\\\");
+                case '\b' -> out.append("\\b");
+                case '\f' -> out.append("\\f");
+                case '\n' -> out.append("\\n");
+                case '\r' -> out.append("\\r");
+                case '\t' -> out.append("\\t");
+                default -> {
+                    // Python ensure_ascii escapes control chars and everything >= 0x7f,
+                    // using lowercase hex; astral chars appear as surrogate-pair escapes,
+                    // which matches escaping each UTF-16 unit here.
+                    if (c < 0x20 || c >= 0x7f) {
+                        out.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        out.append(c);
+                    }
+                }
+            }
+        }
+        out.append('"');
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/service/contract/ContractCompatibility.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/service/contract/ContractCompatibility.java
@@ -1,0 +1,99 @@
+package com.e2eq.framework.service.contract;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Contract compatibility rule for generated-SDK handshakes (decision
+ * 2026-07-20), borrowing Maven version-range semantics.
+ *
+ * <p>A client generated against contract {@code M.m.p} effectively declares the
+ * Maven range {@code [M.m, (M+1).0)} on the serving application:
+ * <ul>
+ *   <li>identical spec hash → identical contract → {@link Verdict#IDENTICAL}
+ *       (fast path; versions not consulted)</li>
+ *   <li>different hash, same major AND server minor ≥ client minor →
+ *       {@link Verdict#COMPATIBLE} — the server carries every feature the
+ *       client was generated against, assuming the platform discipline that
+ *       minor bumps are additive-only (enforced separately in CI by diffing
+ *       operation contracts)</li>
+ *   <li>different major → {@link Verdict#INCOMPATIBLE}</li>
+ *   <li>server minor &lt; client minor → {@link Verdict#SERVICE_OLDER} — the
+ *       deployed service predates this SDK; calls may hit missing operations</li>
+ * </ul>
+ *
+ * <p>Version strings are Maven-style {@code major.minor.patch[-qualifier]};
+ * qualifiers (e.g. {@code -SNAPSHOT}) are ignored for compatibility. The hash
+ * is the fact, the version is the promise: an unparseable or missing version
+ * with a differing hash fails closed as {@link Verdict#INCOMPATIBLE}.
+ */
+public final class ContractCompatibility {
+
+    public enum Verdict {
+        IDENTICAL,
+        COMPATIBLE,
+        SERVICE_OLDER,
+        INCOMPATIBLE
+    }
+
+    public record Result(Verdict verdict, String message) {
+        public boolean allowed() {
+            return verdict == Verdict.IDENTICAL || verdict == Verdict.COMPATIBLE;
+        }
+    }
+
+    private static final Pattern SEMVER = Pattern.compile("^(\\d+)\\.(\\d+)(?:\\.(\\d+))?(?:[-+].*)?$");
+
+    private ContractCompatibility() {
+    }
+
+    public static Result evaluate(String clientHash,
+                                  String clientVersion,
+                                  String serverHash,
+                                  String serverVersion) {
+        Objects.requireNonNull(clientHash, "clientHash");
+        Objects.requireNonNull(serverHash, "serverHash");
+        if (clientHash.equalsIgnoreCase(serverHash)) {
+            return new Result(Verdict.IDENTICAL, "Contract hashes match (" + clientHash + ")");
+        }
+
+        int[] client = parse(clientVersion);
+        int[] server = parse(serverVersion);
+        if (client == null || server == null) {
+            return new Result(Verdict.INCOMPATIBLE,
+                "Contract hashes differ and versions are not comparable (client="
+                    + clientVersion + ", server=" + serverVersion
+                    + "); regenerate the SDK from the service's current OpenAPI document");
+        }
+
+        if (client[0] != server[0]) {
+            return new Result(Verdict.INCOMPATIBLE,
+                "Contract major versions differ: SDK was generated against " + clientVersion
+                    + " but the service serves " + serverVersion
+                    + "; a major bump is a breaking change — regenerate and migrate the caller");
+        }
+        if (server[1] < client[1]) {
+            return new Result(Verdict.SERVICE_OLDER,
+                "Deployed service contract " + serverVersion + " is OLDER than this SDK ("
+                    + clientVersion + "); calls may target operations the service does not have —"
+                    + " deploy the newer service or use an SDK generated against " + serverVersion);
+        }
+        return new Result(Verdict.COMPATIBLE,
+            "Contract " + serverVersion + " is newer-or-equal within major " + client[0]
+                + " (SDK " + clientVersion + "); additive-only minor policy applies");
+    }
+
+    /** Returns {major, minor, patch} or null when unparseable/blank. */
+    static int[] parse(String version) {
+        if (version == null || version.isBlank()) {
+            return null;
+        }
+        Matcher m = SEMVER.matcher(version.trim());
+        if (!m.matches()) {
+            return null;
+        }
+        int patch = m.group(3) == null ? 0 : Integer.parseInt(m.group(3));
+        return new int[] {Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)), patch};
+    }
+}

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterResolveEffectiveRolesTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterResolveEffectiveRolesTest.java
@@ -55,23 +55,33 @@ public class SecurityFilterResolveEffectiveRolesTest {
     // Simple stubs for repos
     private static class StubUserProfileRepo extends UserProfileRepo {
         private final Map<String, UserProfile> bySubject = new HashMap<>();
-        public void put(UserProfile up, String subject) { bySubject.put(subject, up); }
+        public void put(UserProfile up, String subject) { bySubject.put("*::" + subject, up); }
+        public void put(String realm, UserProfile up, String subject) { bySubject.put(realm + "::" + subject, up); }
         @Override
-        public Optional<UserProfile> getBySubject(String realm, String subject) { return Optional.ofNullable(bySubject.get(subject)); }
+        public Optional<UserProfile> getBySubject(String realm, String subject) {
+            UserProfile profile = bySubject.get(realm + "::" + subject);
+            if (profile == null) {
+                profile = bySubject.get("*::" + subject);
+            }
+            return Optional.ofNullable(profile);
+        }
         @Override
-        public Optional<UserProfile> getBySubject(String subject) { return Optional.ofNullable(bySubject.get(subject)); }
+        public Optional<UserProfile> getBySubject(String subject) { return Optional.ofNullable(bySubject.get("*::" + subject)); }
     }
 
     private static class StubUserGroupRepo extends UserGroupRepo {
         private final Map<String, List<UserGroup>> byEntityRef = new HashMap<>();
         public void put(EntityReference ref, List<UserGroup> groups) { byEntityRef.put(ref.getEntityRefName(), groups); }
+        public void put(String realm, EntityReference ref, List<UserGroup> groups) { byEntityRef.put(realm + "::" + ref.getEntityRefName(), groups); }
         @Override
         public List<UserGroup> findByUserProfileRef(EntityReference userProfileRef) {
             return byEntityRef.getOrDefault(userProfileRef.getEntityRefName(), Collections.emptyList());
         }
         @Override
         public List<UserGroup> findByUserProfileRefWithIgnoreRules(String realm, EntityReference userProfileRef) {
-            return findByUserProfileRef(userProfileRef);
+            return byEntityRef.getOrDefault(
+                    realm + "::" + userProfileRef.getEntityRefName(),
+                    findByUserProfileRef(userProfileRef));
         }
     }
 
@@ -167,6 +177,69 @@ public class SecurityFilterResolveEffectiveRolesTest {
         // Expected union: identity(user, viewer) U cred(editor, user) U groups(user, admin, developer)
         Set<String> expected = new HashSet<>(Arrays.asList("user", "viewer", "editor", "admin", "developer"));
         assertEquals(expected, result, "Effective roles should be the union without duplicates");
+    }
+
+    @Test
+    public void testSystemRealmUserGroupRolesApplyWhenResolvingTenantRealm() throws Exception {
+        SecurityIdentity identity = identityWithRoles(Set.of());
+        String subject = "sub-central";
+        CredentialUserIdPassword cred = CredentialUserIdPassword.builder()
+                .userId("u-central")
+                .subject(subject)
+                .domainContext(com.e2eq.framework.model.security.DomainContext.builder()
+                        .tenantId("tenant-a").defaultRealm("tenant-a").orgRefName("org1").accountId("acct1").build())
+                .lastUpdate(new Date())
+                .roles(new String[]{"user"})
+                .build();
+
+        UserProfile centralProfile = UserProfile.builder()
+                .credentialUserIdPasswordRef(EntityReference.builder().entityRefName(subject).entityDisplayName("cred").build())
+                .email("central@example.com")
+                .build();
+        centralProfile.setRefName("central-userProfile-" + subject);
+        centralProfile.setDisplayName("Central User Profile for " + subject);
+
+        UserGroup adminGroup = new UserGroup();
+        adminGroup.setRoles(Arrays.asList("admin", "user"));
+
+        StubUserProfileRepo upr = new StubUserProfileRepo();
+        upr.put("system-com", centralProfile, subject);
+
+        StubUserGroupRepo ugr = new StubUserGroupRepo();
+        ugr.put("system-com", centralProfile.createEntityReference(), List.of(adminGroup));
+
+        SecurityFilter filter = newFilterWithRepos(upr, ugr);
+
+        String[] effective = invokeResolveEffectiveRoles(filter, identity, cred, "tenant-a");
+        Set<String> result = new HashSet<>(Arrays.asList(effective));
+
+        assertEquals(Set.of("user", "admin"), result,
+                "Central system-realm user group roles should apply to tenant authorization without duplicates");
+    }
+
+    @Test
+    public void testCredentialRolesSurviveRealmOverride() throws Exception {
+        SecurityIdentity identity = identityWithRoles(Set.of("admin", "user"));
+        CredentialUserIdPassword cred = CredentialUserIdPassword.builder()
+                .userId("mingardia")
+                .subject("sub-admin")
+                .domainContext(com.e2eq.framework.model.security.DomainContext.builder()
+                        .tenantId("quantum-auth")
+                        .defaultRealm("quantum-auth")
+                        .orgRefName("system")
+                        .accountId("0000000001")
+                        .build())
+                .lastUpdate(new Date())
+                .roles(new String[]{"admin", "user"})
+                .build();
+
+        SecurityFilter filter = newFilterWithRepos(new StubUserProfileRepo(), new StubUserGroupRepo());
+
+        String[] effective = invokeResolveEffectiveRoles(filter, identity, cred, "century-logistics");
+        Set<String> result = new HashSet<>(Arrays.asList(effective));
+
+        assertEquals(Set.of("admin", "user"), result,
+                "A wildcard-authorized admin must not lose flat token/credential roles when X-Realm changes the data realm");
     }
 
     @Test

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/application/AudiencePolicyTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/application/AudiencePolicyTest.java
@@ -46,4 +46,25 @@ class AudiencePolicyTest {
       assertEquals(Decision.ALLOW, AudiencePolicy.evaluate(
               Optional.of(" helixor-di "), true, Set.of("helixor-di")));
    }
+
+   @Test
+   void wildcardAudienceAdmittedByEveryApplication() {
+      // "*" aud = wildcard-entitled principal (bootstrap/ops): explicit, signed,
+      // auditable any-app token. Admission rule: ownAppId ∈ aud OR "*" ∈ aud.
+      assertEquals(Decision.ALLOW, AudiencePolicy.evaluate(
+              Optional.of("helixor-di"), true, Set.of("*")));
+      assertEquals(Decision.ALLOW, AudiencePolicy.evaluate(
+              Optional.of("helixor-scheduler"), true, Set.of("*")));
+   }
+
+   @Test
+   void wildcardMustBeInAudNotMerelyExpected() {
+      // A concrete token is still rejected by an app it does not name; the
+      // wildcard only widens tokens, never a service's expectation.
+      assertEquals(Decision.REJECT_WRONG_AUDIENCE, AudiencePolicy.evaluate(
+              Optional.of("helixor-di"), true, Set.of("helixor-scheduler")));
+      // And strict mode still rejects aud-less tokens even though "*" exists.
+      assertEquals(Decision.REJECT_MISSING_AUDIENCE, AudiencePolicy.evaluate(
+              Optional.of("helixor-di"), true, Set.of()));
+   }
 }

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/contract/CanonicalSpecHashTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/contract/CanonicalSpecHashTest.java
@@ -1,0 +1,67 @@
+package com.e2eq.framework.service.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Cross-language pin: the expected values below were produced by
+ * helixor-sdk-gen's Python canonicalization
+ * ({@code json.dumps(spec, sort_keys=True, separators=(",", ":"), ensure_ascii=True)}
+ * + SHA-256). If this test fails after a change here or in helixor-sdk-gen,
+ * the two implementations have diverged — that is a contract break, not a
+ * test to update casually; bump {@link CanonicalSpecHash#ALGORITHM} in both.
+ */
+class CanonicalSpecHashTest {
+
+    // Computed by helixor_sdk_gen.openapi_ir.canonical_spec_sha256 (2026-07-20).
+    private static final String PYTHON_PINNED_HASH =
+        "03ecefbd400ba4487e98707e9015a85fcf0dcc366cae51842e5e40e10b405b0a";
+
+    private static final String PYTHON_PINNED_CANONICAL =
+        "{\"info\":{\"title\":\"Contract Pin \\u2014 \\u00e9\\u2713\",\"version\":\"1.2.3\"},"
+            + "\"openapi\":\"3.1.0\",\"paths\":{\"/security/login\":{\"post\":{\"operationId\":\"login\","
+            + "\"responses\":{\"200\":{\"description\":\"ok \\\"quoted\\\" \\\\ tab\\tnewline\\n\"}}}}},"
+            + "\"x-bool\":true,\"x-int\":42,\"x-list\":[1,2,{\"a\":\"z\",\"z\":\"a\"}],\"x-null\":null}";
+
+    @Test
+    void matchesPythonCanonicalizationByteForByte() throws Exception {
+        // Parse the pinned canonical form with keys deliberately reordered so the
+        // test proves sorting, escaping, and separators — not input ordering.
+        String reordered = "{\"x-null\":null,\"x-list\":[1,2,{\"z\":\"a\",\"a\":\"z\"}],\"x-int\":42,"
+            + "\"x-bool\":true,\"paths\":{\"/security/login\":{\"post\":{\"responses\":"
+            + "{\"200\":{\"description\":\"ok \\\"quoted\\\" \\\\ tab\\tnewline\\n\"}},\"operationId\":\"login\"}}},"
+            + "\"openapi\":\"3.1.0\",\"info\":{\"version\":\"1.2.3\",\"title\":\"Contract Pin \\u2014 \\u00e9\\u2713\"}}";
+        JsonNode spec = new ObjectMapper().readTree(reordered);
+
+        assertEquals(PYTHON_PINNED_CANONICAL, CanonicalSpecHash.canonicalize(spec));
+        assertEquals(PYTHON_PINNED_HASH, CanonicalSpecHash.sha256(spec));
+    }
+
+    @Test
+    void yamlAndJsonFormsOfTheSameContractHashIdentically() throws Exception {
+        String yaml = """
+            openapi: "3.1.0"
+            info:
+              version: "1.2.3"
+              title: Simple
+            paths: {}
+            """;
+        String json = "{\"paths\":{},\"info\":{\"title\":\"Simple\",\"version\":\"1.2.3\"},\"openapi\":\"3.1.0\"}";
+        JsonNode fromYaml = new ObjectMapper(new YAMLFactory()).readTree(yaml);
+        JsonNode fromJson = new ObjectMapper().readTree(json);
+        assertEquals(CanonicalSpecHash.sha256(fromJson), CanonicalSpecHash.sha256(fromYaml));
+    }
+
+    @Test
+    void nonIntegralNumbersFailFast() throws Exception {
+        JsonNode spec = new ObjectMapper().readTree("{\"x\":1.5}");
+        IllegalArgumentException error =
+            assertThrows(IllegalArgumentException.class, () -> CanonicalSpecHash.sha256(spec));
+        assertEquals(true, error.getMessage().contains("non-integral"));
+    }
+}

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/contract/ContractCompatibilityTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/contract/ContractCompatibilityTest.java
@@ -1,0 +1,77 @@
+package com.e2eq.framework.service.contract;
+
+import com.e2eq.framework.service.contract.ContractCompatibility.Result;
+import com.e2eq.framework.service.contract.ContractCompatibility.Verdict;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ContractCompatibilityTest {
+
+    private static final String HASH_A = "a".repeat(64);
+    private static final String HASH_B = "b".repeat(64);
+
+    @Test
+    void identicalHashShortCircuits_versionsNotConsulted() {
+        Result r = ContractCompatibility.evaluate(HASH_A, "garbage", HASH_A, null);
+        assertEquals(Verdict.IDENTICAL, r.verdict());
+        assertTrue(r.allowed());
+    }
+
+    @Test
+    void patchDifference_isCompatible() {
+        Result r = ContractCompatibility.evaluate(HASH_A, "1.2.1", HASH_B, "1.2.2");
+        assertEquals(Verdict.COMPATIBLE, r.verdict());
+        assertTrue(r.allowed());
+    }
+
+    @Test
+    void serverMinorNewer_isCompatible_clientRangeSemantics() {
+        // Client 1.2.2 declares [1.2, 2.0) on the server: 1.3.2 satisfies it.
+        Result r = ContractCompatibility.evaluate(HASH_A, "1.2.2", HASH_B, "1.3.2");
+        assertEquals(Verdict.COMPATIBLE, r.verdict());
+    }
+
+    @Test
+    void serverMinorOlder_failsDirectionally() {
+        // Client 1.3.2 requires at least a 1.3.x service.
+        Result r = ContractCompatibility.evaluate(HASH_A, "1.3.2", HASH_B, "1.2.9");
+        assertEquals(Verdict.SERVICE_OLDER, r.verdict());
+        assertFalse(r.allowed());
+        assertTrue(r.message().contains("OLDER"));
+    }
+
+    @Test
+    void majorDifference_failsBothDirections() {
+        assertEquals(Verdict.INCOMPATIBLE,
+            ContractCompatibility.evaluate(HASH_A, "1.9.0", HASH_B, "2.0.0").verdict());
+        assertEquals(Verdict.INCOMPATIBLE,
+            ContractCompatibility.evaluate(HASH_A, "2.0.0", HASH_B, "1.9.0").verdict());
+    }
+
+    @Test
+    void mavenStyleQualifiersAreIgnored() {
+        Result r = ContractCompatibility.evaluate(HASH_A, "1.4.0-SNAPSHOT", HASH_B, "1.4.0");
+        assertEquals(Verdict.COMPATIBLE, r.verdict());
+        assertEquals(Verdict.COMPATIBLE,
+            ContractCompatibility.evaluate(HASH_A, "1.4.0", HASH_B, "1.5.0-SNAPSHOT").verdict());
+    }
+
+    @Test
+    void differingHashWithUnparseableVersion_failsClosed() {
+        // The hash is the fact, the version is the promise: no comparable
+        // promise + differing fact = incompatible.
+        Result r = ContractCompatibility.evaluate(HASH_A, "not-a-version", HASH_B, "1.2.3");
+        assertEquals(Verdict.INCOMPATIBLE, r.verdict());
+        Result missing = ContractCompatibility.evaluate(HASH_A, "1.2.3", HASH_B, null);
+        assertEquals(Verdict.INCOMPATIBLE, missing.verdict());
+    }
+
+    @Test
+    void twoSegmentVersionsParse() {
+        Result r = ContractCompatibility.evaluate(HASH_A, "1.2", HASH_B, "1.2.5");
+        assertEquals(Verdict.COMPATIBLE, r.verdict());
+    }
+}

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -620,11 +620,23 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                       applicationId);
                   switch (appAuth.outcome()) {
                      case AMBIGUOUS:
+                        java.util.List<String> selectionCandidates = appAuth.candidates();
+                        if (selectionCandidates.isEmpty()) {
+                           // Pattern grants can't enumerate themselves; the realm
+                           // catalog doubles as the application-usage registry, so
+                           // offer the distinct in-use applications that satisfy
+                           // the credential's pattern — a selection prompt with an
+                           // empty candidate list is unactionable.
+                           String pattern = credential.getApplicationRegEx();
+                           selectionCandidates = realmRepo.findDistinctApplicationRefNames().stream()
+                              .filter(app -> ApplicationAuthorizationResolver.matches(pattern, app))
+                              .toList();
+                        }
                         return new LoginResponse(false,
                            new LoginNegativeResponse(userId, 400, 300,
                               "Multiple applications are authorized; specify which application to sign into",
                               "ApplicationSelectionRequired",
-                              String.join(",", appAuth.candidates()),
+                              String.join(",", selectionCandidates),
                               tokenRealm));
                      case DENIED:
                         return new LoginResponse(false,

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
@@ -24,10 +24,13 @@ import java.util.regex.PatternSyntaxException;
  *   <li><b>Resolution order:</b> explicit requested app → single authorized app →
  *       configured default → otherwise ambiguous (the caller returns the set so the
  *       login UI can prompt). Origin/host is never consulted.</li>
- *   <li><b>{@code "*"} guardrail:</b> a wildcard grant is "may enter any app, but
- *       must name which" — it requires an explicit requested app (the installed set
- *       is not enumerable here), scopes the token to just that app, and flags the
- *       result so the caller can audit-log the wildcard issuance.</li>
+ *   <li><b>{@code "*"} semantics (decision 2026-07-20):</b> a wildcard grant means
+ *       the token is valid for ANY application. It resolves to the literal {@code "*"}
+ *       audience — admitted downstream by the shared audience policy ({@code aud}
+ *       contains the service's own app id OR {@code "*"}) — rather than forcing a
+ *       selection this layer cannot enumerate. {@code azp} records the app actively
+ *       entered when one was named. The result is flagged so the caller can
+ *       audit-log every wildcard issuance.</li>
  * </ul>
  */
 public final class ApplicationAuthorizationResolver {
@@ -110,14 +113,10 @@ public final class ApplicationAuthorizationResolver {
         concrete.remove(WILDCARD);
 
         if (wildcard) {
-            // "*" = may enter any app, but must name which; token is scoped to that one app.
-            if (requested == null) {
-                // Can't enumerate installed apps from this layer, so we can't default a "*" grant.
-                return Result.ambiguous(new ArrayList<>(concrete), true);
-            }
-            LinkedHashSet<String> aud = new LinkedHashSet<>();
-            aud.add(requested);
-            return Result.resolved(aud, requested, true);
+            // "*" = valid for any application: mint the wildcard audience instead of
+            // demanding a selection this layer cannot enumerate. azp = the app
+            // actively entered, when one was named or defaulted.
+            return Result.resolved(wildcardAudience(), requested != null ? requested : defaultApp, true);
         }
 
         if (requested != null) {
@@ -150,24 +149,42 @@ public final class ApplicationAuthorizationResolver {
 
         String requested = trimToNull(requestedApplicationId);
         String defaultApp = trimToNull(defaultApplication);
-        boolean wildcard = WILDCARD.equals(expression);
+
+        if (WILDCARD.equals(expression)) {
+            // Same "*" semantics as a wildcard grant entry: the token is valid for
+            // any application, carried as the literal "*" audience.
+            return Result.resolved(wildcardAudience(), requested != null ? requested : defaultApp, true);
+        }
 
         if (requested != null) {
             if (matches(expression, requested)) {
-                return Result.resolved(new LinkedHashSet<>(List.of(requested)), requested, wildcard);
+                return Result.resolved(new LinkedHashSet<>(List.of(requested)), requested, false);
             }
             return Result.denied(requested);
         }
 
         if (defaultApp != null && matches(expression, defaultApp)) {
-            return Result.resolved(new LinkedHashSet<>(List.of(defaultApp)), defaultApp, wildcard);
+            return Result.resolved(new LinkedHashSet<>(List.of(defaultApp)), defaultApp, false);
         }
 
-        // A pattern can authorize an unbounded set, so callers must name an app.
-        return Result.ambiguous(List.of(), wildcard);
+        // A concrete pattern is a deliberate application-scoping decision and can
+        // authorize an unbounded set, so callers must name an app.
+        return Result.ambiguous(List.of(), false);
     }
 
-    private static boolean matches(String expression, String applicationId) {
+    private static LinkedHashSet<String> wildcardAudience() {
+        LinkedHashSet<String> aud = new LinkedHashSet<>();
+        aud.add(WILDCARD);
+        return aud;
+    }
+
+    /**
+     * True when the application id satisfies the entitlement expression
+     * ({@code "*"} = unrestricted; otherwise full-string, case-insensitive
+     * regex). Public so callers (e.g. the auth provider) can intersect a
+     * pattern with the application registry when enumerating candidates.
+     */
+    public static boolean matches(String expression, String applicationId) {
         if (WILDCARD.equals(expression)) {
             return true;
         }

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/Application.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/Application.java
@@ -1,0 +1,31 @@
+package com.e2eq.framework.model.security;
+
+import com.e2eq.framework.model.persistent.base.FullBaseModel;
+import com.e2eq.ontology.annotations.OntologyClass;
+import dev.morphia.annotations.Entity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity("application")
+@RegisterForReflection
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@OntologyClass(id = "Application")
+
+public class Application extends FullBaseModel {
+
+   @Override
+   public String bmFunctionalArea() {
+      return "SECURITY";
+   }
+
+   @Override
+   public String bmFunctionalDomain() {
+      return "APPLICATION";
+   }
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/Realm.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/Realm.java
@@ -1,6 +1,9 @@
 package com.e2eq.framework.model.security;
 
 import com.e2eq.framework.model.persistent.base.BaseModel;
+import com.e2eq.framework.model.persistent.base.EntityReference;
+import com.e2eq.framework.model.persistent.base.ReferenceTarget;
+import com.e2eq.ontology.annotations.OntologyProperty;
 import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.IndexOptions;
 import dev.morphia.annotations.Indexed;
@@ -75,6 +78,11 @@ public class Realm extends BaseModel {
     * which shell/menu shape to present when a user switches into the realm.
    */
    protected String defaultPerspective;
+
+
+   @ReferenceTarget(target = Application.class, collection = "application")
+   @OntologyProperty(id = "isPartOf", ref = "Application", materializeEdge = true)
+   protected EntityReference applicationRef;
 
    /**
     * Tenant setup projection used by system-perspective catalogs so they can show

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/AccessibleRealmInfo.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/AccessibleRealmInfo.java
@@ -26,6 +26,8 @@ public class AccessibleRealmInfo {
     private Integer pendingMigrationCount;
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Date setupLastUpdated;
+    /** Owning application refName (every realm belongs to exactly one application). */
+    private String application;
 
     public AccessibleRealmInfo(String refName, String displayName) {
         this.refName = refName;
@@ -58,7 +60,7 @@ public class AccessibleRealmInfo {
         if (realm == null) {
             return new AccessibleRealmInfo();
         }
-        return new AccessibleRealmInfo(
+        AccessibleRealmInfo info = new AccessibleRealmInfo(
                 realm.getRefName(),
                 realm.getDisplayName(),
                 realm.getSetupStatus(),
@@ -70,5 +72,9 @@ public class AccessibleRealmInfo {
                 realm.getPendingMigrationCount(),
                 realm.getSetupLastUpdated()
         );
+        if (realm.getApplicationRef() != null) {
+            info.setApplication(realm.getApplicationRef().getEntityRefName());
+        }
+        return info;
     }
 }

--- a/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
@@ -21,9 +21,28 @@ class ApplicationAuthorizationResolverTest {
     void credentialWildcardResolvesExplicitApplication() {
         var r = ApplicationAuthorizationResolver.resolve(null, "*", null, "system-admin");
         assertEquals(ApplicationAuthorizationResolver.Outcome.RESOLVED, r.outcome());
-        assertEquals(Set.of("system-admin"), r.audiences());
+        assertEquals(Set.of("*"), r.audiences());
         assertEquals("system-admin", r.activeApplication());
         assertTrue(r.wildcard());
+    }
+
+    @Test
+    void credentialWildcardPattern_noRequest_noDefault_mintsWildcardAudience() {
+        // "*" = no application restriction: mint the wildcard audience instead of
+        // demanding a selection from an empty candidate list (this layer cannot
+        // enumerate installed apps). Downstream admission = own id ∈ aud or "*" ∈ aud.
+        var r = ApplicationAuthorizationResolver.resolve(null, "*", null, null);
+        assertEquals(ApplicationAuthorizationResolver.Outcome.RESOLVED, r.outcome());
+        assertEquals(Set.of("*"), r.audiences());
+        assertNull(r.activeApplication());
+        assertTrue(r.wildcard());
+    }
+
+    @Test
+    void concretePattern_noRequest_noDefault_isAmbiguous() {
+        // A concrete pattern is a deliberate scoping decision: callers must name an app.
+        var r = ApplicationAuthorizationResolver.resolve(null, "helixor-.*", null, null);
+        assertEquals(ApplicationAuthorizationResolver.Outcome.AMBIGUOUS, r.outcome());
     }
 
     @Test
@@ -110,30 +129,32 @@ class ApplicationAuthorizationResolverTest {
     }
 
     @Test
-    void wildcard_withRequest_scopesToRequestedOnly_andFlagsWildcard() {
+    void wildcard_withRequest_mintsWildcardAudience_azpIsRequested() {
         var r = ApplicationAuthorizationResolver.resolve(List.of("*"), null, "anything");
         assertTrue(r.resolved());
         assertTrue(r.wildcard());
         assertEquals("anything", r.activeApplication());
-        // cannot enumerate installed apps, so aud is scoped to just the named app
-        assertEquals(List.of("anything"), List.copyOf(r.audiences()));
+        // "*" grant = valid for any app; aud carries the literal wildcard
+        assertEquals(List.of("*"), List.copyOf(r.audiences()));
     }
 
     @Test
-    void wildcard_withoutRequest_isAmbiguous() {
+    void wildcard_withoutRequest_mintsWildcardAudience_noAzp() {
         var r = ApplicationAuthorizationResolver.resolve(List.of("*"), null, null);
-        assertEquals(ApplicationAuthorizationResolver.Outcome.AMBIGUOUS, r.outcome());
+        assertTrue(r.resolved());
         assertTrue(r.wildcard());
+        assertNull(r.activeApplication());
+        assertEquals(List.of("*"), List.copyOf(r.audiences()));
     }
 
     @Test
-    void wildcardPlusConcrete_withRequest_scopesToRequested() {
-        // "*" dominates: any requested app is allowed and the token is scoped to it
+    void wildcardPlusConcrete_withRequest_mintsWildcardAudience() {
+        // "*" dominates: the token is valid for any app; azp records the entered one
         var r = ApplicationAuthorizationResolver.resolve(List.of("*", "scheduler"), "scheduler", "di");
         assertTrue(r.resolved());
         assertTrue(r.wildcard());
         assertEquals("di", r.activeApplication());
-        assertEquals(List.of("di"), List.copyOf(r.audiences()));
+        assertEquals(List.of("*"), List.copyOf(r.audiences()));
     }
 
     @Test

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/ApplicationRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/ApplicationRepo.java
@@ -1,0 +1,53 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.security.Application;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Global application registry. Like credential, policy, and realm records,
+ * applications are a system-plane resource: the {@code application} collection
+ * exists ONLY in the configured system realm (quantum-auth) database. Pinning
+ * the security-context realm here makes every inherited repo path — including
+ * the generic {@code ApplicationResource} CRUD — read and write that single
+ * registry regardless of the caller's request realm or X-Realm override.
+ */
+@ApplicationScoped
+public class ApplicationRepo extends MorphiaRepo<Application> {
+
+    @Override
+    public String getSecurityContextRealmId() {
+        return envConfigUtils.getSystemRealm();
+    }
+
+    /**
+     * Rule-free lookup for bootstrap/provisioning paths that run before or
+     * outside a principal security context (mirrors the credential/realm repos).
+     */
+    public java.util.Optional<Application> findByRefNameWithIgnoreRules(String refName) {
+        if (refName == null || refName.isBlank()) {
+            return java.util.Optional.empty();
+        }
+        return java.util.Optional.ofNullable(
+            morphiaDataStoreWrapper.getDataStore(getSecurityContextRealmId())
+                .find(Application.class)
+                .filter(dev.morphia.query.filters.Filters.eq("refName", refName.trim()))
+                .first());
+    }
+
+    /**
+     * Idempotently registers an application in the global registry (system
+     * realm). Provisioning uses this so creating a realm for a new application
+     * also creates the application record — the registry is derived from use,
+     * never hand-maintained.
+     */
+    public Application ensureRegistered(String refName,
+                                        com.e2eq.framework.model.persistent.base.DataDomain dataDomain) {
+        return findByRefNameWithIgnoreRules(refName).orElseGet(() -> {
+            Application application = new Application();
+            application.setRefName(refName.trim());
+            application.setDisplayName(refName.trim());
+            application.setDataDomain(dataDomain);
+            return save(getSecurityContextRealmId(), application);
+        });
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolver.java
@@ -21,8 +21,9 @@ import java.util.*;
  *   - roles from any UserGroup memberships of the associated UserProfile
  * - If a role is provided (no credential), no expansion is performed.
  *
- * Note: Credentials are always stored in system-com (global). The realm parameter
- * is used for UserProfile/UserGroup lookups in the tenant's database.
+ * Note: Credentials and central directory groups are stored in the configured
+ * system realm. Tenant-local UserProfile/UserGroup lookup remains only as a
+ * compatibility fallback for embedded auth mode.
  */
 @ApplicationScoped
 public class IdentityRoleResolver {
@@ -80,12 +81,10 @@ public class IdentityRoleResolver {
                                           String effectiveRealm) {
         String targetRealm = requireRealm(effectiveRealm);
         LinkedHashMap<String, EnumSet<RoleSource>> provenance = new LinkedHashMap<>();
-        boolean sameAuthorityRealm = sameRealm(authorityRealm, targetRealm);
-
-        if (sameAuthorityRealm && identity != null) {
+        if (identity != null) {
             addRoles(provenance, identity.getRoles(), RoleSource.TOKEN);
         }
-        if (sameAuthorityRealm && credential != null) {
+        if (credential != null) {
             addRoles(provenance, credential.getRoles(), RoleSource.CREDENTIAL);
         }
 
@@ -95,17 +94,9 @@ public class IdentityRoleResolver {
                                 credential.getUserId(), targetRealm, envConfigUtils.getSystemRealm())
                         .ifPresent(assignment -> addRoles(provenance, assignment.getRoles(), RoleSource.REALM));
 
-                Optional<UserProfile> profile = userProfileRepo.getBySubject(targetRealm, credential.getSubject());
-                if (profile.isPresent()) {
-                    List<UserGroup> groups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
-                            targetRealm, profile.get().createEntityReference());
-                    if (groups != null) {
-                        for (UserGroup group : groups) {
-                            if (group != null) {
-                                addRoles(provenance, group.getRoles(), RoleSource.USERGROUP);
-                            }
-                        }
-                    }
+                addUserGroupRoles(provenance, credential, envConfigUtils.getSystemRealm());
+                if (!sameRealm(targetRealm, envConfigUtils.getSystemRealm())) {
+                    addUserGroupRoles(provenance, credential, targetRealm);
                 }
             } catch (RuntimeException e) {
                 throw new IllegalStateException(String.format(
@@ -138,8 +129,9 @@ public class IdentityRoleResolver {
      * If the identity matches a credential, include sources from IDP, CREDENTIAL, and USERGROUP.
      * If no credential exists, only IDP roles can be derived.
      *
-     * Note: Credentials are always looked up from system-com (global). The realm parameter
-     * is used for UserProfile/UserGroup lookups in the tenant's database.
+     * Note: Credentials and central directory groups are looked up from the
+     * configured system realm. Tenant-local UserProfile/UserGroup lookup remains
+     * only as a compatibility fallback for embedded auth mode.
      */
     public Map<String, EnumSet<RoleSource>> resolveRoleSources(String identity, String realm, SecurityIdentity securityIdentity) {
         LinkedHashMap<String, EnumSet<RoleSource>> out = new LinkedHashMap<>();
@@ -151,33 +143,45 @@ public class IdentityRoleResolver {
             authorityRealm = credentialHomeRealm(credential.get());
         }
 
-        if (sameRealm(authorityRealm, targetRealm) && currentIdentityMatches(identity, securityIdentity)) {
+        if (currentIdentityMatches(identity, securityIdentity)) {
             addRoles(out, securityIdentity.getRoles(), RoleSource.TOKEN);
         }
 
         if (credential.isPresent()) {
             CredentialUserIdPassword cred = credential.get();
-            if (sameRealm(credentialHomeRealm(cred), targetRealm)) {
-                addRoles(out, cred.getRoles(), RoleSource.CREDENTIAL);
-            }
+            addRoles(out, cred.getRoles(), RoleSource.CREDENTIAL);
             userRealmRoleRepo.findActiveAssignmentForRealmWithIgnoreRules(
                             cred.getUserId(), targetRealm, systemRealm)
                     .ifPresent(assignment -> addRoles(out, assignment.getRoles(), RoleSource.REALM));
 
-            Optional<UserProfile> profile = userProfileRepo.getBySubject(targetRealm, cred.getSubject());
-            if (profile.isPresent()) {
-                List<UserGroup> groups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
-                        targetRealm, profile.get().createEntityReference());
-                if (groups != null) {
-                    for (UserGroup group : groups) {
-                        if (group != null) {
-                            addRoles(out, group.getRoles(), RoleSource.USERGROUP);
-                        }
-                    }
-                }
+            addUserGroupRoles(out, cred, systemRealm);
+            if (!sameRealm(targetRealm, systemRealm)) {
+                addUserGroupRoles(out, cred, targetRealm);
             }
         }
         return out;
+    }
+
+    private void addUserGroupRoles(Map<String, EnumSet<RoleSource>> target,
+                                   CredentialUserIdPassword credential,
+                                   String groupRealm) {
+        if (credential == null || credential.getSubject() == null || groupRealm == null || groupRealm.isBlank()) {
+            return;
+        }
+        Optional<UserProfile> profile = userProfileRepo.getBySubject(groupRealm, credential.getSubject());
+        if (profile.isEmpty()) {
+            return;
+        }
+        List<UserGroup> groups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
+                groupRealm, profile.get().createEntityReference());
+        if (groups == null) {
+            return;
+        }
+        for (UserGroup group : groups) {
+            if (group != null) {
+                addRoles(target, group.getRoles(), RoleSource.USERGROUP);
+            }
+        }
     }
 
     private String credentialHomeRealm(CredentialUserIdPassword credential) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaDataStoreWrapper.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaDataStoreWrapper.java
@@ -14,10 +14,12 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
@@ -43,6 +45,23 @@ public class MorphiaDataStoreWrapper {
 
    @Inject
    EnvConfigUtils envConfigUtils;
+
+   /**
+    * Compatibility escape hatch only. The default keeps global identity/security
+    * resources out of tenant realm datastores; embedded auth still maps those
+    * resources in the configured system realm.
+    */
+   @ConfigProperty(name = "quantum.morphia.map-global-resources-to-tenant-realms", defaultValue = "false")
+   boolean mapGlobalResourcesToTenantRealms;
+
+   @ConfigProperty(
+       name = "quantum.morphia.tenant-excluded-entity-package-prefixes",
+       defaultValue = RealmEntityMappingPolicy.DEFAULT_TENANT_EXCLUDED_ENTITY_PACKAGE_PREFIXES
+   )
+   String tenantExcludedEntityPackagePrefixes;
+
+   @ConfigProperty(name = "quantum.morphia.tenant-excluded-entity-classes")
+   Optional<String> tenantExcludedEntityClasses;
 
 
 
@@ -87,9 +106,26 @@ public class MorphiaDataStoreWrapper {
       mdatastore.getMapper().addInterceptor(referenceInterceptor);
       mdatastore.getMapper().addInterceptor(persistenceAuditEventInterceptor);
 
-      // Reuse already-mapped entity types from the base datastore (no classpath scanning per realm)
+      // Reuse already-mapped entity types from the base datastore (no classpath scanning per realm),
+      // but do not project system-plane security/identity entities into tenant realms.
+      int mappedEntityCount = 0;
+      int skippedEntityCount = 0;
       for (Class<?> entityType : getMappedEntityTypesFromBase()) {
-         mdatastore.getMapper().map(entityType);
+         if (shouldMapEntityType(realm, entityType)) {
+            mdatastore.getMapper().map(entityType);
+            mappedEntityCount++;
+         } else {
+            skippedEntityCount++;
+            Log.debugf("Skipping system-plane entity type %s for tenant realm/database %s", entityType.getName(), realm);
+         }
+      }
+      if (skippedEntityCount > 0) {
+         Log.infof(
+             "MorphiaDataStoreWrapper: mapped %d entity types and skipped %d system-plane entity types for realm/database %s",
+             mappedEntityCount,
+             skippedEntityCount,
+             realm
+         );
       }
 
       // Apply indexes and document validations
@@ -122,6 +158,17 @@ public class MorphiaDataStoreWrapper {
          }
       }
       return cachedMappedEntityTypes;
+   }
+
+   private boolean shouldMapEntityType(String realm, Class<?> entityType) {
+      return RealmEntityMappingPolicy.shouldMapToRealm(
+          realm,
+          envConfigUtils.getSystemRealm(),
+          entityType,
+          mapGlobalResourcesToTenantRealms,
+          tenantExcludedEntityPackagePrefixes,
+          tenantExcludedEntityClasses.orElse("")
+      );
    }
 
     /* Original as of March 26th 2025

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RealmEntityMappingPolicy.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RealmEntityMappingPolicy.java
@@ -1,0 +1,72 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Decides which globally mapped Morphia entity classes should be admitted into
+ * a concrete realm datastore.
+ *
+ * <p>Framework identity, policy, realm, organization, and OAuth records are
+ * system-plane resources. They belong in the system/auth datastore, not in each
+ * tenant application's data realm. Mapping them into every realm causes empty
+ * or misleading security collections to be created during index initialization.
+ */
+public final class RealmEntityMappingPolicy {
+
+    public static final String DEFAULT_TENANT_EXCLUDED_ENTITY_PACKAGE_PREFIXES =
+        "com.e2eq.framework.model.security.,"
+            + "com.e2eq.framework.model.persistent.security.,"
+            + "com.e2eq.framework.oauth.model.";
+
+    private RealmEntityMappingPolicy() {
+    }
+
+    public static boolean shouldMapToRealm(String realm,
+                                           String systemRealm,
+                                           Class<?> entityType,
+                                           boolean mapGlobalResourcesToTenantRealms,
+                                           String tenantExcludedEntityPackagePrefixesCsv,
+                                           String tenantExcludedEntityClassesCsv) {
+        if (realm == null || realm.isBlank()) {
+            throw new IllegalArgumentException("realm must be non-null and non-blank");
+        }
+        if (systemRealm == null || systemRealm.isBlank()) {
+            throw new IllegalArgumentException("systemRealm must be non-null and non-blank");
+        }
+        if (entityType == null) {
+            throw new IllegalArgumentException("entityType must be non-null");
+        }
+        if (realm.equals(systemRealm) || mapGlobalResourcesToTenantRealms) {
+            return true;
+        }
+        return !isTenantExcludedEntity(entityType, tenantExcludedEntityPackagePrefixesCsv, tenantExcludedEntityClassesCsv);
+    }
+
+    public static boolean isTenantExcludedEntity(Class<?> entityType,
+                                                 String tenantExcludedEntityPackagePrefixesCsv,
+                                                 String tenantExcludedEntityClassesCsv) {
+        String className = entityType.getName();
+        Set<String> excludedClasses = parseCsv(tenantExcludedEntityClassesCsv);
+        if (excludedClasses.contains(className)) {
+            return true;
+        }
+        for (String prefix : parseCsv(tenantExcludedEntityPackagePrefixesCsv)) {
+            if (className.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> parseCsv(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return Set.of();
+        }
+        return Arrays.stream(csv.split(","))
+            .map(String::trim)
+            .filter(value -> !value.isBlank())
+            .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RealmRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RealmRepo.java
@@ -32,6 +32,27 @@ public class RealmRepo extends MorphiaRepo<Realm> {
    }
 
 
+   /**
+    * The realm catalog doubles as the application-usage registry: every realm
+    * points at its owning application, so the distinct set of applicationRef
+    * refNames is "applications with at least one realm". Reads the system-realm
+    * database (the single home of the realm collection).
+    */
+   public java.util.List<String> findDistinctApplicationRefNames() {
+      MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(getSecurityContextRealmId());
+      String collectionName = ds.getMapper().getEntityModel(Realm.class).collectionName();
+      java.util.List<String> out = new java.util.ArrayList<>();
+      ds.getDatabase().getCollection(collectionName)
+         .distinct("applicationRef.entityRefName", String.class)
+         .forEach(value -> {
+            if (value != null && !value.isBlank()) {
+               out.add(value);
+            }
+         });
+      java.util.Collections.sort(out);
+      return out;
+   }
+
    public java.util.List<Realm> getAllListWithIgnoreRules (String realmId) {
       MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(realmId);
       String dataBase = ds.getDatabase().getName();

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/RealmEntityMappingPolicyTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/RealmEntityMappingPolicyTest.java
@@ -1,0 +1,69 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.persistent.base.CodeList;
+import com.e2eq.framework.model.persistent.migration.base.DatabaseVersion;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.model.security.Policy;
+import com.e2eq.framework.model.security.Realm;
+import com.e2eq.framework.model.security.UserProfile;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RealmEntityMappingPolicyTest {
+
+    private static final String SYSTEM_REALM = "quantum-auth";
+    private static final String TENANT_REALM = "century-logistics-com";
+
+    @Test
+    void systemRealmMapsIdentityAndSecurityEntities() {
+        assertTrue(shouldMap(SYSTEM_REALM, CredentialUserIdPassword.class, false));
+        assertTrue(shouldMap(SYSTEM_REALM, Realm.class, false));
+        assertTrue(shouldMap(SYSTEM_REALM, Policy.class, false));
+        assertTrue(shouldMap(SYSTEM_REALM, UserProfile.class, false));
+    }
+
+    @Test
+    void tenantRealmDoesNotMapIdentityAndSecurityEntitiesByDefault() {
+        assertFalse(shouldMap(TENANT_REALM, CredentialUserIdPassword.class, false));
+        assertFalse(shouldMap(TENANT_REALM, Realm.class, false));
+        assertFalse(shouldMap(TENANT_REALM, Policy.class, false));
+        assertFalse(shouldMap(TENANT_REALM, UserProfile.class, false));
+    }
+
+    @Test
+    void tenantRealmStillMapsTenantAndMigrationEntities() {
+        assertTrue(shouldMap(TENANT_REALM, CodeList.class, false));
+        assertTrue(shouldMap(TENANT_REALM, DatabaseVersion.class, false));
+    }
+
+    @Test
+    void compatibilityFlagCanMapGlobalEntitiesToTenantRealm() {
+        assertTrue(shouldMap(TENANT_REALM, CredentialUserIdPassword.class, true));
+        assertTrue(shouldMap(TENANT_REALM, Policy.class, true));
+    }
+
+    @Test
+    void explicitClassExclusionIsHonored() {
+        assertFalse(RealmEntityMappingPolicy.shouldMapToRealm(
+            TENANT_REALM,
+            SYSTEM_REALM,
+            CodeList.class,
+            false,
+            "",
+            CodeList.class.getName()
+        ));
+    }
+
+    private boolean shouldMap(String realm, Class<?> entityType, boolean mapGlobalResourcesToTenantRealms) {
+        return RealmEntityMappingPolicy.shouldMapToRealm(
+            realm,
+            SYSTEM_REALM,
+            entityType,
+            mapGlobalResourcesToTenantRealms,
+            RealmEntityMappingPolicy.DEFAULT_TENANT_EXCLUDED_ENTITY_PACKAGE_PREFIXES,
+            ""
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce the `Application` model/registry (`ApplicationRepo`, `/api/security/application`) and require every realm to declare an owning `applicationRef`; tenant provisioning fails fast without an application (or `quantum.tenant.provisioning.default-application`).
- Keep system-plane Morphia entities (security, policy, OAuth) out of tenant realm datastores via `RealmEntityMappingPolicy`, with a config escape hatch for legacy embeddings.
- Add `/contract-hash` plus `CanonicalSpecHash` / `ContractCompatibility` so generated SDKs can handshake OpenAPI identity and fail fast on drift.
- Treat authorization `"*"` grants as a literal wildcard audience admitted by the shared audience policy (with `azp` recording the app entered when named).

## Test plan
- [x] Unit tests for `CanonicalSpecHash`, `ContractCompatibility`, `RealmEntityMappingPolicy`, audience policy, and `ApplicationAuthorizationResolver` wildcard resolution
- [ ] Provision a tenant with `applicationId` (and without) to confirm fail-fast / default-application behavior
- [ ] Confirm tenant realm Morphia mapping skips security/identity entity packages
- [ ] Hit `/contract-hash` with and without `quantum.contract.openapi-location` configured