### PR TITLE
Identity and authorization framework increment

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -792,12 +792,35 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             throw new jakarta.ws.rs.ForbiddenException(
                     "Trusted-issuer token is missing the required realm claim");
         }
+        // The issuer signs the credential's realm boundary into the token as
+        // realmRegEx ("*" = all realms, otherwise a regex). An X-Realm switch is
+        // honored only inside that signed boundary, and never INTO the system
+        // realm -- system authority requires logging in against it directly.
+        boolean realmSwitched = false;
+        String contextRealm = signedRealm;
         if (realmOverride != null && !realmOverride.isBlank()
                 && !realmOverride.equalsIgnoreCase(signedRealm)) {
-            throw new jakarta.ws.rs.ForbiddenException(
-                    "X-Realm does not match the realm authorized by the token");
+            String realmBoundary = claimString("realmRegEx");
+            boolean withinBoundary = false;
+            if (realmBoundary != null && !realmOverride.equalsIgnoreCase(systemRealm)) {
+                if ("*".equals(realmBoundary)) {
+                    withinBoundary = true;
+                } else {
+                    try {
+                        withinBoundary = realmOverride.matches(realmBoundary);
+                    } catch (java.util.regex.PatternSyntaxException e) {
+                        throw new jakarta.ws.rs.ForbiddenException(
+                                "Signed realm boundary is not a valid pattern");
+                    }
+                }
+            }
+            if (!withinBoundary) {
+                throw new jakarta.ws.rs.ForbiddenException(
+                        "X-Realm does not match the realm authorized by the token");
+            }
+            contextRealm = realmOverride;
+            realmSwitched = true;
         }
-        String contextRealm = signedRealm;
         String[] roles = resolveEffectiveRoles(
                 securityIdentity, null, signedRealm, contextRealm);
 
@@ -821,7 +844,9 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             String tenantId = claimString("tenantId");
             String orgRefName = claimString("orgRefName");
             String accountNum = claimString("accountNum");
