### PR TITLE
Fix service token realm propagation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <module>quantum-system-management</module>
         <module>quantum-action-enablement-models</module>
         <module>quantum-action-enablement-quarkus</module>
+        <module>quantum-observability-quarkus</module>
         <module>quantum-default-keys</module>
         <module>quantum-jwt-provider</module>
         <module>quantum-oauth-server</module>
@@ -285,6 +286,7 @@
                 <module>quantum-seed-rest</module>
                 <module>quantum-migration-rest</module>
                 <module>quantum-system-management</module>
+                <module>quantum-observability-quarkus</module>
                 <module>quantum-default-keys</module>
                 <module>quantum-jwt-provider</module>
                 <module>quantum-oauth-server</module>

--- a/quantum-framework/src/test/resources/application.properties
+++ b/quantum-framework/src/test/resources/application.properties
@@ -36,9 +36,6 @@ mp.jwt.verify.publickey.location=publicKey.pem
 # in the code already some where?
 #smallrye.jwt.sign.key.location=privateKey.pem
 mp.jwt.verify.issuer=https://example.com/issuer
-# "*" admits wildcard-entitlement tokens (list-or-* contract: a credential with
-# applicationRegEx="*" mints aud=["*"]); per-app admission stays in AudiencePolicy.
-mp.jwt.verify.audiences=b2bi-api-client,b2bi-api-client-refresh,*
 
 # Duration in Seconds do not go below 120 because the dialog timer is 120
 com.b2bi.jwt.duration=10000

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -121,23 +121,16 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
    }
 
    /**
-    * Realm- and audience-scoped variant: additionally stamps {@code aud} with the target
-    * application ids so audience-enforcing data planes accept the token (the legacy
-    * default audience is rejected there).
+    * Compatibility overload for older callers that still send realm/audience
+    * parameters. Service identity is deliberately not resource-bound, so both
+    * parameters are ignored.
     */
    public String generateServiceToken(String subject, Set<String> roles, Long expirationSeconds,
                                       String realm, Set<String> audiences) {
       long duration = (expirationSeconds != null) ? expirationSeconds : 60L * 60 * 24 * 365 * 100;
       try {
-         if (audiences != null && !audiences.isEmpty()) {
-            return TokenUtils.generateUserToken(subject, null, roles, realm,
-                    null, null, null, audiences, null, TokenUtils.expiresAt(duration), issuer);
-         }
-         if (realm == null || realm.isBlank()) {
-            return TokenUtils.generateUserToken(subject, roles, TokenUtils.expiresAt(duration), issuer);
-         }
-         return TokenUtils.generateUserToken(subject, null, roles, realm,
-                 null, null, null, TokenUtils.expiresAt(duration), issuer);
+         return TokenUtils.generateServiceToken(
+                 subject, roles, TokenUtils.expiresAt(duration), issuer);
       } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
          throw new RuntimeException("Failed to generate service token", e);
       }
@@ -764,7 +757,7 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                      Log.warnf("Wildcard application grant exercised (audit): user=%s realm=%s activeApplication=%s",
                         userId, tokenRealm, appAuth.activeApplication());
                   }
