### PR TITLE
fix(auth): stamp application boundary at create-user; typed 422 on boundary-less login

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/requests/CreateUserRequest.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/requests/CreateUserRequest.java
@@ -58,4 +58,14 @@ public class CreateUserRequest {
    @NonNull
    @Valid
    DomainContext domainContext;
+
+   /**
+    * Application boundary for the created credential: {@code "*"} authorizes any
+    * application; otherwise a regular expression matched against application ids.
+    * Login mints application-scoped tokens and rejects credentials that carry no
+    * boundary and no per-realm application grant, so when this field is omitted the
+    * provider applies its documented default ({@code "*"} for the custom provider —
+    * the pre-application-scoping behavior) to keep the new user loginable.
+    */
+   String applicationRegEx;
 }

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/SecurityResource.java
@@ -422,7 +422,8 @@ public class SecurityResource {
                 request.getPassword(),
                 request.getForceChangePassword(),
                 request.getRoles(),
-                request.getDomainContext()
+                request.getDomainContext(),
+                request.getApplicationRegEx()
         );
         ensureDirectoryProfile(request);
         return Response.ok().build();

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/UserProfileResource.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/resources/UserProfileResource.java
@@ -111,7 +111,8 @@ public class UserProfileResource extends BaseResource<UserProfile, UserProfileRe
             createUserRequest.getPassword(),
             createUserRequest.getForceChangePassword(),
             createUserRequest.getRoles(),
-            createUserRequest.getDomainContext());
+            createUserRequest.getDomainContext(),
+            createUserRequest.getApplicationRegEx());
 
          Optional<CredentialUserIdPassword> ocred = credentialRepo.findByUserId(createUserRequest.getUserId());
          if (!ocred.isPresent())