-            if (tenantId != null && orgRefName != null && accountNum != null) {
+            // Token data-domain claims describe the LOGIN realm; a switched
+            // realm's data domain must come from the realm catalog below.
+            if (!realmSwitched && tenantId != null && orgRefName != null && accountNum != null) {
                 dataDomain = new DataDomain(orgRefName, accountNum, tenantId, 0, userId);
             } else {
                 // Older trusted tokens may not carry the full data-domain projection. Resolve

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/CredentialsResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/CredentialsResource.java
@@ -223,6 +223,37 @@ public class CredentialsResource extends BaseResource<CredentialUserIdPassword, 
         return Response.ok(realms).build();
     }
 
+    /**
+     * Classify the NATURE of an account (USER / SERVICE / SYSTEM). USER
+     * accounts must have a directory profile — login enforces it — so
+     * classifying legacy credentials is how admins retire "unclassified"
+     * rows surfaced by the account audit.
+     */
+    @PUT
+    @Path("accountType/{id}")
+    @RolesAllowed({ "admin", "system" })
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response setAccountType(@PathParam("id") String id,
+                                   @QueryParam("accountType") com.e2eq.framework.model.security.AccountType accountType) {
+        if (id == null || id.isBlank() || accountType == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(RestError.builder()
+                    .status(Response.Status.BAD_REQUEST.getStatusCode())
+                    .statusMessage("id and accountType (USER|SERVICE|SYSTEM) are required")
+                    .build()).build();
+        }
+        Optional<CredentialUserIdPassword> credentialOptional = repo.findById(id);
+        if (credentialOptional.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).entity(RestError.builder()
+                    .status(Response.Status.NOT_FOUND.getStatusCode())
+                    .statusMessage("No credential with id " + id)
+                    .build()).build();
+        }
+        CredentialUserIdPassword credential = credentialOptional.get();
+        credential.setAccountType(accountType);
+        credential.setLastUpdate(new java.util.Date());
+        return Response.ok(repo.save(credential)).build();
+    }
+
     @GET
     @Path("byUserId")
     @RolesAllowed({ "user", "admin", "system" })

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/DatastoreInfoResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/DatastoreInfoResource.java
@@ -1,0 +1,72 @@
+package com.e2eq.framework.rest.resources;
+
+import com.e2eq.framework.annotations.FunctionalAction;
+import com.e2eq.framework.annotations.FunctionalMapping;
+import com.mongodb.ConnectionString;
+import io.quarkus.security.Authenticated;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Reports which MongoDB deployment THIS service instance is connected to.
+ *
+ * <p>Datastore attachment is a property of the running service instance, not
+ * of a deployment environment: two services in the same environment can point
+ * at different clusters, and the system console's topology view must render
+ * what each instance actually uses rather than an environment-level guess.
+ *
+ * <p>The connection string is parsed and projected — hosts, SRV, replica set,
+ * TLS, default database. Credentials and the raw URI are never returned.
+ */
+@Path("/system/datastore-info")
+@ApplicationScoped
+@Authenticated
+@FunctionalMapping(area = "system", domain = "service_instance")
+public class DatastoreInfoResource {
+
+    @ConfigProperty(name = "quarkus.mongodb.connection-string")
+    Optional<String> connectionString;
+
+    @GET
+    @FunctionalAction("view")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response get() {
+        if (connectionString.isEmpty() || connectionString.get().isBlank()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                .entity(Map.of("statusMessage",
+                    "This service does not declare a MongoDB connection (quarkus.mongodb.connection-string is unset)"))
+                .build();
+        }
+        ConnectionString parsed;
+        try {
+            parsed = new ConnectionString(connectionString.get().trim());
+        }
+        catch (RuntimeException e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(Map.of("statusMessage",
+                    "The configured MongoDB connection string could not be parsed: " + e.getMessage()))
+                .build();
+        }
+        Map<String, Object> body = new LinkedHashMap<>();
+        List<String> hosts = parsed.getHosts();
+        body.put("hosts", hosts);
+        body.put("srv", parsed.isSrvProtocol());
+        // A stable one-line label for topology displays.
+        body.put("clusterLabel", (parsed.isSrvProtocol() ? "srv://" : "") + String.join(",", hosts)
+            + (parsed.getRequiredReplicaSetName() != null ? " (rs: " + parsed.getRequiredReplicaSetName() + ")" : ""));
+        if (parsed.getRequiredReplicaSetName() != null) body.put("replicaSet", parsed.getRequiredReplicaSetName());
+        if (parsed.getSslEnabled() != null) body.put("tls", parsed.getSslEnabled());
+        if (parsed.getDatabase() != null) body.put("defaultDatabase", parsed.getDatabase());
+        return Response.ok(body).build();
+    }
+}

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PermissionResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/PermissionResource.java
@@ -423,10 +423,16 @@ public class PermissionResource {
 
          Set<String> actions = ensureAreaDomain(areaDomainActions, area, domain);
          if (includeActions) {
+            // Entity-backed domains genuinely serve generic CRUD via BaseResource.
             if (ei.actions != null) actions.addAll(ei.actions);
             addDefaultActions(actions);
          }
       }
+
+      // 1.5) From REST resources' @FunctionalMapping/@FunctionalAction — their
+      // DECLARED verbs only (a browse resource is view-only, a profile resource
+      // declares password verbs); never widened to CRUD.
+      mergeResourceMappings(areaDomainActions, discoverResourceMappings(), includeActions);
 
       // 2) From DB (FunctionalDomain collection)
       List<FunctionalDomain> stored = functionalDomainRepo.getAllList();
@@ -439,14 +445,17 @@ public class PermissionResource {
 
             Set<String> actions = ensureAreaDomain(areaDomainActions, area, domain);
             if (includeActions) {
+               boolean declaredAny = false;
                if (fd.getFunctionalActions() != null) {
                   for (com.e2eq.framework.model.security.FunctionalAction a : fd.getFunctionalActions()) {
                      if (a == null) continue;
                      String ref = safe(a.getRefName());
-                     if (!ref.isEmpty()) actions.add(ref);
+                     if (!ref.isEmpty()) { actions.add(ref); declaredAny = true; }
                   }
                }
-               addDefaultActions(actions);
+               // A record that DECLARES its actions means them; CRUD is only the
+               // fallback for records that declare nothing.
+               if (!declaredAny) addDefaultActions(actions);
             }
          }
       }