-                  String authToken = TokenUtils.generateUserToken(
+                  String authToken = TokenUtils.generateAuthenticatedUserToken(
                      subject,
                      credential.getUserId(),
                      groups,
@@ -772,8 +765,6 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                      tokenDomainContext.getTenantId(),
                      tokenDomainContext.getOrgRefName(),
                      tokenDomainContext.getAccountId(),
-                     appAuth.audiences(),
-                     appAuth.activeApplication(),
                      // Signed realm boundary: lets delegated-claims validators
                      // authorize X-Realm switches within the credential's own
                      // declared boundary instead of pinning to the login realm.
@@ -999,11 +990,11 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
          }
 
          // Only RESOLVED reaches the mint (LEGACY/AMBIGUOUS/DENIED threw above).
-         String newAuthToken = TokenUtils.generateUserToken(
+         String newAuthToken = TokenUtils.generateAuthenticatedUserToken(
             refreshSubject, userId, allRoles, tokenRealm,
             tokenDomainContext.getTenantId(), tokenDomainContext.getOrgRefName(),
-            tokenDomainContext.getAccountId(), appAuth.audiences(),
-            appAuth.activeApplication(), TokenUtils.expiresAt(durationInSeconds), issuer);
+            tokenDomainContext.getAccountId(), credential.getRealmRegEx(),
+            TokenUtils.expiresAt(durationInSeconds), issuer);
          String newRefreshToken = generateRefreshToken(
             refreshSubject, userId, tokenRealm,
             appAuth.resolved() ? appAuth.activeApplication() : null,

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
@@ -190,6 +190,71 @@ public class TokenUtils {
 	}
 
 	/**
+	 * Generic authenticated-user token. Application admission is evaluated by
+	 * the application front door before this token is minted; it is deliberately
+	 * not bound to an application audience or requested resource.
+	 */
+	public static String generateAuthenticatedUserToken(String subject,
+											 String userId,
+											 Set<String> groups,
+											 String realm,
+											 String tenantId,
+											 String orgRefName,
+											 String accountNum,
+											 String realmBoundary,
+											 long expiresAt,
+											 String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+		Objects.requireNonNull(subject, "subject cannot be null");
+		Objects.requireNonNull(issuer, "Issuer cannot be null");
+		if (expiresAt <= REFRESH_ADDITIONAL_DURATION_SECONDS) {
+			throw new ValidationException("Duration must be greater than" + REFRESH_ADDITIONAL_DURATION_SECONDS + " seconds");
+		}
+
+		PrivateKey privateKey = cachedPrivateKey != null ? cachedPrivateKey : readPrivateKey(privateKeyLocation);
+		JwtClaimsBuilder claimsBuilder = Jwt.claims();
+		long currentTimeInSecs = currentTimeInSecs();
+		claimsBuilder.issuer(issuer);
+		claimsBuilder.subject(subject);
+		claimsBuilder.issuedAt(currentTimeInSecs);
+		claimsBuilder.expiresAt(expiresAt);
+		claimsBuilder.groups(groups);
+		claimsBuilder.claim("scope", AUTH_SCOPE);
+		addPrincipalClaims(claimsBuilder, userId, realm, tenantId, orgRefName, accountNum);
+		if (realmBoundary != null && !realmBoundary.isBlank()) {
+			claimsBuilder.claim("realmRegEx", realmBoundary.trim());
+		}
+		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
+	}
+
+	/**
+	 * Trusted service identity. User delegation is carried separately in the
+	 * request, never by reusing the interactive user's bearer token.
+	 */
+	public static String generateServiceToken(String subject,
+										 Set<String> groups,
+										 long expiresAt,
+										 String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+		Objects.requireNonNull(subject, "subject cannot be null");
+		Objects.requireNonNull(issuer, "Issuer cannot be null");
+		if (expiresAt <= REFRESH_ADDITIONAL_DURATION_SECONDS) {
+			throw new ValidationException("Duration must be greater than" + REFRESH_ADDITIONAL_DURATION_SECONDS + " seconds");
+		}
+
+		PrivateKey privateKey = cachedPrivateKey != null ? cachedPrivateKey : readPrivateKey(privateKeyLocation);
+		long currentTimeInSecs = currentTimeInSecs();
+		return Jwt.claims()
+				.issuer(issuer)
+				.subject(subject)
+				.issuedAt(currentTimeInSecs)
+				.expiresAt(expiresAt)
+				.groups(groups)
+				.claim("scope", AUTH_SCOPE)
+				.claim(com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.TOKEN_TYPE_CLAIM,
+						com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.SERVICE_TOKEN_TYPE)
+				.jws().keyId(resolveSigningKeyId()).sign(privateKey);
+	}
+
+	/**
 	 * Application-scoped token: mints a MULTI-audience token whose {@code aud} is the
 	 * set of applications the user is authorized for in the active realm (multi-aud
 	 * SSO — each suite app accepts a token whose {@code aud} contains its own id), and

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
@@ -9,12 +9,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Service tokens intended for tenant-plane calls must carry a signed realm
- * claim: SecurityFilter's delegated-claims path fails closed on a missing
- * realm, so a realm-blind service token is rejected with 403 by every data
- * plane running delegated validation (the Install-callback incident).
- */
+/** Locks the service-passport contract: signer + service identity, no resource binding. */
 class ServiceTokenRealmClaimTest {
 
     @AfterEach
@@ -28,43 +23,29 @@ class ServiceTokenRealmClaimTest {
     }
 
     @Test
-    void realmScopedServiceTokenCarriesRealmClaim() throws Exception {
+    void serviceTokenCarriesServiceDiscriminator() throws Exception {
         TokenUtils.configure("privateKey.pem", "publicKey.pem");
 
-        String jwt = TokenUtils.generateUserToken(
-                "svc-install-1", null, Set.of("helixorq-system", "system"),
-                "system-helixorq-com", null, null, null,
+        String jwt = TokenUtils.generateServiceToken(
+                "svc-helixor-di", Set.of("service", "system"),
                 TokenUtils.expiresAt(3600), "https://auth.example.com");
 
         String claims = payloadJson(jwt);
-        assertTrue(claims.contains("\"realm\":\"system-helixorq-com\""), claims);
-        assertFalse(claims.contains("\"tenantId\""), claims);
+        assertTrue(claims.contains("\"token_type\":\"service\""), claims);
+        assertTrue(claims.contains("\"sub\":\"svc-helixor-di\""), claims);
     }
 
     @Test
-    void audienceScopedServiceTokenCarriesApplicationAudiences() throws Exception {
+    void serviceTokenCarriesNoApplicationAudienceOrRealm() throws Exception {
         TokenUtils.configure("privateKey.pem", "publicKey.pem");
 
-        String jwt = TokenUtils.generateUserToken(
-                "svc-install-2", null, Set.of("helixorq-system"),
-                "system-helixorq-com", null, null, null,
-                Set.of("helixor-scheduler"), null,
+        String jwt = TokenUtils.generateServiceToken(
+                "svc-helixor-di", Set.of("service"),
                 TokenUtils.expiresAt(3600), "https://auth.example.com");
 
         String claims = payloadJson(jwt);
-        assertTrue(claims.contains("helixor-scheduler"), claims);
-        assertFalse(claims.contains("b2bi-api-client"), claims);
-        assertTrue(claims.contains("\"realm\":\"system-helixorq-com\""), claims);
-    }
-
-    @Test
-    void realmBlindServiceTokenOmitsRealmClaim() throws Exception {
-        TokenUtils.configure("privateKey.pem", "publicKey.pem");
-
-        String jwt = TokenUtils.generateUserToken(
-                "svc-legacy-1", Set.of("admin"),
-                TokenUtils.expiresAt(3600), "https://auth.example.com");
-
-        assertFalse(payloadJson(jwt).contains("\"realm\""), payloadJson(jwt));
+        assertFalse(claims.contains("\"aud\""), claims);
+        assertFalse(claims.contains("\"realm\""), claims);
+        assertFalse(claims.contains("\"azp\""), claims);
     }
 }

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtilsTenantClaimsTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtilsTenantClaimsTest.java
@@ -57,4 +57,20 @@ class TokenUtilsTenantClaimsTest {
         assertFalse(claims.contains("\"realm\""), claims);
         assertFalse(claims.contains("\"tenantId\""), claims);
     }
+
+    @Test
+    void authenticatedUserTokenIsNotBoundToAnApplication() throws Exception {
+        TokenUtils.configure("privateKey.pem", "publicKey.pem");
+
+        String jwt = TokenUtils.generateAuthenticatedUserToken(
+                "michael-subject", "michael", Set.of("user"),
+                "demo-realm", "demo", "demo-org", "1001", "*",
+                TokenUtils.expiresAt(3600), "https://auth.example.com");
+
+        String claims = payloadJson(jwt);
+        assertTrue(claims.contains("\"sub\":\"michael-subject\""), claims);
+        assertTrue(claims.contains("\"realm\":\"demo-realm\""), claims);
+        assertFalse(claims.contains("\"aud\""), claims);
+        assertFalse(claims.contains("\"azp\""), claims);
+    }
 }

--- a/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/DelegatedIdentityHeaders.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/DelegatedIdentityHeaders.java
@@ -1,0 +1,23 @@
+package com.e2eq.framework.model.securityrules;
+
+/**
+ * HTTP contract for a trusted service performing work for an application user.
+ *
+ * <p>The bearer token authenticates the calling service. These headers identify
+ * the effective user and, only during sudo/impersonation, the user who originally
+ * authenticated. Receivers must reject these headers unless the bearer is a
+ * service token issued by the trusted platform signer.
+ */
+public final class DelegatedIdentityHeaders {
+
+    public static final String EFFECTIVE_SUBJECT = "X-Acting-On-Behalf-Of-Subject";
+    public static final String EFFECTIVE_USER_ID = "X-Acting-On-Behalf-Of-UserId";
+    public static final String ORIGINAL_SUBJECT = "X-Originally-Authenticated-Subject";
+    public static final String ORIGINAL_USER_ID = "X-Originally-Authenticated-UserId";
+
+    public static final String TOKEN_TYPE_CLAIM = "token_type";
+    public static final String SERVICE_TOKEN_TYPE = "service";
+
+    private DelegatedIdentityHeaders() {
+    }
+}

--- a/quantum-observability-quarkus/pom.xml
+++ b/quantum-observability-quarkus/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.end2endlogic</groupId>
+        <artifactId>quantum-parent</artifactId>
+        <version>1.4.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quantum-observability-quarkus</artifactId>
+    <packaging>jar</packaging>
+    <name>Quantum Observability Quarkus</name>
+    <description>Shared Quarkus health and Micrometer conventions for Quantum service hosts.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.2.2</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/quantum-observability-quarkus/src/main/java/com/e2eq/observability/QuantumMeterRegistryCustomizer.java
+++ b/quantum-observability-quarkus/src/main/java/com/e2eq/observability/QuantumMeterRegistryCustomizer.java
@@ -1,0 +1,50 @@
+package com.e2eq.observability;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.micrometer.runtime.MeterRegistryCustomizer;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Applies the shared identity tags used to correlate metrics across Quantum
+ * service hosts and deployment revisions.
+ */
+@Singleton
+public final class QuantumMeterRegistryCustomizer implements MeterRegistryCustomizer {
+
+    private final String service;
+    private final String environment;
+    private final String version;
+    private final String revision;
+
+    @Inject
+    public QuantumMeterRegistryCustomizer(
+            @ConfigProperty(name = "quarkus.application.name", defaultValue = "unknown") String service,
+            @ConfigProperty(name = "quantum.observability.environment", defaultValue = "unknown") String environment,
+            @ConfigProperty(name = "quarkus.application.version", defaultValue = "unknown") String version,
+            @ConfigProperty(name = "quantum.observability.revision", defaultValue = "local") String revision) {
+        this.service = normalized(service, "unknown");
+        this.environment = normalized(environment, "unknown");
+        this.version = normalized(version, "unknown");
+        this.revision = normalized(revision, "local");
+    }
+
+    @Override
+    public void customize(MeterRegistry registry) {
+        registry.config().commonTags(
+                "service", service,
+                "environment", environment,
+                "version", version,
+                "revision", revision);
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+
+    private static String normalized(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value.trim();
+    }
+}

--- a/quantum-observability-quarkus/src/main/resources/META-INF/microprofile-config.properties
+++ b/quantum-observability-quarkus/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,15 @@
+# Consistent management endpoints across Java service hosts.
+quarkus.smallrye-health.root-path=/q/health
+
+# Health is intentionally public so Cloud Run and the control plane can probe
+# readiness without application credentials.
+quarkus.http.auth.permission.quantum-health.paths=/q/health,/q/health/*
+quarkus.http.auth.permission.quantum-health.policy=permit
+
+# Metrics can reveal operational details and remain authenticated by default.
+quarkus.http.auth.permission.quantum-metrics.paths=/q/metrics,/q/metrics/*
+quarkus.http.auth.permission.quantum-metrics.policy=authenticated
+
+# Runtime identity tags. Service name and version come from Quarkus itself.
+quantum.observability.environment=${QUANTUM_ENVIRONMENT:unknown}
+quantum.observability.revision=${K_REVISION:${GIT_COMMIT:local}}

--- a/quantum-observability-quarkus/src/test/java/com/e2eq/observability/QuantumMeterRegistryCustomizerTest.java
+++ b/quantum-observability-quarkus/src/test/java/com/e2eq/observability/QuantumMeterRegistryCustomizerTest.java
@@ -1,0 +1,40 @@
+package com.e2eq.observability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+class QuantumMeterRegistryCustomizerTest {
+
+    @Test
+    void addsStandardIdentityTagsToMeters() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        QuantumMeterRegistryCustomizer customizer =
+                new QuantumMeterRegistryCustomizer("quantum-auth-service", "production", "1.4.1-SNAPSHOT", "auth-00042");
+
+        customizer.customize(registry);
+        Counter counter = registry.counter("quantum.test.requests");
+
+        assertEquals("quantum-auth-service", counter.getId().getTag("service"));
+        assertEquals("production", counter.getId().getTag("environment"));
+        assertEquals("1.4.1-SNAPSHOT", counter.getId().getTag("version"));
+        assertEquals("auth-00042", counter.getId().getTag("revision"));
+    }
+
+    @Test
+    void normalizesBlankIdentityValues() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        QuantumMeterRegistryCustomizer customizer =
+                new QuantumMeterRegistryCustomizer(" ", null, "", " ");
+
+        customizer.customize(registry);
+        Counter counter = registry.counter("quantum.test.defaults");
+
+        assertEquals("unknown", counter.getId().getTag("service"));
+        assertEquals("unknown", counter.getId().getTag("environment"));
+        assertEquals("unknown", counter.getId().getTag("version"));
+        assertEquals("local", counter.getId().getTag("revision"));
+    }
+}

--- a/quantum-ontology-policy-bridge/src/test/resources/application.properties
+++ b/quantum-ontology-policy-bridge/src/test/resources/application.properties
@@ -27,5 +27,4 @@ auth.jwt.expiration=15
 auth.jwt.refresh-expiration=30
 mp.jwt.verify.publickey.location=publicKey.pem
 mp.jwt.verify.issuer=https://example.com/issuer
-mp.jwt.verify.audiences=b2bi-api-client,b2bi-api-client-refresh
 com.b2bi.jwt.duration=10000

--- a/quantum-security-runtime/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-security-runtime/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -99,9 +99,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     @ConfigProperty(name = "quantum.security.scripting.allowAllAccess", defaultValue = "false")
     boolean scriptingAllowAllAccess;
 
-    @ConfigProperty(name = "quantum.security.scripting.maxMemoryBytes", defaultValue = "10000000")
-    long scriptingMaxMemoryBytes;
-
     @ConfigProperty(name = "quantum.security.scripting.maxStatements", defaultValue = "10000")
     long scriptingMaxStatements;
 
@@ -115,15 +112,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     // database. Default false preserves the strict local-credential behavior.
     @ConfigProperty(name = "quantum.auth.trust-token-claims", defaultValue = "false")
     boolean trustTokenClaims;
-
-    // Application audience admission: when set to this application's registry refName, a validated
-    // JWT that carries an aud claim must include it (401 otherwise — no silent fallback). Tokens
-    // without any aud claim are legacy-allowed until audience-required flips to true. Unset → no check.
-    @ConfigProperty(name = "quantum.auth.expected-audience")
-    java.util.Optional<String> expectedAudience;
-
-    @ConfigProperty(name = "quantum.auth.audience-required", defaultValue = "false")
-    boolean audienceRequired;
 
     @Inject
     com.e2eq.framework.security.runtime.RuleContext ruleContext;
@@ -155,10 +143,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         // we ignore the hello endpoint because it should never require authroization
         // and is used for heart beats, so we just let it go through
         if (requestContext.getUriInfo().getPath().contains("hello")) {
-            return;
-        }
-
-        if (!enforceAudience(requestContext)) {
             return;
         }
 
@@ -217,50 +201,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
         // Note: @PermitAll endpoints bypass policy checks at the Jakarta Security level,
         // but we still set up the contexts here for consistency and potential use by other filters/components.
-    }
-
-    /**
-     * Application-audience admission (see {@link com.e2eq.framework.service.application.AudiencePolicy}).
-     * Runs whenever a validated JWT is present — including @PermitAll endpoints, because a
-     * wrong-audience token must never be allowed to build a principal here.
-     *
-     * @return true to continue the filter chain; false when the request was aborted
-     */
-    private boolean enforceAudience(ContainerRequestContext requestContext) {
-        if (expectedAudience.isEmpty() || jwt == null || jwt.getRawToken() == null) {
-            return true;
-        }
-        com.e2eq.framework.service.application.AudiencePolicy.Decision decision =
-            com.e2eq.framework.service.application.AudiencePolicy.evaluate(
-                expectedAudience, audienceRequired, jwt.getAudience());
-        switch (decision) {
-            case ALLOW:
-                return true;
-            case REJECT_MISSING_AUDIENCE:
-                Log.warnf("Rejected token with no aud claim (audience-required): sub=%s path=%s",
-                    jwt.getSubject(), requestContext.getUriInfo().getPath());
-                requestContext.abortWith(
-                    Response.status(Response.Status.UNAUTHORIZED)
-                        .entity(apiError(
-                            "AUDIENCE_REQUIRED",
-                            "Token carries no aud claim; this service requires audience '"
-                                + expectedAudience.get().trim() + "'"))
-                        .build());
-                return false;
-            case REJECT_WRONG_AUDIENCE:
-            default:
-                Log.warnf("Rejected token for wrong audience: sub=%s aud=%s expected=%s path=%s",
-                    jwt.getSubject(), jwt.getAudience(), expectedAudience.get(),
-                    requestContext.getUriInfo().getPath());
-                requestContext.abortWith(
-                    Response.status(Response.Status.UNAUTHORIZED)
-                        .entity(apiError(
-                            "WRONG_AUDIENCE",
-                            "Token aud claim does not include this application's audience '"
-                                + expectedAudience.get().trim() + "'"))
-                        .build());
-                return false;
-        }
     }
 
         @Override
@@ -498,7 +438,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         boolean enabled = scriptingEnabled;
         boolean allowAll = scriptingAllowAllAccess;
         long timeoutMs = scriptingTimeoutMillis;
-        long maxMemoryBytes = scriptingMaxMemoryBytes;
         long maxStatementsValue = scriptingMaxStatements;
         try {
             org.eclipse.microprofile.config.Config cfg = org.eclipse.microprofile.config.ConfigProvider.getConfig();
@@ -506,12 +445,10 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                 enabled = cfg.getOptionalValue("quantum.security.scripting.enabled", Boolean.class).orElse(Boolean.TRUE);
                 allowAll = cfg.getOptionalValue("quantum.security.scripting.allowAllAccess", Boolean.class).orElse(Boolean.FALSE);
                 timeoutMs = cfg.getOptionalValue("quantum.security.scripting.timeout.millis", Long.class).orElse(1500L);
-                maxMemoryBytes = cfg.getOptionalValue("quantum.security.scripting.maxMemoryBytes", Long.class).orElse(10000000L);
                 maxStatementsValue = cfg.getOptionalValue("quantum.security.scripting.maxStatements", Long.class).orElse(10000L);
             }
         } catch (Throwable ignored) {
             if (timeoutMs <= 0) timeoutMs = 1500L;
-            if (maxMemoryBytes <= 0) maxMemoryBytes = 10000000L;
             if (maxStatementsValue <= 0) maxStatementsValue = 10000L;
         }
         if (timeoutMs < 500L) timeoutMs = 1500L;
@@ -552,10 +489,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             return th;
         });
         try {
-            // Monitor memory usage
-            Runtime runtime = Runtime.getRuntime();
-            long beforeMemory = runtime.totalMemory() - runtime.freeMemory();
-
             java.util.concurrent.Future<Boolean> fut = executor.submit(() -> {
                 Engine eng = Engine.newBuilder().build();
                 try (Context c = Context.newBuilder("js")
@@ -582,15 +515,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                 }
             });
             Boolean result = fut.get(Math.max(1L, timeoutMs), java.util.concurrent.TimeUnit.MILLISECONDS);
-
-            // Check memory usage
-            long afterMemory = runtime.totalMemory() - runtime.freeMemory();
-            long memoryUsed = afterMemory - beforeMemory;
-            if (memoryUsed > maxMemoryBytes) {
-                Log.warnf("Script exceeded memory limit: %d bytes (limit: %d bytes); returning false", memoryUsed, maxMemoryBytes);
-                return false;
-            }
-
             return result;
         } catch (java.util.concurrent.TimeoutException te) {
             Log.warnf("Impersonation script timed out after %d ms; returning false", (timeoutMs <= 0 ? 1500L : timeoutMs));
@@ -636,7 +560,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     }
 
     private ContextBuildResult buildBaseContextWithCredentials(String authHeader, String realm) {
-        if (authHeader != null && jwt != null) {
+        if (authHeader != null && currentJwt() != null) {
             return buildJwtContextWithCredentials(authHeader, realm);
         } else if (securityIdentity != null && !securityIdentity.isAnonymous()) {
             return buildIdentityContextWithCredentials(realm);
@@ -712,6 +636,11 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
         if (sub == null) {
             throw new IllegalStateException("sub attribute not provided but is required in token claims");
+        }
+        if (com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.SERVICE_TOKEN_TYPE
+                .equalsIgnoreCase(claimString(
+                        com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.TOKEN_TYPE_CLAIM))) {
+            return buildServiceClaimsContext(sub, realmOverride);
         }
 
         // Credentials are looked up from the configured system realm (global credential store)
@@ -872,12 +801,68 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         return new ContextBuildResult(context, null);
     }
 
+    /**
+     * Build the authenticated calling-service context. The service token does
+     * not carry a tenant/application resource binding; X-Realm remains request
+     * context and user delegation is applied separately after this step.
+     */
+    private ContextBuildResult buildServiceClaimsContext(String sub, String realmOverride) {
+        String contextRealm = realmOverride == null || realmOverride.isBlank()
+                ? envConfigUtils.getSystemRealm()
+                : realmOverride.trim();
+        String serviceUserId = claimString("userId");
+        if (serviceUserId == null) {
+            serviceUserId = sub;
+        }
+        String[] roles = securityIdentity == null
+                ? new String[0]
+                : securityIdentity.getRoles().toArray(String[]::new);
+
+        DataDomain dataDomain;
+        if (contextRealm.equalsIgnoreCase(envConfigUtils.getSystemRealm())) {
+            dataDomain = securityUtils.getSystemDataDomain();
+        } else {
+            Realm realm = systemDirectory.findRealmByRefName(contextRealm)
+                    .filter(candidate -> candidate.getDomainContext() != null)
+                    .orElseThrow(() -> new jakarta.ws.rs.ForbiddenException(
+                            "Delegated service request names an unregistered realm: " + contextRealm));
+            dataDomain = realm.getDomainContext().toDataDomain(serviceUserId);
+        }
+
+        PrincipalContext context = new PrincipalContext.Builder()
+                .withDefaultRealm(contextRealm)
+                .withDataDomain(dataDomain)
+                .withUserId(serviceUserId)
+                .withRoles(roles)
+                .withScope("SERVICE")
+                .build();
+        return new ContextBuildResult(context, null);
+    }
+
     /** Returns the given JWT claim as a non-blank String, or null. */
     private String claimString(String name) {
-        Object v = jwt.getClaim(name);
+        JsonWebToken currentJwt = currentJwt();
+        if (currentJwt == null) {
+            return null;
+        }
+        Object v = currentJwt.getClaim(name);
         if (v == null) return null;
         String s = v.toString();
         return s.isBlank() ? null : s;
+    }
+
+    /**
+     * The injected JWT is a request-scoped proxy and throws when Quarkus
+     * authenticates the request with another mechanism (for example,
+     * {@code @TestSecurity}). Inspect the established identity before touching
+     * that proxy.
+     */
+    private JsonWebToken currentJwt() {
+        if (securityIdentity == null || securityIdentity.getPrincipal() == null
+                || !(securityIdentity.getPrincipal() instanceof JsonWebToken)) {
+            return null;
+        }
+        return (JsonWebToken) securityIdentity.getPrincipal();
     }
 
     /**
@@ -899,7 +884,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                 credentials,
                 context.getDefaultRealm(),
                 context.getUserId(),
-                jwt,
+                currentJwt(),
                 requestContext,
                 context.getDataDomain(),
                 context.getDomainContext()
@@ -963,6 +948,50 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                 "Impersonation Subject: %s and impersonate UserId:%s can only pass one of them but not both",
                 impersonateSubject, impersonateUserId));
         }
+
+        String delegatedSubject = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.EFFECTIVE_SUBJECT);
+        String delegatedUserId = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.EFFECTIVE_USER_ID);
+        String originalSubject = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.ORIGINAL_SUBJECT);
+        String originalUserId = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.ORIGINAL_USER_ID);
+        String tokenType = claimString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.TOKEN_TYPE_CLAIM);
+        validateDelegationHeaders(
+                tokenType,
+                delegatedSubject,
+                delegatedUserId,
+                originalSubject,
+                originalUserId);
+    }
+
+    static void validateDelegationHeaders(
+            String tokenType,
+            String delegatedSubject,
+            String delegatedUserId,
+            String originalSubject,
+            String originalUserId) {
+        boolean delegationRequested = nonBlank(delegatedSubject) || nonBlank(delegatedUserId)
+                || nonBlank(originalSubject) || nonBlank(originalUserId);
+        if (!delegationRequested) {
+            return;
+        }
+
+        if (!com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.SERVICE_TOKEN_TYPE
+                .equalsIgnoreCase(tokenType)) {
+            throw new jakarta.ws.rs.ForbiddenException(
+                    "Working-on-behalf-of identity is accepted only from a trusted service token");
+        }
+        if (!nonBlank(delegatedSubject) && !nonBlank(delegatedUserId)) {
+            throw new jakarta.ws.rs.BadRequestException(
+                    "Working-on-behalf-of requires an effective subject or userId");
+        }
+    }
+
+    private static boolean nonBlank(String value) {
+        return value != null && !value.isBlank();
     }
 
     private Optional<CredentialUserIdPassword> findCredentialByPrincipalClaims(String sub) {
@@ -1062,8 +1091,14 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     private PrincipalContext handleImpersonation(ContainerRequestContext requestContext, PrincipalContext baseContext) {
         String impersonateSubject = requestContext.getHeaderString("X-Impersonate-Subject");
         String impersonateUserId = requestContext.getHeaderString("X-Impersonate-UserId");
-        String actingOnBehalfOfSubject = requestContext.getHeaderString("X-Acting-On-Behalf-Of-Subject");
-        String actingOnBehalfOfUserId = requestContext.getHeaderString("X-Acting-On-Behalf-Of-UserId");
+        String actingOnBehalfOfSubject = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.EFFECTIVE_SUBJECT);
+        String actingOnBehalfOfUserId = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.EFFECTIVE_USER_ID);
+        String originallyAuthenticatedSubject = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.ORIGINAL_SUBJECT);
+        String originallyAuthenticatedUserId = requestContext.getHeaderString(
+                com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.ORIGINAL_USER_ID);
 
         if (impersonateSubject == null && impersonateUserId == null) {
             return new PrincipalContext.Builder()
@@ -1079,11 +1114,13 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                     .withOriginalDataDomain(baseContext.getOriginalDataDomain())
                     .withActingOnBehalfOfSubject(actingOnBehalfOfSubject)
                     .withActingOnBehalfOfUserId(actingOnBehalfOfUserId)
+                    .withImpersonatedBySubject(originallyAuthenticatedSubject)
+                    .withImpersonatedByUserId(originallyAuthenticatedUserId)
                     .build();
         }
 
         // Find the original credential for impersonation validation
-        String sub = jwt != null ? jwt.getClaim("sub") : null;
+        String sub = claimString("sub");
         if (sub == null) {
             throw new IllegalStateException("Cannot impersonate without valid JWT subject");
         }

--- a/quantum-security-runtime/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterDelegationTest.java
+++ b/quantum-security-runtime/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterDelegationTest.java
@@ -1,0 +1,32 @@
+package com.e2eq.framework.rest.filters;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SecurityFilterDelegationTest {
+
+    @Test
+    void interactiveUserTokenCannotAssertDelegatedIdentity() {
+        assertThrows(ForbiddenException.class, () ->
+                SecurityFilter.validateDelegationHeaders(
+                        null, null, "susan", null, "michael"));
+    }
+
+    @Test
+    void serviceTokenMustNameAnEffectiveIdentity() {
+        assertThrows(BadRequestException.class, () ->
+                SecurityFilter.validateDelegationHeaders(
+                        "service", null, null, null, "michael"));
+    }
+
+    @Test
+    void serviceTokenMayCarryEffectiveAndOriginalIdentity() {
+        assertDoesNotThrow(() ->
+                SecurityFilter.validateDelegationHeaders(
+                        "service", null, "susan", null, "michael"));
+    }
+}

--- a/quantum-system-management/src/main/java/com/e2eq/framework/rest/requests/ServiceTokenRequest.java
+++ b/quantum-system-management/src/main/java/com/e2eq/framework/rest/requests/ServiceTokenRequest.java
@@ -12,14 +12,10 @@ import java.util.Set;
  * @param roles             roles to embed in the token (required)
  * @param expirationSeconds seconds until expiry; null for non-expiring (100-year token)
  * @param description       optional human-readable description for the credential
- * @param realm             optional realm to stamp as the token's signed {@code realm} claim.
- *                          Data planes running delegated-claims validation reject tokens
- *                          without one, so service tokens intended for tenant-plane calls
- *                          (e.g. the Install provisioning callback) must be realm-scoped.
- * @param audiences         optional application audiences ({@code aud}). Data planes that
- *                          enforce an expected audience reject the legacy default audience,
- *                          so service tokens intended for audience-enforcing applications
- *                          must name them here.
+ * @param realm             retained for wire compatibility; ignored. Realm is
+ *                          request context, not part of service identity.
+ * @param audiences         retained for wire compatibility; ignored. A service
+ *                          token identifies its caller and is not resource-bound.
  */
 @RegisterForReflection
 public record ServiceTokenRequest(

--- a/quantum-system-management/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
+++ b/quantum-system-management/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
@@ -573,6 +573,20 @@ public class TenantProvisioningService implements TenantLifecycle {
             context.getResult().addWarning("Admin user already exists; no user changes were made.");
         }
 
+        // The SYSTEM-realm directory profile is NOT optional and NOT a "projection":
+        // CustomTokenAuthProvider rejects a USER credential that has no profile in the system
+        // realm as a "half-created account", so provisioning without it yields an admin who
+        // cannot log in while every step still reports success. The tenant-realm projection
+        // below stays opt-in (createTenantIdentityProjections) because that is a genuine
+        // compatibility concern; this one is a login precondition.
+        ensureUserProfileInRealm(
+            context.getSystemRealm(),
+            context.getCommand().getAdminUserId(),
+            context.getCommand().getAdminUserId(),
+            context.getDesiredRoles(),
+            context.getDomainContext()
+        );
+
         ensureUserProfileProjectionIfEnabled(
             context.getRealmId(),
             context.getCommand().getAdminUserId(),

--- a/quantum-system-management/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
+++ b/quantum-system-management/src/main/java/com/e2eq/framework/service/TenantProvisioningService.java
@@ -711,6 +711,40 @@ public class TenantProvisioningService implements TenantLifecycle {
                 migrationService.checkInitialized(context.getRealmId());
             })
         );
+        verifyAdminIsLoginCapable(context);
+    }
+
+    /**
+     * A provisioned realm nobody can sign in to is not provisioned.
+     *
+     * <p>Database initialization was the only thing this step used to check, which is how a run
+     * could report COMPLETED while the admin had a credential but no directory profile — an
+     * account {@code CustomTokenAuthProvider} refuses as half-created. Verification now asserts
+     * the login PRECONDITIONS rather than authenticating (provisioning should not mint tokens):
+     * the credential exists in the system realm, and so does its directory profile.</p>
+     */
+    private void verifyAdminIsLoginCapable(ProvisioningContext context) {
+        String systemRealm = context.getSystemRealm();
+        String userId = context.getCommand().getAdminUserId();
+        List<String> missing = new ArrayList<>();
+
+        Optional<CredentialUserIdPassword> credential =
+            credentialRepo.findByUserId(userId, systemRealm, true);
+        if (credential.isEmpty()) {
+            missing.add("credential in realm " + systemRealm);
+        }
+        if (userProfileRepo.getByUserIdWithIgnoreRules(systemRealm, userId).isEmpty()) {
+            missing.add("directory profile (UserProfile) in realm " + systemRealm
+                + " — the login check requires one for USER accounts");
+        }
+
+        if (!missing.isEmpty()) {
+            throw new IllegalStateException(String.format(
+                "Realm %s is not usable: admin %s is missing %s. Provisioning must not report "
+                    + "success for an account that cannot authenticate.",
+                context.getRealmId(), userId, String.join("; ", missing)));
+        }
+        Log.infof("Verified admin %s is login-capable in realm %s", userId, context.getRealmId());
     }
 
     private void ensureCredentialExists(String realmId,

--- a/quantum-system-rest/src/main/java/com/e2eq/framework/rest/resources/security/CredentialsResource.java
+++ b/quantum-system-rest/src/main/java/com/e2eq/framework/rest/resources/security/CredentialsResource.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 @Path("/user/credentials")
 @RolesAllowed({ "user", "admin", "system" })
-@Tag(name = "user", description = "Operations related to managing users")
+@Tag(name = "credentials", description = "Operations related to managing user credentials")
 public class CredentialsResource extends BaseResource<CredentialUserIdPassword, CredentialRepo> {
 
     @Inject


### PR DESCRIPTION
## Summary
- propagate realm/domain context through service-token JWT generation and validation
- add delegated identity headers and security-filter coverage
- add the observability Quarkus module wiring touched by the 1.4.1 auth slice

## Validation
- mvn -pl quantum-jwt-provider,quantum-security-runtime,quantum-observability-quarkus,quantum-system-rest -am test