--- a/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/rest/services/AuthLoginService.java
@@ -48,6 +48,7 @@ public class AuthLoginService {
     /** Application-authorization signals a provider may return as a negative login response. */
     private static final String APP_SELECTION_REQUIRED = "ApplicationSelectionRequired";
     private static final String APP_NOT_AUTHORIZED = "ApplicationNotAuthorized";
+    private static final String APP_AUTHORIZATION_MISSING = "ApplicationAuthorizationMissing";
     private static final String REALM_NOT_AUTHORIZED = "RealmNotAuthorized";
     private static final String REALM_AUTHORIZATION_UNAVAILABLE = "RealmAuthorizationUnavailable";
 
@@ -93,6 +94,13 @@ public class AuthLoginService {
             }
             if (negative != null && APP_NOT_AUTHORIZED.equals(negative.errorType())) {
                 return LoginResult.applicationDenied(negative.errorMessage());
+            }
+            if (negative != null && APP_AUTHORIZATION_MISSING.equals(negative.errorType())) {
+                // Authenticated, but the credential has no application boundary and no
+                // per-realm grant — a configuration defect, not bad credentials. Surface
+                // the provider's diagnostic as a typed 422 instead of falling through to
+                // other providers or a generic 401.
+                return LoginResult.applicationAuthorizationMissing(negative.errorMessage());
             }
             if (negative != null && (REALM_NOT_AUTHORIZED.equals(negative.errorType())
                     || REALM_AUTHORIZATION_UNAVAILABLE.equals(negative.errorType()))) {
@@ -253,6 +261,16 @@ public class AuthLoginService {
             return new LoginResult(null, List.of(), Response.Status.FORBIDDEN.getStatusCode(), null, message);
         }
 
+        /**
+         * Authenticated, but the credential carries no application authorization at all
+         * (no applicationRegEx, no per-realm grant) — application-scoped tokens cannot
+         * be minted for it. 422: the request is well-formed; the account configuration
+         * is not.
+         */
+        public static LoginResult applicationAuthorizationMissing(String message) {
+            return new LoginResult(null, List.of(), 422, null, message);
+        }
+
         public static LoginResult realmDenied(String message) {
             return new LoginResult(null, List.of(), Response.Status.FORBIDDEN.getStatusCode(), null, message);
         }
@@ -263,6 +281,10 @@ public class AuthLoginService {
 
         public boolean needsApplicationSelection() {
             return status == Response.Status.BAD_REQUEST.getStatusCode();
+        }
+
+        public boolean applicationAuthorizationMissing() {
+            return status == 422;
         }
 
         public Response toResponse() {
@@ -280,6 +302,7 @@ public class AuthLoginService {
             }
             RestError error = RestError.builder()
                     .statusMessage(message != null ? message : "Authentication failed")
+                    .reasonMessage(applicationAuthorizationMissing() ? APP_AUTHORIZATION_MISSING : null)
                     .debugMessage(String.join("; ", providerFailures))
                     .status(status)
                     .build();

--- a/quantum-framework/src/test/java/com/e2eq/framework/SecurityTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/SecurityTest.java
@@ -80,6 +80,13 @@ public class SecurityTest extends BaseRepoTest {
         if (credop.isPresent()) {
             Log.info("cred:" + credop.get().getUserId());
             cred = credop.get();
+            if (cred.getApplicationRegEx() == null) {
+                // Login mints application-scoped tokens and rejects credentials with no
+                // application boundary (typed 422); repair credentials persisted by
+                // earlier runs of this suite that predate the boundary requirement.
+                cred.setApplicationRegEx("*");
+                cred = credRepo.save(testUtils.getSystemRealm(), cred);
+            }
         } else {
             cred = new CredentialUserIdPassword();
             cred.setUserId(testUtils.getTestUserId());
@@ -107,6 +114,9 @@ public class SecurityTest extends BaseRepoTest {
             cred.setLastUpdate(new Date());
             cred.setDataDomain(dataDomain);
             cred.setRealmRegEx("*");
+            // Application boundary: without it the credential cannot be minted an
+            // application-scoped token and login fails fast with a typed 422.
+            cred.setApplicationRegEx("*");
             cred.setImpersonateFilterScript("return true");
             cred = credRepo.save(testUtils.getSystemRealm(),cred);
         }

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/auth/SecureResourceTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/auth/SecureResourceTest.java
@@ -3,6 +3,8 @@ package com.e2eq.framework.security.auth;
 import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
 import com.e2eq.framework.model.auth.AuthProvider;
 import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
 import com.e2eq.framework.security.runtime.RuleContext;
@@ -33,6 +35,12 @@ public class SecureResourceTest {
 
     @Inject
     RuleContext ruleContext;
+
+    @Inject
+    UserProfileRepo userProfileRepo;
+
+    @Inject
+    CredentialRepo credentialRepo;
 
     @Test
     public void testSecuredEndpoints() throws ReferentialIntegrityViolationException {
@@ -113,16 +121,22 @@ public class SecureResourceTest {
         try (final SecuritySession ss = new SecuritySession(pContext, rContext)) {
 
             if (authFactory.getUserManager().userIdExists("testuser@end2endlogic.com")) {
+                TestDirectoryProfiles.remove(userProfileRepo, testUtils.getSystemRealm(), "testuser@end2endlogic.com");
                 authFactory.getUserManager().removeUserWithUserId("testuser@end2endlogic.com");
             }
 
             authFactory.getUserManager().createUser( "testuser@end2endlogic.com", "P@55w@rd", Set.of("user"), testUtils.getTestDomainContext());
+            TestDirectoryProfiles.ensure(userProfileRepo, credentialRepo, testUtils.getSystemRealm(),
+                    testUtils.getSystemDataDomain(), "testuser@end2endlogic.com", "testuser@end2endlogic.com");
 
             if (authFactory.getUserManager().userIdExists("testadmin@end2endlogic.com")) {
+                TestDirectoryProfiles.remove(userProfileRepo, testUtils.getSystemRealm(), "testadmin@end2endlogic.com");
                 authFactory.getUserManager().removeUserWithUserId("testadmin@end2endlogic.com");
             }
 
             authFactory.getUserManager().createUser("testadmin@end2endlogic.com", "P@55w@rd",  Set.of("admin"), testUtils.getTestDomainContext());
+            TestDirectoryProfiles.ensure(userProfileRepo, credentialRepo, testUtils.getSystemRealm(),
+                    testUtils.getSystemDataDomain(), "testadmin@end2endlogic.com", "testadmin@end2endlogic.com");
             authFactory.getUserManager().enableImpersonationWithUserId("testadmin@end2endlogic.com", "true", "*", testUtils.getSystemRealm());
 
            loginResponse = authFactory.getAuthProvider().login("testadmin@end2endlogic.com", "P@55w@rd");

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/auth/TestCustTokenAuthProvider.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/auth/TestCustTokenAuthProvider.java
@@ -1,6 +1,8 @@
 package com.e2eq.framework.security.auth;
 
 import com.e2eq.framework.exceptions.ReferentialIntegrityViolationException;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
 import com.e2eq.framework.model.security.DomainContext;
 import com.e2eq.framework.model.auth.AuthProvider;
 import com.e2eq.framework.model.auth.AuthProviderFactory;
@@ -31,6 +33,12 @@ public class TestCustTokenAuthProvider extends BaseRepoTest {
     @Inject
     TestUtils testUtils;
 
+    @Inject
+    UserProfileRepo userProfileRepo;
+
+    @Inject
+    CredentialRepo credentialRepo;
+
 
 
     @Test
@@ -46,8 +54,11 @@ public class TestCustTokenAuthProvider extends BaseRepoTest {
                 AuthProvider authProvider = authProviderFactory.getAuthProvider();
                 UserManagement userManager = authProviderFactory.getUserManager();
 
+                TestDirectoryProfiles.remove(userProfileRepo, testUtils.getSystemRealm(), "testuser");
                 userManager.removeUserWithUserId("testuser"); // remove if exists
                 String subject = userManager.createUser("testuser", "test123456",  Set.of("user"), domainContext);
+                TestDirectoryProfiles.ensure(userProfileRepo, credentialRepo, testUtils.getSystemRealm(),
+                        testUtils.getSystemDataDomain(), "testuser", "testuser@example.test");
                 Set<String> roles = userManager.getUserRolesForSubject(subject);
                 Assert.assertTrue(roles.contains("user"));
                 AuthProvider.LoginResponse response = authProvider.login("testuser", "test123456");
@@ -57,6 +68,7 @@ public class TestCustTokenAuthProvider extends BaseRepoTest {
                 Assert.assertTrue(userManager.getUserRolesForSubject(subject).contains("admin"));
                 userManager.removeRolesForSubject(subject, Set.of("admin"));
                 Assert.assertFalse(userManager.getUserRolesForSubject(subject).contains("admin"));
+                TestDirectoryProfiles.remove(userProfileRepo, testUtils.getSystemRealm(), "testuser");
                 userManager.removeUserWithSubject(subject);
                 Assert.assertFalse(userManager.subjectExists(subject));
                 Assert.assertFalse(userManager.userIdExists("testuser"));
@@ -76,8 +88,11 @@ public class TestCustTokenAuthProvider extends BaseRepoTest {
                                                  .build();
                 AuthProvider authProvider = authProviderFactory.getAuthProvider();
                 UserManagement userManager = authProviderFactory.getUserManager();
+                TestDirectoryProfiles.remove(userProfileRepo, testUtils.getSystemRealm(), "testuser");
                 userManager.removeUserWithUserId("testuser"); // remove if exists
                 String subject = userManager.createUser("testuser", "test123456", Set.of("user"), domainContext);
+                TestDirectoryProfiles.ensure(userProfileRepo, credentialRepo, testUtils.getSystemRealm(),
+                        testUtils.getSystemDataDomain(), "testuser", "testuser@example.test");
                 Set<String> roles = userManager.getUserRolesForSubject(subject);
                 Assert.assertTrue(roles.contains("user"));
                 AuthProvider.LoginResponse response = authProvider.login("testuser", "test123456");
@@ -87,6 +102,7 @@ public class TestCustTokenAuthProvider extends BaseRepoTest {
                 Assert.assertTrue(userManager.getUserRolesForSubject(subject).contains("admin"));
                 userManager.removeRolesForUserId("testuser", Set.of("admin"));
                 Assert.assertFalse(userManager.getUserRolesForSubject(subject).contains("admin"));
+                TestDirectoryProfiles.remove(userProfileRepo, testUtils.getSystemRealm(), "testuser");
                 userManager.removeUserWithSubject(subject);
                 Assert.assertFalse(userManager.subjectExists(subject));
             }

--- a/quantum-framework/src/test/java/com/e2eq/framework/security/auth/TestDirectoryProfiles.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/security/auth/TestDirectoryProfiles.java
@@ -1,0 +1,60 @@
+package com.e2eq.framework.security.auth;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.persistent.morphia.CredentialRepo;
+import com.e2eq.framework.model.persistent.morphia.UserProfileRepo;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.model.security.UserProfile;
+
+/**
+ * Login rejects USER-typed credentials that have no directory profile in the
+ * system realm (half-created accounts are unloginable by design), and
+ * UserManagement.createUser stamps AccountType.USER. Tests that create users
+ * through UserManagement and then log in must therefore create the directory
+ * profile the same way /security/create-user does — and remove it before
+ * deleting the credential so referential integrity holds.
+ */
+final class TestDirectoryProfiles {
+
+    private TestDirectoryProfiles() {
+    }
+
+    static void ensure(UserProfileRepo profiles,
+                       CredentialRepo credentials,
+                       String systemRealm,
+                       DataDomain systemDataDomain,
+                       String userId,
+                       String email) {
+        CredentialUserIdPassword credential = credentials.findByUserId(userId, systemRealm, true)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Credential missing for test user: " + userId));
+        if (profiles.getBySubject(systemRealm, credential.getSubject()).isPresent()
+                || profiles.getByUserIdWithIgnoreRules(systemRealm, userId).isPresent()) {
+            return;
+        }
+        UserProfile profile = new UserProfile();
+        profile.setUserId(userId);
+        profile.setRefName(userId);
+        profile.setDisplayName(userId);
+        profile.setEmail(email);
+        profile.setFname(userId);
+        profile.setLname("user");
+        profile.setStatus(UserProfile.Status.ACTIVE);
+        profile.setCredentialUserIdPasswordRef(credential.createEntityReference(systemRealm));
+        profile.setDataDomain(new DataDomain(
+                systemDataDomain.getOrgRefName(),
+                systemDataDomain.getAccountNum(),
+                systemDataDomain.getTenantId(),
+                systemDataDomain.getDataSegment(),
+                userId));
+        profiles.save(systemRealm, profile);
+    }
+
+    static void remove(UserProfileRepo profiles, String systemRealm, String userId)
+            throws com.e2eq.framework.exceptions.ReferentialIntegrityViolationException {
+        var profile = profiles.getByUserIdWithIgnoreRules(systemRealm, userId);
+        if (profile.isPresent()) {
+            profiles.delete(systemRealm, profile.get());
+        }
+    }
+}

--- a/quantum-framework/src/test/resources/application.properties
+++ b/quantum-framework/src/test/resources/application.properties
@@ -36,7 +36,9 @@ mp.jwt.verify.publickey.location=publicKey.pem
 # in the code already some where?
 #smallrye.jwt.sign.key.location=privateKey.pem
 mp.jwt.verify.issuer=https://example.com/issuer
-mp.jwt.verify.audiences=b2bi-api-client,b2bi-api-client-refresh
+# "*" admits wildcard-entitlement tokens (list-or-* contract: a credential with
+# applicationRegEx="*" mints aud=["*"]); per-app admission stays in AudiencePolicy.
+mp.jwt.verify.audiences=b2bi-api-client,b2bi-api-client-refresh,*
 
 # Duration in Seconds do not go below 120 because the dialog timer is 120
 com.b2bi.jwt.duration=10000

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -212,6 +212,12 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
    @Override
    public String createUser (String userId, String password, Boolean forceChangePassword
       , Set<String> roles, DomainContext domainContext) throws SecurityException {
+      return createUser(userId, password, forceChangePassword, roles, domainContext, (String) null);
+   }
+
+   @Override
+   public String createUser (String userId, String password, Boolean forceChangePassword
+      , Set<String> roles, DomainContext domainContext, String applicationRegEx) throws SecurityException {
 
       Objects.requireNonNull(userId, "UserId cannot be null");
       Objects.requireNonNull(password, "Password cannot be null");
@@ -260,6 +266,7 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
          // createUser is the human-account path; service/system principals are
          // created through their own dedicated surfaces which stamp their type.
          credential.setAccountType(com.e2eq.framework.model.security.AccountType.USER);
+         credential.setApplicationRegEx(resolveApplicationBoundary(applicationRegEx));
          credentialRepo.save(credential);
       }
       return subject;
@@ -316,10 +323,41 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
             credential.setDataDomain(dataDomain);
          }
          credential.setAuthProviderName(getName());
+         credential.setApplicationRegEx(resolveApplicationBoundary(null));
          credentialRepo.save(credential);
 
       }
       return subject;
+   }
+
+   /**
+    * Application boundary stamped on every credential this provider creates. Login
+    * mints application-scoped tokens (the {@code aud} set comes from the credential's
+    * boundary or a per-realm application grant) and fails fast with a typed 422 when a
+    * credential has neither — so a credential created without a boundary would be
+    * unloginable. An explicit boundary is validated and used; otherwise the documented
+    * default {@code "*"} applies (any application — the pre-application-scoping
+    * behavior), which admins can narrow later with a concrete pattern or per-realm
+    * grants. Invalid patterns are rejected here, at create time, because the resolver
+    * fails closed on them at login — accepting one would recreate the unloginable-user
+    * defect with a harder-to-diagnose cause.
+    */
+   private static String resolveApplicationBoundary(String applicationRegEx) {
+      String boundary = applicationRegEx == null ? null : applicationRegEx.trim();
+      if (boundary == null || boundary.isEmpty()) {
+         return ApplicationAuthorizationResolver.WILDCARD;
+      }
+      if (!ApplicationAuthorizationResolver.WILDCARD.equals(boundary)) {
+         try {
+            java.util.regex.Pattern.compile(boundary);
+         } catch (java.util.regex.PatternSyntaxException e) {
+            throw new jakarta.ws.rs.WebApplicationException(
+               "Invalid applicationRegEx '" + boundary + "': " + e.getDescription()
+                  + ". Use '*' for any application or a valid regular expression.",
+               422);
+         }
+      }
+      return boundary;
    }
 
 
@@ -693,8 +731,23 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                               "ApplicationNotAuthorized",
                               appAuth.deniedApplication(),
                               tokenRealm));
+                     case LEGACY:
+                        // The credential authenticated but carries no application
+                        // authorization at all (applicationRegEx unset AND no per-realm
+                        // application grant). Application-scoped minting cannot produce a
+                        // valid audience set for it, so fail fast with a diagnostic the
+                        // operator can act on instead of letting the mint blow up as a 500.
+                        return new LoginResponse(false,
+                           new LoginNegativeResponse(userId, 422, 422,
+                              "Credential for user '" + userId + "' has no application authorization in realm '"
+                                 + tokenRealm + "': applicationRegEx is unset and the realm assigns no application "
+                                 + "grant. Set an application boundary on the credential (e.g. applicationRegEx '*') "
+                                 + "or grant applications on the user's realm role, then retry.",
+                              "ApplicationAuthorizationMissing",
+                              "applicationRegEx",
+                              tokenRealm));
                      default:
-                        break; // LEGACY or RESOLVED — mint below
+                        break; // RESOLVED — mint below
                   }
 
                   DomainContext tokenDomainContext = Objects.equals(credentialRealm, tokenRealm)
@@ -705,45 +758,28 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                         "Realm has no data-domain configuration: " + tokenRealm);
                   }
 
-                  String authToken;
-                  if (appAuth.resolved()) {
-                     if (appAuth.wildcard()) {
-                        Log.warnf("Wildcard application grant exercised (audit): user=%s realm=%s activeApplication=%s",
-                           userId, tokenRealm, appAuth.activeApplication());
-                     }
-                     authToken = TokenUtils.generateUserToken(
-                        subject,
-                        credential.getUserId(),
-                        groups,
-                        tokenRealm,
-                        tokenDomainContext.getTenantId(),
-                        tokenDomainContext.getOrgRefName(),
-                        tokenDomainContext.getAccountId(),
-                        appAuth.audiences(),
-                        appAuth.activeApplication(),
-                        // Signed realm boundary: lets delegated-claims validators
-                        // authorize X-Realm switches within the credential's own
-                        // declared boundary instead of pinning to the login realm.
-                        credential.getRealmRegEx(),
-                        TokenUtils.expiresAt(durationInSeconds),
-                        issuer);
-                  } else {
-                     authToken = TokenUtils.generateUserToken(
-                        subject,
-                        credential.getUserId(),
-                        groups,
-                        tokenRealm,
-                        tokenDomainContext.getTenantId(),
-                        tokenDomainContext.getOrgRefName(),
-                        tokenDomainContext.getAccountId(),
-                        null,
-                        null,
-                        // Signed realm boundary for delegated X-Realm switching,
-                        // matching the application-resolved branch above.
-                        credential.getRealmRegEx(),
-                        TokenUtils.expiresAt(durationInSeconds),
-                        issuer);
+                  // Only RESOLVED reaches the mint: LEGACY/AMBIGUOUS/DENIED all returned
+                  // typed negative responses above, so the audience set is always non-empty.
+                  if (appAuth.wildcard()) {
+                     Log.warnf("Wildcard application grant exercised (audit): user=%s realm=%s activeApplication=%s",
+                        userId, tokenRealm, appAuth.activeApplication());
                   }
+                  String authToken = TokenUtils.generateUserToken(
+                     subject,
+                     credential.getUserId(),
+                     groups,
+                     tokenRealm,
+                     tokenDomainContext.getTenantId(),
+                     tokenDomainContext.getOrgRefName(),
+                     tokenDomainContext.getAccountId(),
+                     appAuth.audiences(),
+                     appAuth.activeApplication(),
+                     // Signed realm boundary: lets delegated-claims validators
+                     // authorize X-Realm switches within the credential's own
+                     // declared boundary instead of pinning to the login realm.
+                     credential.getRealmRegEx(),
+                     TokenUtils.expiresAt(durationInSeconds),
+                     issuer);
 
                   String refreshToken = generateRefreshToken(
                      subject,
@@ -946,6 +982,14 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                || appAuth.outcome() == ApplicationAuthorizationResolver.Outcome.AMBIGUOUS) {
             throw new SecurityException("Application authorization is no longer valid during refresh");
          }
+         if (appAuth.outcome() == ApplicationAuthorizationResolver.Outcome.LEGACY) {
+            // The application boundary was removed after login (login fails fast on a
+            // boundary-less credential, so an active session can only get here through
+            // an admin change). Refresh must not widen it back with an unscoped token.
+            throw new SecurityException(
+               "Credential has no application authorization (applicationRegEx unset and no per-realm "
+                  + "application grant); cannot refresh an application-scoped session");
+         }
 
          DomainContext tokenDomainContext = Objects.equals(credentialRealm, tokenRealm)
             ? credential.getDomainContext()
@@ -954,16 +998,12 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
             throw new SecurityException("Realm has no data-domain configuration: " + tokenRealm);
          }
 
-         String newAuthToken = appAuth.resolved()
-            ? TokenUtils.generateUserToken(
-               refreshSubject, userId, allRoles, tokenRealm,
-               tokenDomainContext.getTenantId(), tokenDomainContext.getOrgRefName(),
-               tokenDomainContext.getAccountId(), appAuth.audiences(),
-               appAuth.activeApplication(), TokenUtils.expiresAt(durationInSeconds), issuer)
-            : TokenUtils.generateUserToken(
-               refreshSubject, userId, allRoles, tokenRealm,
-               tokenDomainContext.getTenantId(), tokenDomainContext.getOrgRefName(),
-               tokenDomainContext.getAccountId(), TokenUtils.expiresAt(durationInSeconds), issuer);
+         // Only RESOLVED reaches the mint (LEGACY/AMBIGUOUS/DENIED threw above).
+         String newAuthToken = TokenUtils.generateUserToken(
+            refreshSubject, userId, allRoles, tokenRealm,
+            tokenDomainContext.getTenantId(), tokenDomainContext.getOrgRefName(),
+            tokenDomainContext.getAccountId(), appAuth.audiences(),
+            appAuth.activeApplication(), TokenUtils.expiresAt(durationInSeconds), issuer);
          String newRefreshToken = generateRefreshToken(
             refreshSubject, userId, tokenRealm,
             appAuth.resolved() ? appAuth.activeApplication() : null,

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
@@ -41,7 +41,12 @@ public final class ApplicationAuthorizationResolver {
     }
 
     public enum Outcome {
-        /** No application grant configured for this membership — use legacy (single-audience) behavior. */
+        /**
+         * No application authorization configured at all (no per-realm grant AND no
+         * credential-wide pattern). Tokens are application-scoped, so nothing can be
+         * minted for this credential: login fails fast with a typed diagnostic
+         * (ApplicationAuthorizationMissing, 422) and refresh fails closed.
+         */
         LEGACY,
         /** Resolved to a concrete audience set + active application. */
         RESOLVED,

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/UserManagement.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/UserManagement.java
@@ -30,6 +30,25 @@ public interface UserManagement extends UserManagementBase{
     String createUser(String userId, String password,  Set<String> roles,  DomainContext domainContext) throws SecurityException;
     String createUser(String userId, String password, Boolean forceChangePassword,  Set<String> roles,  DomainContext domainContext) throws SecurityException;
 
+    /**
+     * Creates a user with an explicit application boundary ({@code applicationRegEx}:
+     * {@code "*"} for any application, otherwise a regex matched against application ids).
+     * Login mints application-scoped tokens and rejects credentials that carry no
+     * boundary and no per-realm application grant, so providers that persist
+     * {@link com.e2eq.framework.model.security.CredentialUserIdPassword} MUST stamp a
+     * boundary at create time (the explicit value, or their documented default when null).
+     * The default implementation delegates to the boundary-less overload for a null
+     * boundary and fails fast for providers that don't model application boundaries.
+     */
+    default String createUser(String userId, String password, Boolean forceChangePassword,
+                    Set<String> roles, DomainContext domainContext, String applicationRegEx) throws SecurityException {
+        if (applicationRegEx == null) {
+            return createUser(userId, password, forceChangePassword, roles, domainContext);
+        }
+        throw new UnsupportedOperationException(
+                "This authentication provider does not support explicit application boundaries");
+    }
+
     // New overloads to support explicit DataDomain specification
     String createUser(String userId, String password,
                     Set<String> roles, DomainContext domainContext, DataDomain dataDomain) throws SecurityException;


### PR DESCRIPTION
## Problem

A credential whose `applicationRegEx` is null (and with no per-realm application grant) cannot be minted an application-scoped token under the list-or-* audience contract. Two defects (reproduced 2026-07-22 on gcp-dev while migrating erik@helixor.ai):

1. `/user/userProfile/create` and `/security/create-user` set **no application boundary** on the credential they create, so every freshly created user was unloginable until someone ran `PUT /user/credentials/set?id=..&pairs=applicationRegEx:'*'` by hand.
2. Login surfaced this as an opaque **500** `jakarta.validation.ValidationException: audiences cannot be empty for an application-scoped token` instead of a typed 4xx.

## Fix (fail-fast at both ends)

- **create-user stamps a boundary**: explicit `CreateUserRequest.applicationRegEx` is validated *before* persist (uncompilable pattern → 422 — the resolver fails closed on it at login, which would recreate the unloginable-user defect with a worse diagnosis); omitted → documented default `"*"` (any application — the pre-application-scoping behavior). Both canonical `createUser` impls stamp it, so tenant provisioning, access invites, and seed `CredentialUpsertTransform` inherit the fix. The new `UserManagement` overload is a default method, keeping out-of-tree providers (e.g. Cognito) source-compatible.
- **login returns a typed diagnostic**: the `LEGACY` resolver outcome now yields `422 ApplicationAuthorizationMissing` naming the user, realm, and both remediations (set `applicationRegEx` or add a per-realm grant) instead of reaching the mint. Refresh fails closed via `SecurityException` if the boundary is removed mid-session. Dead legacy-mint branches removed from login and refresh.

## Test repairs (pre-existing failures on 1.4.0-SNAPSHOT tip)

`mvn clean install` on the branch tip already failed 5 tests (`SecurityTest.testLoginAPI`/`testGetUserProfileRESTAPI`, `SecureResourceTest.testImpersonation`, `TestCustTokenAuthProvider` ×2) — verified by stashing this change. Causes and fixes:

- The 2026-07-21 half-created-account invariant (USER credential without a directory profile cannot log in) broke tests that create users via `UserManagement` and log in. New `TestDirectoryProfiles` helper creates/removes system-realm profiles around those flows (mirroring `/security/create-user`).
- `SecurityTest`'s hand-built fixture credential had `realmRegEx="*"` but no `applicationRegEx` → its login was the 500 bug in miniature. It now stamps `"*"` and repairs stale credentials persisted by earlier runs.
- Test JWT verifier config now admits the `"*"` audience (`mp.jwt.verify.audiences`), matching the list-or-* contract; per-app admission remains `AudiencePolicy`'s job.

## Verification

- `mvn clean install`: full reactor green, quantum-framework module **465 tests, 0 failures**.
- Companion enterprise PR adds `ApplicationBoundaryLoginTest` (4 tests incl. the admin@system.com null-boundary regression) in quantum-auth-service.

Note for deployments: existing boundary-less credentials (e.g. `admin@system.com` on gcp-dev) still need the one-time data fix; after this change their login explains itself with the 422 instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)