@@ -489,6 +498,68 @@ public class PermissionResource {
       target.add("DELETE");
       target.add("VIEW");
       target.add("LIST");
+   }
+
+   /**
+    * Domains declared by REST resources via {@code @FunctionalMapping}, with the
+    * ACTIONS THEY ACTUALLY DECLARE via {@code @FunctionalAction} methods. Actions
+    * are not a fixed CRUD set — a user-profile resource declares verbs like a
+    * password reset, a browse resource declares only {@code view}. A resource
+    * that declares a mapping but no explicit actions falls back to the CRUD
+    * defaults (we know nothing better). Entity-backed domains keep their CRUD
+    * defaults elsewhere — BaseResource genuinely serves them.
+    */
+   private Map<String, Map<String, Set<String>>> discoverResourceMappings() {
+      Map<String, Map<String, Set<String>>> out = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+      try {
+         jakarta.enterprise.inject.spi.BeanManager beanManager =
+                 jakarta.enterprise.inject.spi.CDI.current().getBeanManager();
+         java.util.Set<jakarta.enterprise.inject.spi.Bean<?>> beans =
+                 beanManager.getBeans(Object.class, jakarta.enterprise.inject.Any.Literal.INSTANCE);
+         io.quarkus.logging.Log.debugf("Resource @FunctionalMapping discovery scanning %d beans", beans.size());
+         for (jakarta.enterprise.inject.spi.Bean<?> bean : beans) {
+            Class<?> clazz = bean.getBeanClass();
+            if (clazz == null) continue;
+            com.e2eq.framework.annotations.FunctionalMapping fm =
+                    clazz.getAnnotation(com.e2eq.framework.annotations.FunctionalMapping.class);
+            if (fm == null) continue;
+            // Only REST resources contribute here; entities are discovered from the model.
+            if (clazz.getAnnotation(jakarta.ws.rs.Path.class) == null) continue;
+            String area = safe(fm.area());
+            String domain = safe(fm.domain());
+            if (area.isEmpty() || domain.isEmpty()) continue;
+            Set<String> declared = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            for (Method m : clazz.getDeclaredMethods()) {
+               com.e2eq.framework.annotations.FunctionalAction fa =
+                       m.getAnnotation(com.e2eq.framework.annotations.FunctionalAction.class);
+               if (fa == null) continue;
+               String val = safe(fa.value());
+               declared.add(val.isEmpty() ? m.getName() : val);
+            }
+            Set<String> actions = ensureAreaDomain(out, area, domain);
+            if (declared.isEmpty()) {
+               addDefaultActions(actions);
+            } else {
+               actions.addAll(declared);
+            }
+         }
+      } catch (Throwable t) {
+         io.quarkus.logging.Log.warnf("Resource @FunctionalMapping discovery skipped: %s", t);
+      }
+      io.quarkus.logging.Log.debugf("Resource @FunctionalMapping discovery found %d areas: %s", out.size(), out.keySet());
+      return out;
+   }
+
+   /** Merge resource-declared mappings into a discovery map without widening declared action sets. */
+   private static void mergeResourceMappings(Map<String, Map<String, Set<String>>> target,
+                                             Map<String, Map<String, Set<String>>> resourceMappings,
+                                             boolean includeActions) {
+      for (Map.Entry<String, Map<String, Set<String>>> areaEntry : resourceMappings.entrySet()) {
+         for (Map.Entry<String, Set<String>> domainEntry : areaEntry.getValue().entrySet()) {
+            Set<String> actions = ensureAreaDomain(target, areaEntry.getKey(), domainEntry.getKey());
+            if (includeActions) actions.addAll(domainEntry.getValue());
+         }
+      }
    }
 
 
@@ -781,6 +852,8 @@ public class PermissionResource {
          if (ei.actions != null) actions.addAll(ei.actions);
          addDefaultActions(actions);
       }
+      // 1.5) REST resources' declared verbs (see /fd) — never widened to CRUD.
+      mergeResourceMappings(discovered, discoverResourceMappings(), true);
       // 2) From DB FunctionalDomain collection
       List<FunctionalDomain> stored = functionalDomainRepo.getAllList();
       if (stored != null) {
@@ -790,14 +863,15 @@ public class PermissionResource {
             String d = safe(fd.getRefName());
             if (a.isEmpty() || d.isEmpty()) continue;
             Set<String> actions = ensureAreaDomain(discovered, a, d);
+            boolean declaredAny = false;
             if (fd.getFunctionalActions() != null) {
                for (com.e2eq.framework.model.security.FunctionalAction fa : fd.getFunctionalActions()) {
                   if (fa == null) continue;
                   String ref = safe(fa.getRefName());
-                  if (!ref.isEmpty()) actions.add(ref);
+                  if (!ref.isEmpty()) { actions.add(ref); declaredAny = true; }
                }
             }
-            addDefaultActions(actions);
+            if (!declaredAny) addDefaultActions(actions);
          }
       }
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
@@ -424,7 +424,55 @@ public class SecurityResource {
                 request.getRoles(),
                 request.getDomainContext()
         );
+        ensureDirectoryProfile(request);
         return Response.ok().build();
+    }
+
+    /**
+     * A credential without a directory profile is a half-created user: it can
+     * log in, but it is invisible to the global directory (admin user lists,
+     * access assignments) and 404s on {@code /security/me}. Creating a user
+     * therefore creates BOTH records in one operation. Idempotent: an existing
+     * profile is left untouched. Directory profiles carry the SYSTEM data
+     * domain — the global directory is a system-plane surface; per-tenant
+     * visibility remains the policy engine's job.
+     */
+    private void ensureDirectoryProfile(CreateUserRequest request) {
+        String systemRealm = envConfigUtils.getSystemRealm();
+        CredentialUserIdPassword credential = credentialRepo
+                .findByUserId(request.getUserId(), systemRealm, true)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Credential missing immediately after create for userId: " + request.getUserId()));
+
+        Optional<UserProfile> existing = userProfileRepo.getBySubject(systemRealm, credential.getSubject());
+        if (existing.isEmpty()) {
+            existing = userProfileRepo.getByUserIdWithIgnoreRules(systemRealm, request.getUserId());
+        }
+        if (existing.isPresent()) {
+            return;
+        }
+
+        UserProfile profile = new UserProfile();
+        profile.setUserId(request.getUserId());
+        profile.setRefName(request.getUserId());
+        profile.setDisplayName(request.getDisplayName() != null && !request.getDisplayName().isBlank()
+                ? request.getDisplayName() : request.getUserId());
+        profile.setEmail(request.getEmail());
+        profile.setFname(request.getFirstName() != null && !request.getFirstName().isBlank()
+                ? request.getFirstName() : request.getUserId());
+        profile.setLname(request.getLastName() != null && !request.getLastName().isBlank()
+                ? request.getLastName() : "user");
+        profile.setStatus(UserProfile.Status.ACTIVE);
+        profile.setCredentialUserIdPasswordRef(credential.createEntityReference(systemRealm));
+        profile.setDataDomain(com.e2eq.framework.model.persistent.base.DataDomain.builder()
+                .orgRefName(envConfigUtils.getSystemOrgRefName())
+                .accountNum(envConfigUtils.getSystemAccountNumber())
+                .tenantId(envConfigUtils.getSystemTenantId())
+                .dataSegment(0)
+                .ownerId(request.getUserId())
+                .build());
+        userProfileRepo.save(systemRealm, profile);
+        Log.infof("createUser: created directory profile for %s in realm %s", request.getUserId(), systemRealm);
     }
 
     @POST

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/UserRealmRoleResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/UserRealmRoleResource.java
@@ -1,7 +1,12 @@
 package com.e2eq.framework.rest.resources;
 
+import com.e2eq.framework.model.auth.ApplicationAuthorizationResolver;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.RealmRepo;
 import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
 import com.e2eq.framework.model.security.UserRealmRole;
+import com.e2eq.framework.rest.models.ApplicationAccessEvaluation;
 import com.e2eq.framework.rest.models.ApplicationGrantRequest;
 import com.e2eq.framework.rest.models.RestError;
 import com.e2eq.framework.service.application.ApplicationRegistryUnavailableException;
@@ -48,6 +53,12 @@ public class UserRealmRoleResource extends BaseResource<UserRealmRole, UserRealm
    @Inject
    ApplicationRegistryValidator applicationRegistryValidator;
 
+   @Inject
+   CredentialRepo credentialRepo;
+
+   @Inject
+   RealmRepo realmRepo;
+
    protected UserRealmRoleResource(UserRealmRoleRepo repo) {
       super(repo);
    }
@@ -63,6 +74,62 @@ public class UserRealmRoleResource extends BaseResource<UserRealmRole, UserRealm
          return notFound(userId, realmRefName);
       }
       return Response.ok(membership.get()).build();
+   }
+
+   /**
+    * Server-truth application-access evaluation: runs the SAME resolver a login
+    * runs (list-or-* contract) against the user's stored credential pattern and
+    * (user, realm) grant — without authenticating. Answers: what token scoping
+    * would a login to this realm (optionally naming an application) produce?
+    * AMBIGUOUS results with a pattern grant are enriched with candidates from
+    * the realm catalog (the application-usage registry), like login is.
+    */
+   @GET
+   @Path("{userId}/{realmRefName}/applications/evaluate")
+   @Produces(MediaType.APPLICATION_JSON)
+   public Response evaluateApplicationAccess(@PathParam("userId") String userId,
+                                             @PathParam("realmRefName") String realmRefName,
+                                             @jakarta.ws.rs.QueryParam("applicationId") String applicationId) {
+      Optional<CredentialUserIdPassword> credentialOp =
+              credentialRepo.findByUserId(userId, envConfigUtils.getSystemRealm(), true);
+      if (credentialOp.isEmpty()) {
+         return Response.status(Response.Status.NOT_FOUND)
+                 .entity(RestError.builder()
+                         .status(Response.Status.NOT_FOUND.getStatusCode())
+                         .statusMessage("No credential exists for userId '" + userId + "'")
+                         .build())
+                 .build();
+      }
+      CredentialUserIdPassword credential = credentialOp.get();
+      Optional<UserRealmRole> membership = loadMembership(userId, realmRefName);
+      List<String> granted = membership.map(UserRealmRole::getAuthorizedApplications).orElse(null);
+      String defaultApplication = membership.map(UserRealmRole::getDefaultApplication).orElse(null);
+
+      ApplicationAuthorizationResolver.Result result = ApplicationAuthorizationResolver.resolve(
+              granted, credential.getApplicationRegEx(), defaultApplication, trimToNull(applicationId));
+
+      List<String> candidates = result.candidates();
+      if (result.outcome() == ApplicationAuthorizationResolver.Outcome.AMBIGUOUS && candidates.isEmpty()) {
+         String pattern = credential.getApplicationRegEx();
+         candidates = realmRepo.findDistinctApplicationRefNames().stream()
+                 .filter(app -> ApplicationAuthorizationResolver.matches(pattern, app))
+                 .toList();
+      }
+
+      return Response.ok(new ApplicationAccessEvaluation(
+              userId,
+              realmRefName,
+              trimToNull(applicationId),
+              result.outcome().name(),
+              result.audiences(),
+              result.activeApplication(),
+              result.wildcard(),
+              candidates,
+              result.deniedApplication(),
+              credential.getApplicationRegEx(),
+              granted,
+              defaultApplication,
+              membership.isPresent())).build();
    }
 
    /**

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -4,6 +4,7 @@ package com.e2eq.framework.model.auth.provider.jwtToken;
 import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
 
 
+import com.e2eq.framework.model.persistent.base.ActiveStatus;
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.auth.ApplicationAuthorizationResolver;
 import com.e2eq.framework.model.auth.AuthProvider;
@@ -256,6 +257,9 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
          credential.setRoles(roles.toArray(new String[roles.size()]));
          credential.setLastUpdate(new Date());
          credential.setAuthProviderName(getName());
+         // createUser is the human-account path; service/system principals are
+         // created through their own dedicated surfaces which stamp their type.
+         credential.setAccountType(com.e2eq.framework.model.security.AccountType.USER);
          credentialRepo.save(credential);
       }
       return subject;
@@ -525,6 +529,50 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
 
          if (ocredential.isPresent()) {
             CredentialUserIdPassword credential = ocredential.get();
+            // Disabled credentials must not authenticate. null activeStatus is
+            // legacy-allowed (rows that predate the flag); INACTIVE/DELETED are
+            // authoritative. The negative envelope stays generic so account
+            // state is not disclosed to callers; the real reason is logged.
+            if (credentialDisabled(credential)) {
+               Log.warnf("Login rejected: credential %s has activeStatus=%s", userId, credential.getActiveStatus());
+               return new LoginResponse(false,
+                  new LoginNegativeResponse(userId,
+                     400,
+                     401,
+                     "Invalid credentials",
+                     "Invalid credentials",
+                     "credentials did not match",
+                     envConfigUtils.getSystemRealm())
+               );
+            }
+            // Account-nature invariant: a USER account must have a directory
+            // profile (half-created accounts can otherwise log in while being
+            // invisible to every admin surface). Legacy credentials (null
+            // accountType) are flagged in the log but not locked out.
+            if (credential.getAccountType() == com.e2eq.framework.model.security.AccountType.USER
+                  || credential.getAccountType() == null) {
+               boolean hasProfile = userProfileRepo
+                     .getBySubject(envConfigUtils.getSystemRealm(), credential.getSubject()).isPresent()
+                     || userProfileRepo
+                     .getByUserIdWithIgnoreRules(envConfigUtils.getSystemRealm(), credential.getUserId()).isPresent();
+               if (!hasProfile) {
+                  if (credential.getAccountType() == com.e2eq.framework.model.security.AccountType.USER) {
+                     Log.warnf("Login rejected: USER account %s has no directory profile (half-created account)",
+                           userId);
+                     return new LoginResponse(false,
+                        new LoginNegativeResponse(userId,
+                           400,
+                           401,
+                           "Invalid credentials",
+                           "Invalid credentials",
+                           "credentials did not match",
+                           envConfigUtils.getSystemRealm())
+                     );
+                  }
+                  Log.warnf("Unclassified credential %s has no directory profile — classify its accountType "
+                        + "and create a profile, or mark it SERVICE/SYSTEM", userId);
+               }
+            }
             if (credential.getForceChangePassword() != null && credential.getForceChangePassword()) {
                return new LoginResponse(false,
                   new LoginNegativeResponse(userId,
@@ -673,6 +721,10 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                         tokenDomainContext.getAccountId(),
                         appAuth.audiences(),
                         appAuth.activeApplication(),
+                        // Signed realm boundary: lets delegated-claims validators
+                        // authorize X-Realm switches within the credential's own
+                        // declared boundary instead of pinning to the login realm.
+                        credential.getRealmRegEx(),
                         TokenUtils.expiresAt(durationInSeconds),
                         issuer);
                   } else {
@@ -684,6 +736,11 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                         tokenDomainContext.getTenantId(),
                         tokenDomainContext.getOrgRefName(),
                         tokenDomainContext.getAccountId(),
+                        null,
+                        null,
+                        // Signed realm boundary for delegated X-Realm switching,
+                        // matching the application-resolved branch above.
+                        credential.getRealmRegEx(),
                         TokenUtils.expiresAt(durationInSeconds),
                         issuer);
                   }
@@ -853,6 +910,10 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
          if (!credentialRealmAuthorized) {
             throw new SecurityException("Credential is no longer authorized for realm: " + tokenRealm);
          }
+         if (credentialDisabled(credential)) {
+            Log.warnf("Refresh rejected: credential %s has activeStatus=%s", userId, credential.getActiveStatus());
+            throw new SecurityException("Credential is no longer authorized");
+         }
 
          Set<String> credentialRoles = credentialRolesForRealm(
             credential.getRoles(), credentialRealm, tokenRealm);
@@ -943,6 +1004,16 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                e.toString(),
                envConfigUtils.getSystemRealm()));
       }
+   }
+
+   /**
+    * A credential marked INACTIVE or DELETED must not authenticate or refresh.
+    * null is legacy-allowed: rows created before the flag existed carry no
+    * status, and "unknown" must not lock every existing deployment out.
+    */
+   static boolean credentialDisabled(CredentialUserIdPassword credential) {
+      ActiveStatus status = credential.getActiveStatus();
+      return status == ActiveStatus.INACTIVE || status == ActiveStatus.DELETED;
    }
 
    static boolean credentialAuthorizesRealm(SecurityUtils securityUtils,

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
@@ -220,6 +220,28 @@ public class TokenUtils {
 											String activeApplication,
 											long expiresAt,
 											String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+		return generateUserToken(subject, userId, groups, realm, tenantId, orgRefName, accountNum,
+				audiences, activeApplication, null, expiresAt, issuer);
+	}
+
+	/**
+	 * Application-scoped token that also carries the credential's REALM BOUNDARY
+	 * ({@code realmRegEx} claim — {@code "*"} or a regex). Delegated-claims
+	 * validators use it to authorize X-Realm switches inside the boundary the
+	 * issuer signed, instead of pinning the session to the login realm.
+	 */
+	public static String generateUserToken(String subject,
+											String userId,
+											Set<String> groups,
+											String realm,
+											String tenantId,
+											String orgRefName,
+											String accountNum,
+											Set<String> audiences,
+											String activeApplication,
+											String realmBoundary,
+											long expiresAt,
+											String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
 
 		Objects.requireNonNull(subject, "subject cannot be null");
 		Objects.requireNonNull(issuer, "Issuer cannot be null");
@@ -244,6 +266,9 @@ public class TokenUtils {
 		addPrincipalClaims(claimsBuilder, userId, realm, tenantId, orgRefName, accountNum);
 		if (activeApplication != null && !activeApplication.isBlank()) {
 			claimsBuilder.claim("azp", activeApplication);
+		}
+		if (realmBoundary != null && !realmBoundary.isBlank()) {
+			claimsBuilder.claim("realmRegEx", realmBoundary.trim());
 		}
 		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
 	}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/AccountType.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/AccountType.java
@@ -1,0 +1,28 @@
+package com.e2eq.framework.model.security;
+
+/**
+ * The NATURE of the account behind a credential — orthogonal to
+ * {@link CredentialType}, which is the authentication MECHANISM (password,
+ * service token, OAuth…). A password credential can belong to a human or to a
+ * bootstrap principal; this classification is what invariants hang on:
+ *
+ * <ul>
+ *   <li>{@link #USER} — a human user. A directory {@code UserProfile} is
+ *       REQUIRED: login is refused for a USER credential without one, and admin
+ *       surfaces list users from the profile directory. This closes the
+ *       "half-created account" gap (can log in, invisible everywhere).</li>
+ *   <li>{@link #SERVICE} — machine identity (service tokens, integrations).
+ *       No profile expected; excluded from people-facing directory views.</li>
+ *   <li>{@link #SYSTEM} — platform principals (bootstrap, system accounts).
+ *       Profile optional; shown to operators but distinguishable from people.</li>
+ * </ul>
+ *
+ * A null accountType is a LEGACY credential created before this field existed:
+ * enforcement logs the inconsistency but does not lock the account out;
+ * admin surfaces flag it as unclassified.
+ */
+public enum AccountType {
+    USER,
+    SERVICE,
+    SYSTEM
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/CredentialUserIdPassword.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/CredentialUserIdPassword.java
@@ -143,6 +143,13 @@ public class CredentialUserIdPassword extends BaseModel {
    @Builder.Default
    protected CredentialType credentialType = CredentialType.PASSWORD;
 
+   /**
+    * The NATURE of the account (orthogonal to the mechanism above): USER
+    * requires a directory UserProfile (enforced at login), SERVICE/SYSTEM do
+    * not. null = legacy/unclassified (flagged, not locked out).
+    */
+   protected AccountType accountType;
+
    /** For SERVICE_TOKEN credentials: the subject of the owning PASSWORD credential. */
    protected String parentCredentialSubject;
 

--- a/quantum-models/src/main/java/com/e2eq/framework/rest/models/ApplicationAccessEvaluation.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/rest/models/ApplicationAccessEvaluation.java
@@ -1,0 +1,34 @@
+package com.e2eq.framework.rest.models;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Server-truth result of evaluating a user's application access for a realm —
+ * the SAME {@code ApplicationAuthorizationResolver} decision a login would
+ * make (list-or-* contract), computed from the stored credential pattern and
+ * the (user, realm) membership grant without authenticating.
+ */
+@RegisterForReflection
+public record ApplicationAccessEvaluation(
+        String userId,
+        String realmRefName,
+        String requestedApplicationId,
+        /** LEGACY | RESOLVED | AMBIGUOUS | DENIED */
+        String outcome,
+        /** Token aud set a login would mint (RESOLVED only; may be ["*"]). */
+        Set<String> audiences,
+        /** azp a login would mint (RESOLVED; may be null). */
+        String activeApplication,
+        boolean wildcard,
+        /** Selection candidates (AMBIGUOUS; registry-enriched for patterns). */
+        List<String> candidates,
+        String deniedApplication,
+        /** Inputs the decision was made from, for admin transparency. */
+        String applicationRegEx,
+        List<String> authorizedApplications,
+        String defaultApplication,
+        boolean membershipExists) {
+}

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/PermissionRuleInterceptor.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/interceptors/PermissionRuleInterceptor.java
@@ -47,6 +47,10 @@ public class PermissionRuleInterceptor implements EntityListener {
                    || action.equalsIgnoreCase("delete")
                    || action.equalsIgnoreCase("apply")
                    || action.equalsIgnoreCase("write")
+                   // Imperative execution verb: migrations and runs mutate state
+                   // by definition (DatabaseVersion, ChangeSetRecord). The rule
+                   // check below still decides WHETHER the principal may do it.
+                   || action.equalsIgnoreCase("run")
                   || action.equals("*"))) {
              throw new SecurityException("Persistence callback requires an explicit write action; received: " + action);
           }

--- a/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/ManagedSecretResource.java
+++ b/quantum-secrets/src/main/java/com/e2eq/framework/secrets/rest/ManagedSecretResource.java
@@ -1,5 +1,7 @@
 package com.e2eq.framework.secrets.rest;
 
+import com.e2eq.framework.annotations.FunctionalAction;
+import com.e2eq.framework.annotations.FunctionalMapping;
 import com.e2eq.framework.secrets.crypto.EncryptedValue;
 import com.e2eq.framework.secrets.crypto.SecretEncryptor;
 import com.e2eq.framework.secrets.model.ManagedSecret;
@@ -31,6 +33,11 @@ import java.util.Map;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @RolesAllowed({"tenantAdmin", "platformAdmin", "admin", "system"})
+// Mirrors the ManagedSecret model's mapping. Without a RESOURCE-level mapping the
+// SecurityFilter builds an anonymous ResourceContext (action=none) for this path
+// and PermissionRuleInterceptor.prePersist fail-closes every save with
+// "Persistence callback requires an explicit write action".
+@FunctionalMapping(area = "SECURITY", domain = "SECRET")
 public class ManagedSecretResource {
 
     private static final Logger LOG = Logger.getLogger(ManagedSecretResource.class);
@@ -71,6 +78,7 @@ public class ManagedSecretResource {
     }
 
     @GET
+    @FunctionalAction("LIST")
     public Response list(@QueryParam("type") String secretType) {
         String realmId = repo.getSecurityContextRealmId();
         List<ManagedSecretResponse> response = repo.findAll(realmId, secretType)
@@ -82,6 +90,7 @@ public class ManagedSecretResource {
 
     @GET
     @Path("{refName}")
+    @FunctionalAction("VIEW")
     public Response get(@PathParam("refName") String refName) {
         String realmId = repo.getSecurityContextRealmId();
         ManagedSecret secret = repo.findByRefName(realmId, refName)
@@ -96,6 +105,7 @@ public class ManagedSecretResource {
     @GET
     @Path("{refName}/value")
     @RolesAllowed({"tenantAdmin", "platformAdmin", "admin", "system"})
+    @FunctionalAction("VIEW")
     public Response getValue(@PathParam("refName") String refName) {
         String realmId = repo.getSecurityContextRealmId();
         ManagedSecret secret = repo.findByRefName(realmId, refName)
@@ -134,6 +144,7 @@ public class ManagedSecretResource {
     }
 
     @POST
+    @FunctionalAction("CREATE")
     public Response create(ManagedSecretCreateUpdateRequest request) {
         if (request == null || request.getRefName() == null || request.getRefName().isBlank()) {
             return Response.status(Response.Status.BAD_REQUEST).entity("refName is required").build();
@@ -150,6 +161,7 @@ public class ManagedSecretResource {
 
     @PUT
     @Path("{refName}")
+    @FunctionalAction("UPDATE")
     public Response update(@PathParam("refName") String refName, ManagedSecretCreateUpdateRequest request) {
         if (request == null) {
             return Response.status(Response.Status.BAD_REQUEST).build();
@@ -164,6 +176,7 @@ public class ManagedSecretResource {
 
     @DELETE
     @Path("{refName}")
+    @FunctionalAction("DELETE")
     public Response delete(@PathParam("refName") String refName) {
         String realmId = repo.getSecurityContextRealmId();
         if (!repo.deleteByRefName(realmId, refName)) {
@@ -179,6 +192,7 @@ public class ManagedSecretResource {
     @POST
     @Path("rotate-keys")
     @RolesAllowed({"platformAdmin", "admin", "system"})
+    @FunctionalAction("UPDATE")
     public Response rotateKeys() {
         if (!encryptor.isKeysAvailable()) {
             return Response.status(Response.Status.SERVICE_UNAVAILABLE)


### PR DESCRIPTION
Delegated realm-boundary switching (signed realmRegEx claim), resource-declared FD/FA discovery (actions are not always CRUD), run-as-write-verb for migrations, per-instance datastore-info endpoint, AccountType + evaluation DTOs.

Verified live across the local stack (tenant switching, FD matrix per backend, gcp-dev identity plane) during the 2026-07-21/22 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)