### PR TITLE
feat: centralize application-scoped authorization

### DIFF
--- a/docs/design/central-application-scoped-authorization-plane-implementation-plan.md
+++ b/docs/design/central-application-scoped-authorization-plane-implementation-plan.md
@@ -1,0 +1,217 @@
+# Implementation Plan — Central Application-Scoped Authorization Plane
+
+- **Design:** `design_c3eaa8a9a8a544548a7a45ceaeab898c` — *Central application-scoped authorization plane*
+- **TODO stack:** `central-application-scoped-authorization-plane` (`bae39e3a-4cb2-469f-b88a-89fe51d529ca`, 6 items)
+- **Workflow:** `sdlc.safe_change_delivery.v1` / step `implementation_plan`
+- **Governing repo:** `/Users/mingardia/dev/mrisys/end2endlogic/quantum/framework`
+- **Linked enterprise repo:** `/Users/mingardia/dev/mrisys/end2endlogic/quantum/quantum-enterprise`
+- **Status:** plan only — no product code changed in this step.
+
+---
+
+## 0. Ground truth & preconditions (verified by scouting the working tree)
+
+### 0.1 Version drift (must reconcile before coding)
+The objective says both repos base against **1.4.0-SNAPSHOT**. The actual working tree is:
+- framework aggregate pom `<version>` = **1.4.1-SNAPSHOT**; branch = **1.4.2-SNAPSHOT**.
+- enterprise `quantum-enterprise-parent` `<version>` = **1.4.1-SNAPSHOT**; `quantum.version` = **1.4.1-SNAPSHOT**; each auth module pins `quantum.framework.version=1.4.1-SNAPSHOT`.
+
+**Action:** treat the live tree (1.4.1 line) as authoritative — the in-progress auth work below already exists at this line. Do **not** rebase to 1.4.0. Flag the discrepancy in the change-delivery evidence; do not silently change versions.
+
+### 0.2 Preserve unrelated dirty work
+The tree carries unrelated in-flight work that MUST be preserved (seed, ontology, migration, billing/test-db changes). Do not revert or reformat:
+- `quantum-*/src/test/**` seed/ontology/migration test edits, `**/application.properties` test config, `SeedContextVariableResolver`, `SeedAdminResource`, `MongoDbInitResource*`, `MongoTenantDataExpirationProviderIT`, etc.
+- TODO note on the stack: *"Preserve unrelated dirty billing and test-database changes."*
+
+### 0.3 Auth work already present in the tree (do NOT re-create — extend/verify)
+This design is **partially delivered**. Confirmed already-present artifacts:
+
+| Artifact | Location | State |
+|---|---|---|
+| `AuthorizationProvider` SPI | `quantum-models/.../model/auth/AuthorizationProvider.java` | **untracked (new)** — `checkRules(...)`, javadoc "must fail closed" |
+| RuleContext delegation seam | `quantum-morphia-repos/.../securityrules/RuleContext.java` (pkg `security.runtime`) | **modified** — delegates to `AuthProviderFactory.getAuthProvider()` when it is an `AuthorizationProvider`, fails closed on null (~L1308) |
+| RuleContext delegation test | `quantum-morphia-repos/.../securityrules/RuleContextAuthorizationProviderTest.java` | **untracked (new)** |
+| SecurityFilter provider wiring | `quantum-security-runtime/.../rest/filters/SecurityFilter.java` | **modified** |
+| SecurityFilter delegated-provider test | `quantum-security-runtime/.../rest/filters/SecurityFilterDelegatedProviderTest.java` | **untracked (new)** |
+| App-scope grant model | `quantum-models/.../model/security/UserRealmRole.java` | present — `authorizedApplications`, `defaultApplication`, `APPLICATION_WILDCARD="*"` |
+| App-scope resolver (pure fn) | `quantum-models/.../model/auth/ApplicationAuthorizationResolver.java` | present — LEGACY/RESOLVED/AMBIGUOUS/DENIED |
+| App-scoped login | `quantum-models/.../model/auth/AuthProvider.java` | present — `login(user,pw,applicationId,realmId)`, `LoginPositiveResponse.audiences/activeApplication` |
+| Role resolution (union of sources incl. groups) | `quantum-morphia-repos/.../morphia/IdentityRoleResolver.java` | present — TOKEN/CREDENTIAL/REALM/**USERGROUP** |
+| **Enterprise** decision facade | `quantum-enterprise/quantum-auth-service/.../resource/AuthzFilterResource.java` `GET /v1/authz/filter` | present — thin facade over `RuleContext.checkRules` |
+| **Enterprise** remote provider | `quantum-enterprise/quantum-auth-client-provider/.../QuantumAuthServiceAuthProvider.java` | present — implements `AuthProvider` + `ClaimsAuthProvider` + `AuthorizationProvider.checkRules` via generated SDK; fails fast on no decision |
+| **Enterprise** generated SDK (java/py/ts) | `quantum-enterprise/quantum-auth-service/generated/quantum-auth-service-sdk/{java,python,typescript}` | present — GAV `com.e2eq.framework.auth:quantum-auth-service:0.1.0`, pkg `com.e2eq.framework.auth.sdk` |
+| SDK-gen config + contract | `quantum-auth-service/contracts/quantum-auth-service-sdk.yml` + `.openapi.yaml` (334 paths) | present |
+
+### 0.4 The actual gap this plan closes
+The **identity/provider/delegation** layer is done. The **application-scoping of the authorization decision** is NOT. Specifically:
+- `SecurityURIHeader`/`SecurityURIBody`, `PrincipalContext`, `ResourceContext`, and `Rule` carry **no `applicationId`**.
+- `Policy` selection and `RuleContext.checkRules` do **not** scope by application.
+- `Application` (`quantum-models/.../model/security/Application.java`) is an **empty marker entity** — no vocabulary (FunctionalDomain/Action) catalog, no admission validation.
+- No explicit `applicationId` in the decision contract (OpenAPI `/v1/authz/filter`) → SDKs cannot pass it.
+- No compatibility rule keeping **legacy unscoped policies local-only** / non-matching to a named application.
+
+> helixor-sdk-gen is an **out-of-band Python CLI** (`/Users/mingardia/dev/helixor/helixor-sdk-gen`), NOT a Maven plugin. SDKs are regenerated by running the CLI, then the `generated/.../java` module builds in the reactor. quantum-auth-service currently lacks a `scripts/verify-generated-sdk.sh` drift check (system/billing have one) — add it.
+
+---
+
+## 1. Scope, boundaries, non-negotiables
+
+- **Framework stays clean:** no dependency on `quantum-enterprise` or Helixor. All remote/consolidated behavior lives behind the existing `AuthorizationProvider` SPI in `quantum-models`; the impl lives in enterprise `quantum-auth-client-provider`.
+- **Fail closed** at every seam: missing `applicationId`, unknown application, missing catalog entry, provider returns null, remote unavailable → **DENY**.
+- **Additive & backward-compatible:** new `applicationId` fields are optional on the wire; absent → legacy behavior. Legacy unscoped policies never match a *named* application unless explicitly configured.
+- **No hand-written seam DTOs/clients:** every Quantum↔auth-service seam goes through helixor-sdk-gen output. If the generator lacks a capability, enhance `helixor-sdk-gen` (+ cover in `helixor-sdk-test`) — do not hand-roll.
+- **Ownership (per design):** auth-service owns Application, FunctionalDomain/Action vocabulary, UserGroup roles, UserRealmRole grants, and Policy/Rule persistence in the auth realm. Functional app DBs own only business entities. Ontology keeps semantic TBox; auth owns the authorization-vocabulary projection.
+
+---
+
+## 2. Work breakdown — mapped to the 6 TODO items
+
+Each item lists concrete files (module-relative), the change, fail-closed points, and the design verification item it satisfies.
+
+### TODO 1 — Inventory overlapping changes & freeze the application/realm authorization contract
+*(Section 0 above is the inventory. This item finalizes the contract shape before touching code.)*
+
+Deliverables:
+1. **Freeze the `applicationId` contract** — a short ADR appended to this doc:
+   - `applicationId` is a stable string ref (matches `Application.refName`), realm-qualified.
+   - Wildcard `*` = "all applications in realm" (mirror `UserRealmRole.APPLICATION_WILDCARD`).
+   - Absent/null `applicationId` on a request = **legacy scope** (local-only, unscoped policies; never matches a named application).
+   - Decision contract adds `applicationId` as an **optional** request field and echoes a `decisionScope` (already present on `AuthzFilterResponse`) that names the resolved application.
+2. **Confirm `ApplicationRepo` exists** in `quantum-morphia-repos` and its realm scoping (auth realm `quantum-auth` / `system-com`). If absent, it is added in TODO 3.
+3. Record the freeze in `brain_design` (`implementation[]`) and the TODO notes.
+
+Verification: none directly — gating artifact for the rest.
+
+### TODO 2 — Provider-neutral application scope + local policy resolution abstractions in **quantum-framework**
+Thread `applicationId` through the decision path and introduce a provider-neutral local resolver. All in **quantum-models** + **quantum-morphia-repos** (no enterprise deps).
+
+**quantum-models (`com.e2eq.framework.model.securityrules` / `model.security`):**
+- `SecurityURIHeader.java` — add optional `applicationId` field (+ builder, equals/hashCode, wildcard match support). This is the rule-matching key, so wildcard semantics must match `WildCardMatcher`.
+- `SecurityURIBody.java` — if application scope belongs to the "resource body" side, add there instead / additionally; decide during TODO 1. (Header is the natural home since it's identity+area+domain+action.)
+- `PrincipalContext.java` — add optional `applicationId` (resolved active application for the principal; default from `UserRealmRole.defaultApplication`). Builder + immutability preserved.
+- `ResourceContext.java` — add optional `applicationId` (application the target resource belongs to).
+- `Rule.java` — add optional `applicationId` on the rule (so a policy's rules can be application-qualified); default null = unscoped/legacy.
+- `SecurityCheckResponse.java` — add `resolvedApplicationId` / reflect application in the decision provenance (additive).
+
+**quantum-morphia-repos (`com.e2eq.framework.security.runtime` + `.morphia`):**
+- `RuleContext.java`:
+  - Extend `getApplicableRulesForPrincipalAndAssociatedRoles(...)` and `getEffectiveRulesForRequest(...)` to **filter by `applicationId`**: a rule matches iff `rule.applicationId` is null (legacy) **and** the request is legacy-scoped, OR `rule.applicationId` equals the request app, OR `rule.applicationId == "*"`. Legacy unscoped rules do **not** match a named-application request (compatibility rule).
+  - Add an explicit **local policy resolver abstraction**: extract the local (PolicyRepo-backed) resolution behind a small interface, e.g. `LocalPolicyResolver` (`@ApplicationScoped` default impl `MorphiaLocalPolicyResolver`) so the decision engine is provider-neutral and unit-testable without Mongo. Keep the existing delegation-to-`AuthorizationProvider` seam unchanged.
+  - **Fail closed:** if a request presents a named `applicationId` that resolves to no known application (via `ApplicationRepo`), and no wildcard/legacy rule applies → DENY. Never widen.
+  - Wire `applicationId` into the request cache key (`RuleContextRequestCache`) and the compiled `RuleIndex` key so caching stays correct per application.
+- `PolicyRepo.java` — add finder(s) that select policies by `applicationId` + realm + principal (role/user), plus the legacy-unscoped set, honoring the compatibility rule.
+- `WildCardMatcher` usage — ensure `applicationId` participates in URI expansion/matching consistently.
+
+**Enforcement call sites — populate `applicationId` (no logic change, just carry it):**
+- `quantum-security-runtime/.../rest/filters/SecurityFilter.java` — resolve active application from token (`ApplicationAuthorizationResolver` over `LoginPositiveResponse.activeApplication`/`audiences` + `UserRealmRole.defaultApplication`, honoring `X-Application` header if adopted) and set it on `PrincipalContext`; derive `ResourceContext.applicationId` from the model's owning application. **Fail closed** when the token is application-ambiguous (`AMBIGUOUS`/`DENIED` outcomes) for an app-scoped resource.
+- `quantum-morphia-repos/.../interceptors/PermissionRuleInterceptor.java`, `MorphiaRepo.java`, `RepoSecurityFilterBuilder.java` — pass through the ambient `applicationId` from `SecurityContext` (no new resolution here).
+- `quantum-query-rest/.../QueryGatewayResource.java`, `quantum-system-rest/.../PermissionResource.java` — accept optional `applicationId` and thread it into the contexts.
+
+Verification satisfied: **Application/realm policy isolation tests**, **Provider delegation & fail-closed tests** (delegation already present; extend with app-scope).
+
+### TODO 3 — Auth-owned application vocabulary, group-role policy resolution, validation & REST contracts in **quantum-auth-service** (enterprise)
+All in `quantum-enterprise/quantum-auth-service` (+ shared entities in framework `quantum-models`/`quantum-morphia-repos` where they are framework-owned model classes).
+
+**Vocabulary (application + functional area/domain/action catalog):**
+- Flesh out `Application` (`quantum-models/.../model/security/Application.java`): add `refName` usage as the app id, `displayName`, and an owned **authorization-vocabulary projection** — the set of `FunctionalDomain`/`FunctionalAction` valid for the application (either embedded refs or a join). Keep it a framework model (Morphia entity) so the local engine can read it; auth-service owns *writes*.
+- Add/confirm `ApplicationRepo` in `quantum-morphia-repos` (auth-realm scoped).
+- **Admission validation service** in auth-service (`.../auth/service/`), e.g. `AuthorizationVocabularyAdmissionService`: validate that a submitted Policy/Rule references only area/domain/action pairs present in the target application's catalog; reject unknown vocabulary (fail closed). Mirror the ontology TBox-admission pattern (see `quantum-ontology-service`), but for the authorization projection.
+
+**Group-role → role-policy resolution (central):**
+- Reuse `IdentityRoleResolver` (already unions TOKEN/CREDENTIAL/REALM/USERGROUP → effective roles). Add the **role → role-policy selection** step scoped by `applicationId` + realm: given effective roles, select `Policy` rows where `principalType=ROLE` and `principalId ∈ effectiveRoles`, filtered by application per TODO 2's compatibility rule. Confirm `AuthzFilterResource`/`checkRules` path applies this for group-derived roles identically to direct roles.
+- Add provenance: decision echoes which roles (and their `RoleSource`, incl. `USERGROUP`) contributed, per design "provenance".
+
+**REST contracts (code-first, then regenerate SDK in TODO 4):**
+- `AuthzFilterResource` (`/v1/authz/filter`) — add optional `applicationId` request param + `resolvedApplicationId`/`decisionScope` in `AuthzFilterResponse`. Keep `includeCheck` behavior.
+- New/extended resources under `/v1/authz` (or `/security/…`) for:
+  - **Application catalog** CRUD/read (`GET/POST /v1/applications`).
+  - **Functional-domain/action catalog** read + admission (`GET /v1/applications/{app}/vocabulary`, admission on policy write).
+  - **Policy CRUD/admission** — extend existing `/security/permission/policies/**` to carry `applicationId` and run vocabulary admission before persist.
+  - **Provenance** — decision response provenance (roles, sources, matched rules, resolved app).
+- **Seed packs:** update `quantum-auth-service/src/main/resources/seed-packs/platform-system-admin/datasets/{applications,policies,userGroups}.jsonl` to include application-scoped examples for tests.
+
+**Fail-closed points:** unknown application, empty catalog for a named app, policy referencing out-of-catalog vocabulary, missing role→policy match → DENY / reject.
+
+Verification satisfied: **Group role to role-policy resolution tests**, **Vocabulary admission validation tests**.
+
+### TODO 4 — Regenerate Java/TS/Python auth-service SDKs with helixor-sdk-gen & wire the enterprise provider
+- Update `quantum-auth-service/contracts/quantum-auth-service-sdk.yml` operation grouping if new ops added (keep `authorization`/`policies`/`identity` resources coherent).
+- Re-export the code-first OpenAPI (`quantum-auth-service.openapi.yaml`) from the running/annotated resources (SmallRye export), then run the generator:
+  ```
+  python -m helixor_sdk_gen.cli generate \
+    quantum-auth-service/contracts/quantum-auth-service-sdk.yml \
+    quantum-auth-service/contracts/quantum-auth-service.openapi.yaml \
+    --out quantum-auth-service/generated/quantum-auth-service-sdk --local
+  ```
+  (env `HELIXOR_SDK_GEN_ROOT=/Users/mingardia/dev/helixor/helixor-sdk-gen`.)
+- **Add `quantum-auth-service/scripts/verify-generated-sdk.sh`** (mirror system/billing) so drift is caught in CI; wire it into the build/review step.
+- Bump generated SDK artifact version if the contract changed (currently hard-pinned `0.1.0` in `quantum-auth-client-provider`; update both GAV and the dependency, or adopt a version property). Refresh `GeneratedContract.SPEC_SHA256`/`CONTRACT_VERSION` used by the `/contract-hash` handshake.
+- Wire provider: `QuantumAuthServiceAuthProvider.checkRules(...)` now sends `applicationId` on `getAuthzFilter(...)` and maps `resolvedApplicationId`/provenance back into `SecurityCheckResponse`. Still **fail fast** on no decision.
+- Regenerate/refresh the Python and TypeScript clients (`system-ux useAuthClient`) so the `applicationId`/decisionScope fields surface.
+
+Verification satisfied: **Generated SDK contract test**.
+
+### TODO 5 — Unit/integration/persistence-boundary tests + targeted builds
+Add tests (respect existing `*IT` = integration, `*Test` = unit conventions; Mongo IT via existing `MongoDbInitResource`):
+
+| Test | Module | Asserts | Design item |
+|---|---|---|---|
+| `RuleContextApplicationScopeTest` (extend `RuleContextAuthorizationProviderTest`) | quantum-morphia-repos | named-app request only matches app/wildcard rules; legacy request only matches legacy rules; unknown app → DENY | Isolation; fail-closed |
+| `ApplicationPolicyIsolationIT` | quantum-framework (IT) | policies in app A never leak to app B in same realm; cross-realm isolation holds | Application/realm policy isolation |
+| `SecurityFilterDelegatedProviderTest` (extend) | quantum-security-runtime | provider path forwards bearer + application/realm scope; provider null/unavailable → DENY | Provider delegation & fail-closed |
+| `GroupRoleToRolePolicyResolutionIT` | quantum-morphia-repos or quantum-framework | UserGroup role → role Policy selected & applied, app-scoped, with `USERGROUP` provenance | Group role → role-policy |
+| `VocabularyAdmissionValidationTest` | quantum-auth-service (enterprise) | policy referencing out-of-catalog area/domain/action rejected; valid admitted | Vocabulary admission |
+| `AuthServiceSdkContractTest` + `verify-generated-sdk.sh` | quantum-auth-service (enterprise) | generated SDK matches committed OpenAPI (no drift); `applicationId` present on decision op | Generated SDK contract |
+| `FunctionalAppPersistenceBoundaryIT` | quantum-framework (IT) | functional app DB holds only business entities; Application/Policy/UserGroup/UserRealmRole persist only in the auth realm | Functional-app persistence boundary |
+| `ApplicationAdmissionFailClosedIT` | quantum-framework (IT) | missing application context on an app-scoped resource → DENY | Fail-closed |
+
+Targeted builds (fast → full):
+```
+# framework — compile + focused module tests
+mvn -q -pl quantum-models,quantum-morphia-repos,quantum-security-runtime -am compile
+mvn -q -pl quantum-morphia-repos -Dtest='RuleContext*Test,GroupRole*' test
+mvn -q -pl quantum-framework -Dit.test='ApplicationPolicyIsolationIT,FunctionalAppPersistenceBoundaryIT,ApplicationAdmissionFailClosedIT' verify
+# enterprise — auth-service + provider + sdk
+mvn -q -pl quantum-auth-service,quantum-auth-client-provider -am test
+quantum-auth-service/scripts/verify-generated-sdk.sh
+```
+
+### TODO 6 — Security/code review, durable evidence, migration follow-ups
+- Run `/security-review` and `/code-review` (or `code.review`) on the diff; focus: fail-closed completeness, no framework→enterprise leak, cache-key correctness, wildcard-match safety.
+- Update `brain_design` `implementation[]` and the TODO stack (mark items done) with changed-file lists, commands, and results.
+- **Migration follow-ups to document (not necessarily code now):**
+  - Backfill/annotate existing Policies with `applicationId` (or leave legacy-unscoped by design). Provide a changeset guide.
+  - Reconcile the SDK `0.1.0` version pin.
+  - Reconcile the 1.4.0 vs 1.4.1/1.4.2 version drift (Section 0.1).
+
+---
+
+## 3. Sequencing & dependencies
+
+```
+TODO 1 (freeze contract) ─┬─> TODO 2 (framework: thread applicationId + local resolver)
+                          │        │
+                          │        └─> TODO 5 framework tests (isolation, fail-closed, boundary)
+                          └─> TODO 3 (enterprise: vocabulary, admission, group-role, REST)
+                                   │
+                                   └─> TODO 4 (regenerate SDK + wire provider) ─> TODO 5 SDK/enterprise tests
+                                                                                        │
+                                                                                        └─> TODO 6 (review + evidence)
+```
+- TODO 2 (framework) and the entity additions in TODO 3 that live in `quantum-models` should land together so both repos compile.
+- TODO 4 must run **after** the auth-service REST contract in TODO 3 is final (OpenAPI is code-first / exported from resources).
+
+## 4. Risks & mitigations
+- **Cache correctness:** adding `applicationId` to matching without adding it to `RuleContextRequestCache`/`RuleIndex` keys would cross-contaminate decisions. → key-inclusion is an explicit TODO-2 acceptance check.
+- **Compatibility regressions:** legacy callers send no `applicationId`. → additive optional fields + explicit "legacy request matches only legacy rules" rule; covered by `RuleContextApplicationScopeTest`.
+- **SDK drift:** no Maven-plugin generation; manual CLI step. → add `verify-generated-sdk.sh` + contract test to gate.
+- **Framework purity:** entity/vocabulary must stay in `quantum-models`/`quantum-morphia-repos`; only *write/admission/remote* logic in enterprise. → `FunctionalAppPersistenceBoundaryIT` + a dependency check that framework modules declare no enterprise/Helixor deps.
+- **Version drift (0.1):** could cause enterprise/framework artifact mismatch. → confirm both stay on 1.4.1 line for this change; document.
+
+## 5. Acceptance = design "Verification" section, fully covered
+Provider delegation/fail-closed ✔ (TODO 2/5) · Application/realm isolation ✔ (TODO 2/5) · Group-role→role-policy ✔ (TODO 3/5) · Vocabulary admission ✔ (TODO 3/5) · Generated SDK contract ✔ (TODO 4/5) · Functional-app persistence boundary ✔ (TODO 5).
+
+## 6. Explicit non-goals (this change)
+- No new identity provider / OIDC changes (JWKS validation stays local).
+- No migration of *business* data; only authorization vocabulary/policy ownership.
+- No UI beyond regenerating the TS client fields; `system-ux` UX work is a follow-up.

--- a/promptsplans/central-application-scoped-authorization-plane.plan.md
+++ b/promptsplans/central-application-scoped-authorization-plane.plan.md
@@ -1,0 +1,155 @@
+# Implementation Plan — Central Application-Scoped Authorization Plane
+
+- **Design:** `design_c3eaa8a9a8a544548a7a45ceaeab898c` — *Central application-scoped authorization plane*
+- **TODO:** `central-application-scoped-authorization-plane` (list `bae39e3a-4cb2-469f-b88a-89fe51d529ca`, 6 items)
+- **Governing repo:** `/Users/mingardia/dev/mrisys/end2endlogic/quantum/framework` (OSS framework)
+- **Linked enterprise repo:** `/Users/mingardia/dev/mrisys/end2endlogic/quantum/quantum-enterprise`
+- **Workflow:** `sdlc.safe_change_delivery.v1` — step `implementation_plan` (planner; no production code changed in this step)
+
+> **Baseline correction:** the objective says both repos base against `1.4.0-SNAPSHOT`; the actual working-tree version of **both** repos is **`1.4.1-SNAPSHOT`**. Plan against 1.4.1-SNAPSHOT.
+
+---
+
+## 1. Current-state reality (what already exists — do NOT rebuild)
+
+A large fraction of this design is already scaffolded. The delta is **threading an explicit `applicationId` scope through the decision path, resolving group roles + selecting policies by that scope centrally, and closing the fail-closed / persistence-boundary gaps** — not greenfield modeling.
+
+**Framework (`quantum-framework`) — module layout for this work:**
+- Security value objects: `quantum-models/.../model/securityrules/` (`PrincipalContext`, `ResourceContext`, `SecurityContext`, `SecurityURI`/`SecurityURIHeader`/`SecurityURIBody`).
+- Persisted security entities: `quantum-models/.../model/security/` (`Policy`, `Rule`, `FunctionalDomain`, `FunctionalAction`, `UserGroup`, `UserRealmRole`).
+- Engine + repos + interceptors: `quantum-morphia-repos/` (`securityrules/RuleContext.java` — **FQN is `com.e2eq.framework.security.runtime.RuleContext`**, note path/package mismatch; `PolicyRepo`, `IdentityRoleResolver`, `interceptors/PermissionRuleInterceptor`).
+- Request-time filters: `quantum-security-runtime/` (`SecurityFilter`, `RolesAugmentor`).
+- Auth SPI: `quantum-models/.../model/auth/` (`AuthProvider`, `AuthorizationProvider`, `ApplicationAuthorizationResolver`, `RoleAssignment`, `RoleSource`).
+
+**Already in place (relevant to this design):**
+1. **Provider seam** — `AuthorizationProvider extends AuthProvider` with `checkRules(...)`; `RuleContext.checkRules` already delegates to it when `AuthProviderFactory.getAuthProvider() instanceof AuthorizationProvider`, and **fails closed** on a null decision. *(This is in-flight uncommitted work — Group A dirty tree.)*
+2. **Two provider tests already drafted (uncommitted):** `RuleContextAuthorizationProviderTest`, `SecurityFilterDelegatedProviderTest`.
+3. **Remote delegation impl** — `quantum-enterprise/quantum-auth-client-provider/.../QuantumAuthServiceAuthProvider` implements `AuthorizationProvider`, calls the central `/v1/authz/filter` over the **generated SDK**, and runs a `/contract-hash` semver+sha256 handshake (fail-fast, no silent fallback).
+4. **Central service** — `quantum-enterprise/quantum-auth-service` already exposes: `/v1/authz/filter` (`AuthzFilterResource`, injects framework `RuleContext`), `/system/permissions/check|fd/evaluate|role-provenance`, policy CRUD (`/security/permission/policies`), application catalog (`/api/security/application`), `/security/functionalDomain`, `/user/usergroup`, `/security/user-realm-roles` (incl. `.../applications/evaluate`).
+5. **Generated SDKs (java/ts/python)** already checked in at `quantum-auth-service/generated/quantum-auth-service-sdk/{java,python,typescript}`; gen config `quantum-auth-service/contracts/quantum-auth-service-sdk.yml`; OpenAPI source `quantum-auth-service/contracts/quantum-auth-service.openapi.yaml`; embedded `GeneratedContract.SPEC_SHA256` + `CONTRACT_VERSION`.
+6. **Group-role resolution** — `IdentityRoleResolver` already unions token + credential + `UserRealmRole` + `UserGroup` roles with `RoleSource` provenance; `UserGroup.roles[]` exists; `/system/permissions/role-provenance` exposes provenance.
+7. **Login-time application scope** — `UserRealmRole.authorizedApplications[]` / `defaultApplication`; `ApplicationAuthorizationResolver` (decisions locked 2026-07-12 / 07-20, `"*"` wildcard).
+
+**The gap this design closes:** application scope exists **only in the auth/token-audience layer**. It is **absent** from every authorization-*decision* object — `PrincipalContext`, `ResourceContext`, `Policy`, `SecurityURIHeader`/`Body`, and the `/v1/authz/filter` + `CheckRequest`/`EvaluateRequest` contract (`applicationId` appears 0× in those, confirmed). Policy selection today is by string identity match only; there is no application dimension.
+
+---
+
+## 2. Scope boundaries — preserve unrelated dirty work
+
+**Do NOT touch (preserve in place):**
+- **Framework Group B (test-infra):** `MongoDbInitResource(+Test)`, `TestMorphiaDataStore`, `MigrationStartupRealmsTestProfile`, `TestLocks`, all `application.properties` under `src/test/resources`, `AgentConfigResourceIT`, `MongoTenantDataExpirationProviderIT`.
+- **Framework Group C (seed/ontology tests + seed main):** all `service/seed/*` tests, `SeedContextVariableResolver`, `SeedAdminResource`, `quantum-ontology-mongo`/`-policy-bridge` IT tests.
+- **Enterprise billing branch (large, active):** everything under `quantum-billing-*`, the `quantum-system-service` billing bindings/offers/selection files, and all regenerated billing/system SDKs.
+- **Enterprise auth files entangled with the billing branch:** `QuantumAuthServiceAuthProvider.java`, `GitHubOAuthLoginService.java`, auth `application.properties` are already `M` on the billing branch — **coordinate before editing**; prefer additive edits and confirm they do not collide with the billing commit.
+
+**Fair game to modify/extend:** framework Group A auth seam (RuleContext, SecurityFilter, AuthorizationProvider, the two new provider tests), plus new files. In enterprise: `quantum-auth-service` REST/service + contract + regenerated auth SDK, `quantum-auth-client-provider` (coordinated).
+
+**Hard rule:** the OSS framework must not gain any `quantum-enterprise` or Helixor dependency. All enterprise↔framework coupling stays behind the framework-owned `AuthorizationProvider` SPI + the generated SDK.
+
+---
+
+## 3. Workstreams (mapped to the 6 TODO items)
+
+### WS-1 — Inventory & freeze the application/realm authorization contract  *(TODO #1)*
+- Freeze the decision contract shape as an **additive** change: `applicationId` (nullable/optional) on the decision input + Policy selection, echoed in the response for provenance.
+- Confirm the semantics table (below) and record it as the contract-of-record note in the design.
+- **Done:** contract semantics agreed; no code yet.
+
+**`applicationId` semantics (the compatibility contract):**
+| Policy `applicationId` | Context `applicationId` | Match? |
+|---|---|---|
+| `null` (legacy/unscoped) | `null` | yes (local-only compat) |
+| `null` (legacy/unscoped) | named `A` | **no** — legacy must not match a named application unless explicitly opted in |
+| `A` | `A` | yes |
+| `A` | `B` or `null` | no |
+| `*` (explicit wildcard) | any | yes (audit-logged) |
+- **Fail closed:** context has a named application but no catalog entry / no matching scoped policy / provider unreachable ⇒ **DENY**, typed diagnostic.
+
+### WS-2 — Framework: provider-neutral application scope + local resolver  *(TODO #2)*
+Files (framework, additive):
+- `quantum-models/.../model/securityrules/PrincipalContext.java` — add `String applicationId` (+ builder `withApplicationId`, getter, equals/hashCode/toString). Default `null`.
+- `quantum-models/.../model/securityrules/ResourceContext.java` — add `String applicationId` (+ builder, getter). Keep lowercase-normalization consistent with siblings.
+- `quantum-models/.../model/securityrules/SecurityURIBody.java` — add `application` scope dimension (default `"*"`), mirroring the existing `realm` dimension so rule scope matching gains an application axis **without** changing the `SecurityURIHeader` wildcard-trie key (avoids reindexing/ABI break).
+- `quantum-models/.../model/security/Policy.java` — add `String applicationId` (nullable) as the coarse selection filter.
+- `quantum-morphia-repos/.../morphia/PolicyRepo.java` — add application-scoped selection: `getPoliciesForIdentities(realm, identities, applicationId)` overloads that (a) include policies whose `applicationId` equals the context app or is `*`, and (b) include `applicationId==null` legacy policies **only when** the context application is null (or an explicit opt-in flag is set). Keep existing signatures for compatibility.
+- `quantum-morphia-repos/.../securityrules/RuleContext.java` — in the **local** (non-delegated) branch, pass the context `applicationId` into policy selection + `SecurityURIBody` application matching; **fail closed** when a named application is present but resolves to no catalog entry / no policy. The already-present delegated branch stays.
+- `quantum-security-runtime/.../rest/filters/SecurityFilter.java` — populate `applicationId` on the built `PrincipalContext`/`ResourceContext` from the token (`azp`/`aud` active application per `ApplicationAuthorizationResolver`) and/or request. Additive; null when absent (legacy).
+- **Config:** a property (e.g. `quantum.security.application-scope.require-named=false`) to keep legacy behavior default-on and let deployments enforce named-application-only.
+- **Done:** local resolver honors application scope + fails closed; contexts carry `applicationId`; all existing callers compile unchanged (fields optional).
+
+### WS-3 — Auth service: auth-owned vocabulary, group→role policy resolution, admission, REST  *(TODO #3)*
+Files (enterprise `quantum-auth-service`):
+- `.../resource/AuthzFilterResource.java` — accept an `applicationId` query param; set it on the `PrincipalContext`/`ResourceContext` before `ruleContext.checkRules(...)`; echo it in `AuthzFilterResponse`. Fail closed (400/deny) when required application context is absent under enforced mode.
+- Group-role resolution — ensure the central decision path resolves **effective roles = direct + realm (`UserRealmRole`) + active `UserGroup` roles** before policy selection (reuse `IdentityRoleResolver`); expose via `/system/permissions/role-provenance` (already present) and use in `check`/`fd/evaluate`.
+- Vocabulary **admission validation** — extend `.../service/RegistryBackedApplicationValidator.java` (and/or a new `PolicyAdmissionValidator`) so persisting a `Policy` validates that referenced `area` / `functionalDomain` / `action` / `applicationId` exist in the catalog; reject unknown vocabulary with a typed error (fail closed). Wire into the policy CRUD write path (`PolicyResource` / `PolicyRepo` pre-persist).
+- **Ownership / persistence boundary** — confirm that in **remote** mode a functional application delegates all policy/vocabulary reads and never persists `policy`/`functionalDomain`/`application`/`userGroup`/`userRealmRole` documents locally; auth-service (auth realm DB) is the persistence owner. Reuse the `quantum.mode=embedded|remote` fail-loud seam; do NOT “fix” those throws.
+- **Done:** central service selects policies by application+realm+effective-roles, validates vocabulary on admission, fails closed on missing app/catalog.
+
+### WS-4 — Regenerate SDKs + wire the enterprise provider  *(TODO #4)*
+1. Edit OpenAPI `quantum-auth-service/contracts/quantum-auth-service.openapi.yaml`:
+   - Add `applicationId` (optional) to `getAuthzFilter` params, `CheckRequest`, `EvaluateRequest`, `RoleProvenanceRequest`, `AuthzFilterResponse`, and the `Policy` schema.
+2. Regenerate (command from `contracts/quantum-auth-service-sdk.yml` header):
+   ```
+   PYTHONPATH=/Users/mingardia/dev/helixor/helixor-sdk-gen/src \
+     python -m helixor_sdk_gen.cli generate \
+     quantum-auth-service/contracts/quantum-auth-service-sdk.yml \
+     quantum-auth-service/contracts/quantum-auth-service.openapi.yaml \
+     --out quantum-auth-service/generated/quantum-auth-service-sdk --local
+   ```
+   Regenerates java/ts/python; refreshes `GeneratedContract.SPEC_SHA256` + `CONTRACT_VERSION`.
+3. Enterprise provider `quantum-auth-client-provider/.../QuantumAuthServiceAuthProvider.checkRules(...)` — forward `applicationId` (from `ResourceContext`/`PrincipalContext`) to `getAuthzFilter`. **(Coordinate — file is entangled with the billing branch.)**
+4. If `helixor-sdk-gen` lacks a needed capability, **enhance the generator + cover in `helixor-sdk-test`** — never hand-write client code or copy DTOs.
+5. **Done:** SDKs regenerated, contract hash bumped, provider forwards application scope, `/contract-hash` handshake still passes.
+
+### WS-5 — Tests + targeted builds  *(TODO #5)* — see §5 matrix.
+
+### WS-6 — Security/code review, durable evidence, migration follow-ups  *(TODO #6)*
+- Run `sdlc.safe_change_delivery.v1` security gate (`helixor.security_review_decision.v1`) over the diff; `/security-review`.
+- Update the design `implementation` + TODO items with evidence (files, commands, results).
+- Document migration follow-ups: backfilling `applicationId` on existing policies, catalog seeding for existing functional domains, and the embedded→remote persistence cutover per realm.
+
+---
+
+## 4. Sequencing & dependencies
+
+```
+WS-1 (freeze contract)
+  └─> WS-2 (framework: contexts + local resolver + fail-closed)   ← unblocks OSS build + local tests
+  └─> WS-3 (auth-service: decision scope + admission)             ← depends on WS-2 model fields
+         └─> WS-4 (OpenAPI edit → regen SDK → provider forwards)  ← depends on WS-3 REST shape
+                └─> WS-5 (delegation/SDK-contract/persistence tests)
+                       └─> WS-6 (review + evidence + migration notes)
+```
+Critical path is WS-2 → WS-3 → WS-4. WS-2 is self-contained in the OSS repo and can land first (framework must stay independently buildable/testable). WS-4 SDK regen must follow the OpenAPI edit and precede provider wiring.
+
+---
+
+## 5. Verification matrix (design’s 6 categories → concrete tests)
+
+| Design verification item | Concrete test | Location |
+|---|---|---|
+| Provider delegation + fail-closed | extend existing `RuleContextAuthorizationProviderTest` + `SecurityFilterDelegatedProviderTest`; add null-decision + provider-unreachable ⇒ DENY | `quantum-morphia-repos/src/test/...securityrules/`, `quantum-security-runtime/src/test/...rest/filters/` |
+| Application/realm policy isolation | new `ApplicationScopedPolicyIsolationTest` — policy for app `A`/realm `R1` must not match app `B`/realm `R2`; legacy (`null`) must not match a named app | `quantum-morphia-repos/src/test/...securityrules/` |
+| Group role → role-policy resolution | new `GroupRoleToPolicyResolutionTest` — `UserGroup.roles` resolve into effective identities that select the matching role `Policy` | `quantum-morphia-repos/src/test/...` (build on `IdentityRoleResolver`) |
+| Vocabulary admission validation | new `PolicyAdmissionValidationTest` — persisting a policy with unknown area/domain/action/application is rejected fail-closed | `quantum-auth-service/src/test/...` (or framework admission module) |
+| Generated SDK contract test | new `AuthSdkContractTest` — SDK `SPEC_SHA256` matches the OpenAPI; `getAuthzFilter` carries `applicationId` | `quantum-auth-service` (align with system/billing `scripts/verify-generated-sdk.sh`; note: auth has none yet — add one) |
+| Functional-app persistence boundary | new `FunctionalAppPersistenceBoundaryTest` — in remote mode the app DB holds no `policy`/`functionalDomain`/`application`/`userGroup`/`userRealmRole` docs; reads delegate | framework IT (reuse existing Mongo test harness — Group B, do not modify it) |
+
+**Targeted builds:**
+- Framework: `mvn -q -pl quantum-models,quantum-morphia-repos,quantum-security-runtime -am install -DskipTests` then run the above unit tests.
+- Enterprise: `mvn -q -pl quantum-auth-service,quantum-auth-client-provider -am install -DskipTests` after SDK regen; run SDK contract test.
+
+---
+
+## 6. Risks & open decisions
+- **`SecurityURI` axis choice:** application scope goes on `SecurityURIBody` (like `realm`), *not* `SecurityURIHeader`, to avoid breaking the wildcard-trie header key and rule-index ABI. Confirm no consumer relies on header cardinality.
+- **Legacy default:** ship `require-named=false` so unscoped policies keep working; enforcing named-application-only is an opt-in per deployment (design “Compatibility”).
+- **Enterprise entanglement:** `QuantumAuthServiceAuthProvider` + auth `application.properties` are dirty on the billing branch — sequence WS-4 edits to avoid clobbering; consider a dedicated branch/worktree.
+- **RuleContext path/package mismatch** (`securityrules/` dir vs `security.runtime` package) — leave as-is (out of scope); note for callers.
+- **`quantum-ontology-service` `/v1/security/decide`** is a parallel decision surface also calling `ruleContext.checkRules(...)` — ensure application scoping is consistent there or explicitly deferred.
+- **Migration:** existing policies have `applicationId==null`; a follow-up changeset backfills scoped policies and seeds the application/vocabulary catalog before any deployment flips to `require-named=true`.
+
+## 7. Out of scope / follow-ups
+- Backfill/migration changeset for existing policies & catalog seeding (WS-6 follow-up).
+- Wiring the remote ontology decision surface to application scope.
+- Renaming the `RuleContext` directory to match its package.

--- a/quantum-framework/src/test/java/com/e2eq/framework/MongoPolicyParityIT.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/MongoPolicyParityIT.java
@@ -29,7 +29,7 @@ public class MongoPolicyParityIT {
     @Inject
     RuleContext ruleContext;
 
-    private static final String REALM = "parity-realm"; // isolated realm for this test
+    private static final String REALM = "test-parity-realm"; // isolated realm for this test
 
     private PrincipalContext admin;
     private PrincipalContext user;

--- a/quantum-framework/src/test/java/com/e2eq/framework/migration/MigrationStartupRealmsTestProfile.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/migration/MigrationStartupRealmsTestProfile.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class MigrationStartupRealmsTestProfile implements QuarkusTestProfile {
 
-    public static final String EXTRA_REALM = "startup-extra-apply-realms-it-com";
+    public static final String EXTRA_REALM = "test-startup-extra-apply-realms-it-com";
 
     @Override
     public Map<String, String> getConfigOverrides() {

--- a/quantum-framework/src/test/java/com/e2eq/framework/migration/TestLocks.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/migration/TestLocks.java
@@ -23,7 +23,7 @@ public class TestLocks {
     @Test
     public void testLocks() {
         MongoCollection<Document> collection = mongoClient
-                .getDatabase("sherlock")
+                .getDatabase("test-sherlock")
                 .getCollection("locks");
 
         Sherlock sherlock = MongoSherlock.create(collection);
@@ -35,7 +35,7 @@ public class TestLocks {
     @Test
     public void testLocks2() throws InterruptedException {
         MongoCollection<Document> collection = mongoClient
-                .getDatabase("sherlock")
+                .getDatabase("test-sherlock")
                 .getCollection("locks");
 
         Sherlock sherlock = MongoSherlock.create(collection);
@@ -97,7 +97,7 @@ public class TestLocks {
     @Test
     public void testShirlockMigration() {
         MongoCollection<Document> collection = mongoClient
-                .getDatabase("sherlock")
+                .getDatabase("test-sherlock")
                 .getCollection("locks");
         Sherlock sherlock = MongoSherlock.create(collection);
         // first commit - all migrations are executed

--- a/quantum-framework/src/test/java/com/e2eq/framework/model/persistent/morphia/changesets/ApplySeedPacksChangeSetIT.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/model/persistent/morphia/changesets/ApplySeedPacksChangeSetIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(MongoDbInitResource.class)
 public class ApplySeedPacksChangeSetIT {
 
-    private static final String REALM = "seed-changeset-it";
+    private static final String REALM = "test-seed-changeset-it";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/persistent/TestMorphiaDataStore.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/persistent/TestMorphiaDataStore.java
@@ -48,7 +48,7 @@ public class TestMorphiaDataStore extends BaseRepoTest{
 
     @Test
     public void testConcurrentAccessCreatesSingleDatastore() throws Exception {
-        String realm = "concurrent-test-realm";
+        String realm = "test-concurrent-realm";
 
         int threads = 10;
         ExecutorService executor = Executors.newFixedThreadPool(threads);

--- a/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/XRealmUserProvisioningIT.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/rest/filters/XRealmUserProvisioningIT.java
@@ -51,10 +51,10 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class XRealmUserProvisioningIT extends BaseRepoTest {
 
     // Test target realm configuration (the "other" tenant)
-    private static final String TARGET_REALM_REF_NAME = "xrealm-provision-target";
+    private static final String TARGET_REALM_REF_NAME = "test-xrealm-provision-target";
     private static final String TARGET_EMAIL_DOMAIN = "xrealmtarget.com";
     private static final String TARGET_ORG = "XREALM-TARGET-ORG";
-    private static final String TARGET_TENANT = "xrealm-provision-target";
+    private static final String TARGET_TENANT = "test-xrealm-provision-target";
     private static final String TARGET_ACCOUNT = "XREALM-TARGET-ACCT";
 
     // Test users to be provisioned

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/ClasspathSeedSourceTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/ClasspathSeedSourceTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(MongoDbInitResource.class)
 class ClasspathSeedSourceTest {
 
-    private static final String REALM = "classpath-seed-source-test";
+    private static final String REALM = "test-classpath-seed-source";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/MorphiaSeedRepositoryIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/MorphiaSeedRepositoryIntegrationTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class MorphiaSeedRepositoryIntegrationTest {
 
     private static final Path SEED_ROOT = Path.of("src", "test", "resources", "seed-packs");
-    private static final String REALM = "morphia-seed-it";
+    private static final String REALM = "test-morphia-seed-it";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedLoaderConflictPolicyIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedLoaderConflictPolicyIntegrationTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 class SeedLoaderConflictPolicyIntegrationTest {
 
     private static final Path SEED_ROOT = Path.of("src", "test", "resources", "seed-packs");
-    private static final String REALM = "seed-loader-conflict-it";
+    private static final String REALM = "test-seed-loader-conflict-it";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedLoaderInsertOnlyDefaultIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedLoaderInsertOnlyDefaultIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class SeedLoaderInsertOnlyDefaultIntegrationTest {
 
     private static final Path SEED_ROOT = Path.of("src", "test", "resources", "seed-packs");
-    private static final String REALM = "seed-loader-insert-only-it";
+    private static final String REALM = "test-seed-loader-insert-only-it";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedLoaderIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedLoaderIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class SeedLoaderIntegrationTest {
 
     private static final Path SEED_ROOT = Path.of("src", "test", "resources", "seed-packs");
-    private static final String REALM = "seed-loader-it";
+    private static final String REALM = "test-seed-loader-it";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedNoHttpTestProfile.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedNoHttpTestProfile.java
@@ -23,8 +23,8 @@ public class SeedNoHttpTestProfile implements QuarkusTestProfile {
         // Bind explicitly to loopback if anything starts
         cfg.put("quarkus.http.host", "127.0.0.1");
         // Use a dedicated Morphia database for tests to avoid collisions with default/system DB
-        cfg.put("quarkus.morphia.database", "seed-tests");
-        cfg.put("quarkus.mongodb.database", "seed-tests");
+        cfg.put("quarkus.morphia.database", "test-seed");
+        cfg.put("quarkus.mongodb.database", "test-seed");
         // Avoid Morphia auto index creation to reduce startup work and flakiness
         cfg.put("quarkus.morphia.create-indexes", "false");
         // Disable database migrations during these tests; tests drive seeding explicitly

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedTransformsIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedTransformsIntegrationTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SeedTransformsIntegrationTest {
 
     private static final Path SEED_ROOT = Path.of("src", "test", "resources", "seed-packs");
-    private static final String REALM = "seed-transforms-it";
+    private static final String REALM = "test-seed-transforms-it";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedVersionSelectionIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/SeedVersionSelectionIntegrationTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SeedVersionSelectionIntegrationTest {
 
     private static final Path SEED_ROOT = Path.of("src", "test", "resources", "seed-packs");
-    private static final String REALM = "seed-version-it";
+    private static final String REALM = "test-seed-version-it";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/service/seed/StringInterpolationIntegrationTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/service/seed/StringInterpolationIntegrationTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class StringInterpolationIntegrationTest {
 
     private static final Path SEED_ROOT = Path.of("src", "test", "resources", "seed-packs");
-    private static final String REALM = "interpolation-test-realm";
+    private static final String REALM = "test-interpolation-realm";
 
     @Inject
     MongoClient mongoClient;

--- a/quantum-framework/src/test/java/com/e2eq/framework/system/TestRealmMembership.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/system/TestRealmMembership.java
@@ -28,7 +28,7 @@ public class TestRealmMembership extends BaseRepoTest {
     @Inject UserRealmRoleRepo userRealmRoleRepo;
     @Inject SystemDirectory systemDirectory;
 
-    private static final String REALM = "membership-test-realm-com";
+    private static final String REALM = "test-membership-realm-com";
 
     @Test
     public void ownerAndParticipantsResolveAndUserRolesArePerRealm() {

--- a/quantum-framework/src/test/java/com/e2eq/framework/test/MongoDbInitResource.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/test/MongoDbInitResource.java
@@ -33,20 +33,28 @@ import java.util.Set;
  */
 public class MongoDbInitResource implements QuarkusTestResourceLifecycleManager {
 
+    static final String TEST_DATABASE_PREFIX = "test-";
+
     private MongoClient mongoClient;
 
     @Override
     public Map<String, String> start() {
         try {
+            String systemRealm = getCfg("quantum.realmConfig.systemRealm", "test-system-com");
+            String testRealm = getCfg("quantum.realmConfig.testRealm", "test-system-com");
+            String defaultRealm = getCfg("quantum.realmConfig.defaultRealm", "test-mycompanyxyz-com");
+
+            requireTestDatabaseName(systemRealm, "quantum.realmConfig.systemRealm");
+            requireTestDatabaseName(testRealm, "quantum.realmConfig.testRealm");
+            requireTestDatabaseName(defaultRealm, "quantum.realmConfig.defaultRealm");
+            requireConfiguredTestDatabaseName("quarkus.mongodb.database");
+            requireConfiguredTestDatabaseName("quarkus.morphia.database");
+
             String conn = ConfigProvider.getConfig().getValue("quarkus.mongodb.connection-string", String.class);
             this.mongoClient = MongoClients.create(conn);
 
             String requiredVersionStr = ConfigProvider.getConfig().getValue("quantum.database.version", String.class);
             Semver required = Semver.parse(requiredVersionStr);
-
-            String systemRealm = getCfg("quantum.realmConfig.systemRealm", "system-com");
-            String testRealm = getCfg("quantum.realmConfig.testRealm", "test-system-com");
-            String defaultRealm = getCfg("quantum.realmConfig.defaultRealm", "mycompanyxyz-com");
 
             // Ensure system and test DBs are at required version; if not, drop (BaseRepoTest will migrate)
             ensureRealmInitialized(systemRealm, required);
@@ -178,6 +186,7 @@ public class MongoDbInitResource implements QuarkusTestResourceLifecycleManager 
     }
 
     private void dropDatabaseQuietly(String dbName) {
+        requireTestDatabaseName(dbName, "database selected for test cleanup");
         try {
             mongoClient.getDatabase(dbName).drop();
         } catch (Exception e) {
@@ -331,6 +340,20 @@ public class MongoDbInitResource implements QuarkusTestResourceLifecycleManager 
 
     private String getCfg(String name, String defVal) {
         return ConfigProvider.getConfig().getOptionalValue(name, String.class).orElse(defVal);
+    }
+
+    private void requireConfiguredTestDatabaseName(String configName) {
+        ConfigProvider.getConfig().getOptionalValue(configName, String.class)
+                .ifPresent(databaseName -> requireTestDatabaseName(databaseName, configName));
+    }
+
+    static String requireTestDatabaseName(String databaseName, String source) {
+        if (databaseName == null || !databaseName.startsWith(TEST_DATABASE_PREFIX)) {
+            throw new IllegalArgumentException(
+                    source + " must name a test database beginning with '"
+                            + TEST_DATABASE_PREFIX + "'; received: " + databaseName);
+        }
+        return databaseName;
     }
 
     private String emailDomainFromTenantId(String tenantId) {

--- a/quantum-framework/src/test/java/com/e2eq/framework/test/MongoDbInitResourceTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/test/MongoDbInitResourceTest.java
@@ -1,0 +1,26 @@
+package com.e2eq.framework.test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MongoDbInitResourceTest {
+
+    @Test
+    void acceptsTestPrefixedDatabaseName() {
+        assertEquals("test-quantum-framework-shared",
+                MongoDbInitResource.requireTestDatabaseName(
+                        "test-quantum-framework-shared", "test config"));
+    }
+
+    @Test
+    void rejectsUnscopedDatabaseNameBeforeCleanupCanRun() {
+        assertThrows(IllegalArgumentException.class,
+                () -> MongoDbInitResource.requireTestDatabaseName(
+                        "end2endlogic", "test config"));
+        assertThrows(IllegalArgumentException.class,
+                () -> MongoDbInitResource.requireTestDatabaseName(
+                        "quantum-system", "test config"));
+    }
+}

--- a/quantum-framework/src/test/resources/application.properties
+++ b/quantum-framework/src/test/resources/application.properties
@@ -77,10 +77,10 @@ quarkus.mongodb.connection-string = ${MONGODB_CONNECTION_STRING:mongodb://localh
 
 
 # mandatory if you don't specify the name of the database using @MongoEntity
-quarkus.mongodb.database = ${MONGODB_DEFAULT_SCHEMA:system-com}
+quarkus.mongodb.database = ${MONGODB_DEFAULT_SCHEMA:test-system-quantum-com}
 
 #--- Morphia
-quarkus.morphia.database=system-quantum-com
+quarkus.morphia.database=test-system-quantum-com
 quarkus.morphia.packages=com.e2eq.framework.model.persistent.security,com.e2eq.framework.model.persistent.base,com.e2eq.framework.model.persistent.morphia,com.e2eq.framework.model.persistent.migration.base,com.e2eq.framework.persistent.base,com.e2eq.framework.validators 
 quarkus.morphia.create-caps=true
 quarkus.morphia.create-indexes=true
@@ -99,13 +99,13 @@ quantum.seed.root=src/test/resources/seed-packs
 # Limit which seed packs the ApplySeedPacksChangeSet applies during tests to avoid test-only transforms
 quantum.seed.apply.filter=demo-seed
 
-quantum.realmConfig.systemRealm=system-quantum-com
+quantum.realmConfig.systemRealm=test-system-quantum-com
 quantum.realmConfig.systemTenantId=system-quantum.com
 quantum.realmConfig.systemOrgRefName=system.com
 quantum.realmConfig.systemAccountNumber=0000000000
 quantum.realmConfig.systemUserId=system@system.com
 
-quantum.realmConfig.devRealm=dev-quantum-com
+quantum.realmConfig.devRealm=test-dev-quantum-com
 quantum.realmConfig.devTenantId=dev-quantum-com
 
 quantum.realmConfig.testRealm=test-quantum-com
@@ -114,7 +114,7 @@ quantum.realmConfig.testTenantId=test-quantum.com
 quantum.realmConfig.testOrgRefName=test-system.com
 quantum.realmConfig.testAccountNumber=0000000000
 
-quantum.realmConfig.defaultRealm=mycompanyxyz-com
+quantum.realmConfig.defaultRealm=test-mycompanyxyz-com
 quantum.realmConfig.defaultTenantId=mycompanyxyz.com
 quantum.realmConfig.defaultAccountNumber=9999999999
 

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -757,7 +757,10 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                      Log.warnf("Wildcard application grant exercised (audit): user=%s realm=%s activeApplication=%s",
                         userId, tokenRealm, appAuth.activeApplication());
                   }
-                  String authToken = TokenUtils.generateAuthenticatedUserToken(
+                  java.util.Set<String> userGroupRoles = resolveUserGroupRoles(
+                     subject, tokenRealm, appAuth.activeApplication());
+                  groups.addAll(userGroupRoles);
+                  String authToken = TokenUtils.generateUserToken(
                      subject,
                      credential.getUserId(),
                      groups,
@@ -765,6 +768,8 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                      tokenDomainContext.getTenantId(),
                      tokenDomainContext.getOrgRefName(),
                      tokenDomainContext.getAccountId(),
+                     appAuth.audiences(),
+                     appAuth.activeApplication(),
                      // Signed realm boundary: lets delegated-claims validators
                      // authorize X-Realm switches within the credential's own
                      // declared boundary instead of pinning to the login realm.
@@ -787,26 +792,6 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                   java.util.Set<String> idpRoles = (identity != null) ? new java.util.LinkedHashSet<>(identity.getRoles()) : java.util.Set.of();
                   java.util.Set<String> credentialRoles = credentialRolesForRealm(
                      credential.getRoles(), credentialRealm, tokenRealm);
-                  java.util.Set<String> userGroupRoles = new java.util.LinkedHashSet<>();
-                  try {
-                     var userProfileOpt = userProfileRepo.getBySubject(realm, subject);
-                     if (userProfileOpt.isPresent()) {
-                        var userGroups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
-                           realm, userProfileOpt.get().createEntityReference());
-                        if (userGroups != null) {
-                           for (UserGroup g : userGroups) {
-                              if (g != null && g.getRoles() != null) {
-                                 userGroupRoles.addAll(new java.util.LinkedHashSet<>(g.getRoles()));
-                              }
-                           }
-                        }
-                     }
-                  } catch (Exception e) {
-                     throw new IllegalStateException(
-                        "Unable to resolve user-group roles for user '" + userId
-                           + "' in realm '" + tokenRealm + "'", e);
-                  }
-
                   java.util.Set<String> rolesSet = new java.util.LinkedHashSet<>();
                   rolesSet.addAll(idpRoles);
                   rolesSet.addAll(credentialRoles);
@@ -946,23 +931,7 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
             credential.getRoles(), credentialRealm, tokenRealm);
          Set<String> realmRoles = new LinkedHashSet<>();
          realmAssignment.map(UserRealmRole::getRoles).ifPresent(realmRoles::addAll);
-         Set<String> userGroupRoles = new LinkedHashSet<>();
-         userProfileRepo.getBySubject(tokenRealm, credential.getSubject()).ifPresent(profile -> {
-            var userGroups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
-               tokenRealm, profile.createEntityReference());
-            if (userGroups != null) {
-               for (UserGroup group : userGroups) {
-                  if (group != null && group.getRoles() != null) {
-                     userGroupRoles.addAll(group.getRoles());
-                  }
-               }
-            }
-         });
-
-         Set<String> allRoles = new LinkedHashSet<>();
-         allRoles.addAll(credentialRoles);
-         allRoles.addAll(realmRoles);
-         allRoles.addAll(userGroupRoles);
+         Set<String> userGroupRoles;
 
          ApplicationAuthorizationResolver.Result appAuth = ApplicationAuthorizationResolver.resolve(
             realmAssignment.map(UserRealmRole::getAuthorizedApplications).orElse(null),
@@ -981,6 +950,12 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
                "Credential has no application authorization (applicationRegEx unset and no per-realm "
                   + "application grant); cannot refresh an application-scoped session");
          }
+         userGroupRoles = resolveUserGroupRoles(
+            credential.getSubject(), tokenRealm, appAuth.activeApplication());
+         Set<String> allRoles = new LinkedHashSet<>();
+         allRoles.addAll(credentialRoles);
+         allRoles.addAll(realmRoles);
+         allRoles.addAll(userGroupRoles);
 
          DomainContext tokenDomainContext = Objects.equals(credentialRealm, tokenRealm)
             ? credential.getDomainContext()
@@ -990,10 +965,11 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
          }
 
          // Only RESOLVED reaches the mint (LEGACY/AMBIGUOUS/DENIED threw above).
-         String newAuthToken = TokenUtils.generateAuthenticatedUserToken(
+         String newAuthToken = TokenUtils.generateUserToken(
             refreshSubject, userId, allRoles, tokenRealm,
             tokenDomainContext.getTenantId(), tokenDomainContext.getOrgRefName(),
-            tokenDomainContext.getAccountId(), credential.getRealmRegEx(),
+            tokenDomainContext.getAccountId(), appAuth.audiences(),
+            appAuth.activeApplication(), credential.getRealmRegEx(),
             TokenUtils.expiresAt(durationInSeconds), issuer);
          String newRefreshToken = generateRefreshToken(
             refreshSubject, userId, tokenRealm,
@@ -1076,6 +1052,7 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
             Map.entry("tenantId", Objects.requireNonNullElse(claimString(jwt, "tenantId"), "")),
             Map.entry("orgRefName", Objects.requireNonNullElse(claimString(jwt, "orgRefName"), "")),
             Map.entry("accountNum", Objects.requireNonNullElse(claimString(jwt, "accountNum"), "")),
+            Map.entry("azp", Objects.requireNonNullElse(claimString(jwt, "azp"), "")),
             Map.entry("activeApplication", Objects.requireNonNullElse(claimString(jwt, "azp"), ""))
          ));
          return identity;
@@ -1149,6 +1126,42 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
 
    private Optional<CredentialUserIdPassword> getCredentials (String realm, String userId) {
       return (realm == null) ? credentialRepo.findByUserId(userId) : credentialRepo.findByUserId(userId, realm);
+   }
+
+   private Set<String> resolveUserGroupRoles(String subject, String operatingRealm, String applicationId) {
+      if (subject == null || subject.isBlank()) return Set.of();
+      LinkedHashSet<String> roles = new LinkedHashSet<>();
+      LinkedHashSet<String> directoryRealms = new LinkedHashSet<>();
+      directoryRealms.add(envConfigUtils.getSystemRealm());
+      if (operatingRealm != null && !operatingRealm.isBlank()) directoryRealms.add(operatingRealm);
+      try {
+         for (String directoryRealm : directoryRealms) {
+            userProfileRepo.getBySubject(directoryRealm, subject).ifPresent(profile -> {
+               List<UserGroup> groups = userGroupRepo.findByUserProfileRefWithIgnoreRules(
+                  directoryRealm, profile.createEntityReference());
+               if (groups == null) return;
+               for (UserGroup group : groups) {
+                  if (group != null && group.getRoles() != null
+                        && groupAppliesToApplication(group, applicationId)) {
+                     roles.addAll(group.getRoles());
+                  }
+               }
+            });
+         }
+      } catch (RuntimeException e) {
+         throw new IllegalStateException(
+            "Unable to resolve application-scoped user-group roles for subject '"
+               + subject + "' in realm '" + operatingRealm + "'", e);
+      }
+      return roles;
+   }
+
+   private boolean groupAppliesToApplication(UserGroup group, String applicationId) {
+      if (applicationId == null || applicationId.isBlank()) return false;
+      String groupApplication = group.getApplicationId();
+      return groupApplication != null
+         && ("*".equals(groupApplication.trim())
+            || groupApplication.trim().equalsIgnoreCase(applicationId.trim()));
    }
 
    private SecurityIdentity buildIdentity (String userId, Set<String> roles) {

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtilsTenantClaimsTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtilsTenantClaimsTest.java
@@ -73,4 +73,21 @@ class TokenUtilsTenantClaimsTest {
         assertFalse(claims.contains("\"aud\""), claims);
         assertFalse(claims.contains("\"azp\""), claims);
     }
+
+    @Test
+    void applicationScopedTokenCarriesAudienceAndActiveApplication() throws Exception {
+        TokenUtils.configure("privateKey.pem", "publicKey.pem");
+
+        String jwt = TokenUtils.generateUserToken(
+                "michael-subject", "michael", Set.of("scheduler-user"),
+                "acme-com", "acme", "acme-org", "1001",
+                Set.of("scheduler", "reporting"), "scheduler", "acme-.*",
+                TokenUtils.expiresAt(3600), "https://auth.example.com");
+
+        String claims = payloadJson(jwt);
+        assertTrue(claims.contains("\"azp\":\"scheduler\""), claims);
+        assertTrue(claims.contains("\"aud\""), claims);
+        assertTrue(claims.contains("scheduler"), claims);
+        assertTrue(claims.contains("reporting"), claims);
+    }
 }

--- a/quantum-mcp-server/src/test/java/com/e2eq/framework/api/agent/AgentConfigResourceIT.java
+++ b/quantum-mcp-server/src/test/java/com/e2eq/framework/api/agent/AgentConfigResourceIT.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.*;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AgentConfigResourceIT {
 
-    private static final String REALM = "defaultRealm";
+    private static final String REALM = "test-agent-config-realm";
     private static final String REF_NAME = "test-supply-chain-agent";
 
     @Test

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolver.java
@@ -119,9 +119,12 @@ public final class ApplicationAuthorizationResolver {
 
         if (wildcard) {
             // "*" = valid for any application: mint the wildcard audience instead of
-            // demanding a selection this layer cannot enumerate. azp = the app
-            // actively entered, when one was named or defaulted.
-            return Result.resolved(wildcardAudience(), requested != null ? requested : defaultApp, true);
+            // narrowing the audience, but application-scoped policy still requires
+            // an active application (azp). Without a request/default, require selection.
+            String active = requested != null ? requested : defaultApp;
+            return active == null
+                    ? Result.ambiguous(new ArrayList<>(concrete), true)
+                    : Result.resolved(wildcardAudience(), active, true);
         }
 
         if (requested != null) {
@@ -157,8 +160,12 @@ public final class ApplicationAuthorizationResolver {
 
         if (WILDCARD.equals(expression)) {
             // Same "*" semantics as a wildcard grant entry: the token is valid for
-            // any application, carried as the literal "*" audience.
-            return Result.resolved(wildcardAudience(), requested != null ? requested : defaultApp, true);
+            // any application, but a concrete active application remains mandatory
+            // so authorization can select the correct vocabulary and policies.
+            String active = requested != null ? requested : defaultApp;
+            return active == null
+                    ? Result.ambiguous(List.of(), true)
+                    : Result.resolved(wildcardAudience(), active, true);
         }
 
         if (requested != null) {

--- a/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthorizationProvider.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/auth/AuthorizationProvider.java
@@ -1,0 +1,30 @@
+package com.e2eq.framework.model.auth;
+
+import com.e2eq.framework.model.securityrules.EvalMode;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.SecurityCheckResponse;
+
+/**
+ * Optional SPI for authentication providers that also own authorization policy.
+ *
+ * <p>When the configured {@link AuthProvider} implements this interface, data-plane
+ * services delegate policy evaluation to it instead of reading a local policy
+ * repository. Providers that do not implement it retain the framework's embedded
+ * {@code RuleContext}/{@code PolicyRepo} behavior.</p>
+ */
+public interface AuthorizationProvider extends AuthProvider {
+
+    /**
+     * Evaluate the caller's access to a resource through the provider's policy plane.
+     * Implementations must fail closed when the policy service cannot make a decision.
+     */
+    SecurityCheckResponse checkRules(
+            PrincipalContext principalContext,
+            ResourceContext resourceContext,
+            String modelClass,
+            Object resourceInstance,
+            RuleEffect defaultFinalEffect,
+            EvalMode evalMode);
+}

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/FunctionalDomain.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/FunctionalDomain.java
@@ -14,6 +14,9 @@ import java.util.List;
 @EqualsAndHashCode (callSuper = true)
 public class FunctionalDomain extends BaseModel {
 
+   /** Application whose authorization vocabulary contains this domain. */
+   protected String applicationId;
+
    protected String area;
 
    protected List<FunctionalAction> functionalActions;

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/Policy.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/Policy.java
@@ -33,6 +33,10 @@ public class Policy extends FullBaseModel {
       }
    }
 
+   /** Application whose authorization vocabulary this policy targets; {@code *} means every application. */
+   protected String applicationId;
+   /** Operating realm this policy targets; {@code *} means every realm. Policies remain centrally stored. */
+   protected String realmRefName;
    protected @NotNull String principalId;
    protected PrincipalType principalType = PrincipalType.ROLE;
    protected String description;

--- a/quantum-models/src/main/java/com/e2eq/framework/model/security/UserGroup.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/security/UserGroup.java
@@ -22,6 +22,9 @@ import java.util.List;
 @OntologyClass(id = "UserGroup")
 public class UserGroup extends BaseModel {
 
+   /** Application in which the group's roles are effective; {@code *} means every application. */
+   protected String applicationId;
+
    @OntologyProperty(id = "hasMember", ref = "UserProfile", materializeEdge = true)
    protected List<EntityReference> userProfiles;
    protected List<String> roles;

--- a/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/PrincipalContext.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/PrincipalContext.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public final class PrincipalContext {
    @NotNull( message = "defaultRealm must be non null, needs to be the realm that this principal will use by default")
    String defaultRealm;           // The realm that this Principal came from
+   String applicationId;          // The application whose authorization vocabulary/policies apply
    @NotNull( message = "the data domain must be non null, needs to be the org, account, tenant, ds, or owner for this principal")
    DataDomain dataDomain;  // org, account, tenant, ds, owner
 
@@ -101,6 +102,7 @@ public final class PrincipalContext {
    public static class Builder {
 
       String defaultRealm = null;
+      String applicationId = null;
       DataDomain dataDomain = null;
       String userId = null;
       String subjectId = null;
@@ -119,6 +121,10 @@ public final class PrincipalContext {
 
       public Builder withDefaultRealm(String realm) {
          this.defaultRealm = realm;
+         return this;
+      }
+      public Builder withApplicationId(String applicationId) {
+         this.applicationId = applicationId;
          return this;
       }
       public Builder withDataDomain(@Valid @NotNull DataDomain dataDomain) {
@@ -236,6 +242,7 @@ public final class PrincipalContext {
             new PrincipalContext(defaultRealm, dataDomain, userId, roles, scope,
                impersonatedBySubject, impersonatedByUserId, actingOnBehalfOfUserId, actingOnBehalfOfSubject);
          pc.area2RealmOverrides = this.area2RealmOverrides;
+         pc.applicationId = this.applicationId;
          pc.dataDomainPolicy = this.dataDomainPolicy;
          pc.realmOverrideActive = this.realmOverrideActive;
          pc.originalDataDomain = this.originalDataDomain;
@@ -268,6 +275,15 @@ public final class PrincipalContext {
 
    public void setDefaultRealm (String defaultRealm) {
       this.defaultRealm = defaultRealm;
+   }
+
+   @HostAccess.Export
+   public String getApplicationId() {
+      return applicationId;
+   }
+
+   public void setApplicationId(String applicationId) {
+      this.applicationId = applicationId;
    }
 
    @HostAccess.Export
@@ -435,6 +451,7 @@ public final class PrincipalContext {
       PrincipalContext that = (PrincipalContext) o;
 
       if (defaultRealm != null ? !defaultRealm.equals(that.defaultRealm) : that.defaultRealm != null) return false;
+      if (applicationId != null ? !applicationId.equals(that.applicationId) : that.applicationId != null) return false;
       if (dataDomain != null ? !dataDomain.equals(that.dataDomain) : that.dataDomain != null) return false;
       if (userId != null ? !userId.equals(that.userId) : that.userId != null) return false;
       if (impersonatedBySubject != null ? !impersonatedBySubject.equals(that.impersonatedBySubject) : that.impersonatedBySubject != null) return false;
@@ -456,6 +473,7 @@ public final class PrincipalContext {
    @HostAccess.Export
    public int hashCode () {
       int result = defaultRealm != null ? defaultRealm.hashCode() : 0;
+      result = 31 * result + (applicationId != null ? applicationId.hashCode() : 0);
       result = 31 * result + (dataDomain != null ? dataDomain.hashCode() : 0);
       result = 31 * result + (userId != null ? userId.hashCode() : 0);
       result = 31 * result + Arrays.hashCode(roles);
@@ -476,6 +494,7 @@ public final class PrincipalContext {
    public String toString () {
       return "PrincipalContext{" +
                "defaultRealm='" + defaultRealm + '\'' +
+               ", applicationId='" + applicationId + '\'' +
                ", dataDomain=" + dataDomain +
                ", userId='" + userId + '\'' +
                ", roles=" + Arrays.toString(roles) +

--- a/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/ResourceContext.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/ResourceContext.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 @RegisterForReflection
 public class ResourceContext {
   protected @NotNull String realm;              // The realm this resource is in
+  protected String applicationId;               // application-scoped authorization vocabulary
   protected @NotNull  String area;               // the area the resource resides in
   protected @NotNull String functionalDomain;   // the functional domain with in the area
   protected @NotNull String action;             // the action we are trying to take
@@ -39,10 +40,11 @@ public class ResourceContext {
                    @NotNull(message="action can not be null") String action,
                    String resourceId,
                    String ownerId) {
-      this(realm, area, functionalDomain, action, resourceId, ownerId, null, Collections.emptyMap());
+      this(realm, null, area, functionalDomain, action, resourceId, ownerId, null, Collections.emptyMap());
    }
 
    ResourceContext(@NotNull(message="realmId can not be null") String realm,
+                   String applicationId,
                    @NotNull(message="area can not be null") String area,
                    @NotNull(message="functional domain can not be null") String functionalDomain,
                    @NotNull(message="action can not be null") String action,
@@ -57,6 +59,7 @@ public class ResourceContext {
 
 
       this.realm = realm.toLowerCase();
+      this.applicationId = normalize(applicationId);
       this.area = area.toLowerCase();
       this.functionalDomain = functionalDomain.toLowerCase();
       this.action = action.toLowerCase();
@@ -71,6 +74,7 @@ public class ResourceContext {
    public static class Builder {
       String any = "*";
       String realm = any;
+      String applicationId = null;
 
       String area = any;
       String functionalDomain = any;
@@ -82,6 +86,11 @@ public class ResourceContext {
 
       public Builder withRealm(String realm) {
          this.realm = realm.toLowerCase();
+         return this;
+      }
+
+      public Builder withApplicationId(String applicationId) {
+         this.applicationId = applicationId;
          return this;
       }
 
@@ -129,7 +138,7 @@ public class ResourceContext {
       }
 
       public ResourceContext build() {
-         return new ResourceContext( realm, area,
+         return new ResourceContext( realm, applicationId, area,
             functionalDomain, action, resourceId, ownerId, dataDomain, attributes);
       }
    };
@@ -140,6 +149,15 @@ public class ResourceContext {
    }
    public void setRealm (String realm) {
       this.realm = realm.toLowerCase();
+   }
+
+   @HostAccess.Export
+   public String getApplicationId() {
+      return applicationId;
+   }
+
+   public void setApplicationId(String applicationId) {
+      this.applicationId = normalize(applicationId);
    }
 
    @HostAccess.Export
@@ -199,7 +217,14 @@ public class ResourceContext {
    }
 
    public ResourceContext withDataDomain(DataDomain dataDomain) {
-      return new ResourceContext(realm, area, functionalDomain, action, resourceId, ownerId, dataDomain, attributes);
+      return new ResourceContext(realm, applicationId, area, functionalDomain, action, resourceId, ownerId, dataDomain, attributes);
+   }
+
+   private static String normalize(String value) {
+      if (value == null || value.isBlank()) {
+         return null;
+      }
+      return value.trim().toLowerCase();
    }
 
    @HostAccess.Export
@@ -211,6 +236,7 @@ public class ResourceContext {
       ResourceContext that = (ResourceContext) o;
 
       if (realm != null ? !realm.equals(that.realm) : that.realm != null) return false;
+      if (applicationId != null ? !applicationId.equals(that.applicationId) : that.applicationId != null) return false;
 
       if (area != null ? !area.equals(that.area) : that.area != null) return false;
       if (functionalDomain != null ? !functionalDomain.equals(that.functionalDomain) : that.functionalDomain != null)
@@ -223,6 +249,7 @@ public class ResourceContext {
    @Override
    public int hashCode () {
       int result = realm != null ? realm.hashCode() : 0;
+      result = 31 * result + (applicationId != null ? applicationId.hashCode() : 0);
       result = 31 * result + (area != null ? area.hashCode() : 0);
       result = 31 * result + (functionalDomain != null ? functionalDomain.hashCode() : 0);
       result = 31 * result + (action != null ? action.hashCode() : 0);
@@ -234,6 +261,7 @@ public class ResourceContext {
    public String toString () {
       return "ResourceContext{" +
                 "realm='" + realm + '\'' +
+                ", applicationId='" + applicationId + '\'' +
                 ", area='" + area + '\'' +
                 ", functionalDomain='" + functionalDomain + '\'' +
                 ", action='" + action + '\'' +

--- a/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/auth/ApplicationAuthorizationResolverTest.java
@@ -27,13 +27,11 @@ class ApplicationAuthorizationResolverTest {
     }
 
     @Test
-    void credentialWildcardPattern_noRequest_noDefault_mintsWildcardAudience() {
-        // "*" = no application restriction: mint the wildcard audience instead of
-        // demanding a selection from an empty candidate list (this layer cannot
-        // enumerate installed apps). Downstream admission = own id ∈ aud or "*" ∈ aud.
+    void credentialWildcardPattern_noRequest_noDefault_requiresApplicationSelection() {
+        // Wildcard admission does not identify which application's vocabulary applies.
         var r = ApplicationAuthorizationResolver.resolve(null, "*", null, null);
-        assertEquals(ApplicationAuthorizationResolver.Outcome.RESOLVED, r.outcome());
-        assertEquals(Set.of("*"), r.audiences());
+        assertEquals(ApplicationAuthorizationResolver.Outcome.AMBIGUOUS, r.outcome());
+        assertNull(r.audiences());
         assertNull(r.activeApplication());
         assertTrue(r.wildcard());
     }
@@ -139,12 +137,12 @@ class ApplicationAuthorizationResolverTest {
     }
 
     @Test
-    void wildcard_withoutRequest_mintsWildcardAudience_noAzp() {
+    void wildcard_withoutRequest_requiresAzpSelection() {
         var r = ApplicationAuthorizationResolver.resolve(List.of("*"), null, null);
-        assertTrue(r.resolved());
+        assertEquals(ApplicationAuthorizationResolver.Outcome.AMBIGUOUS, r.outcome());
         assertTrue(r.wildcard());
         assertNull(r.activeApplication());
-        assertEquals(List.of("*"), List.copyOf(r.audiences()));
+        assertNull(r.audiences());
     }
 
     @Test

--- a/quantum-models/src/test/java/com/e2eq/framework/model/securityrules/ApplicationScopedSecurityContextTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/securityrules/ApplicationScopedSecurityContextTest.java
@@ -1,0 +1,54 @@
+package com.e2eq.framework.model.securityrules;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ApplicationScopedSecurityContextTest {
+
+    @Test
+    void principalAndResourceCarryApplicationScope() {
+        DataDomain dataDomain = new DataDomain("acme", "1001", "acme", 0, "alice");
+        PrincipalContext principal = new PrincipalContext.Builder()
+                .withDefaultRealm("acme-com")
+                .withApplicationId("scheduler")
+                .withDataDomain(dataDomain)
+                .withUserId("alice")
+                .withRoles(new String[]{"scheduler-user"})
+                .withScope("AUTHENTICATED")
+                .build();
+        ResourceContext resource = new ResourceContext.Builder()
+                .withRealm("acme-com")
+                .withApplicationId("Scheduler")
+                .withArea("workforce")
+                .withFunctionalDomain("shift")
+                .withAction("view")
+                .build();
+
+        assertEquals("scheduler", principal.getApplicationId());
+        assertEquals("scheduler", resource.getApplicationId());
+        assertEquals("scheduler", resource.withDataDomain(dataDomain).getApplicationId());
+    }
+
+    @Test
+    void applicationParticipatesInContextEquality() {
+        DataDomain dataDomain = new DataDomain("acme", "1001", "acme", 0, "alice");
+        PrincipalContext scheduler = principal(dataDomain, "scheduler");
+        PrincipalContext reporting = principal(dataDomain, "reporting");
+
+        assertNotEquals(scheduler, reporting);
+    }
+
+    private static PrincipalContext principal(DataDomain dataDomain, String applicationId) {
+        return new PrincipalContext.Builder()
+                .withDefaultRealm("acme-com")
+                .withApplicationId(applicationId)
+                .withDataDomain(dataDomain)
+                .withUserId("alice")
+                .withRoles(new String[]{"user"})
+                .withScope("AUTHENTICATED")
+                .build();
+    }
+}

--- a/quantum-models/src/test/resources/application.properties
+++ b/quantum-models/src/test/resources/application.properties
@@ -23,10 +23,10 @@ quarkus.mongodb.connection-string=${MONGODB_CONNECTION_STRING:mongodb://localhos
 
 
 # mandatory if you don't specify the name of the database using @MongoEntity
-quarkus.mongodb.database = ${MONGODB_DEFAULT_SCHEMA:system-com}
+quarkus.mongodb.database = ${MONGODB_DEFAULT_SCHEMA:test-quantum-models-shared}
 
 #--- Morphia
-quarkus.morphia.database=system-com
+quarkus.morphia.database=test-quantum-models-shared
 quarkus.morphia.packages=com.e2eq.framework.model.persistent.security,com.e2eq.framework.model.persistent.base,com.e2eq.framework.model.persistent.morphia,com.e2eq.framework.model.persistent.migration.base,com.e2eq.framework.persistent
 quarkus.morphia.create-caps=true
 quarkus.morphia.create-indexes=true
@@ -38,4 +38,3 @@ quarkus.log.console.format=%d{HH:mm:ss} %-5p [%l] (%t) %s%e%n
 #quarkus.log.handler.console."console-handlers".darken=3
 quarkus.log.category."com.e2eq".level=INFO
 quarkus.log.category."com.e2eq.framework.model.security.rules".level=INFO
-

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/FunctionalDomainRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/FunctionalDomainRepo.java
@@ -3,7 +3,11 @@ package com.e2eq.framework.model.persistent.morphia;
 import com.e2eq.framework.model.security.FunctionalDomain;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.List;
+import java.util.Optional;
 
 
 
@@ -11,8 +15,49 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 public class FunctionalDomainRepo extends MorphiaRepo<FunctionalDomain>{
    @ConfigProperty(name = "quantum.realmConfig.defaultRealm")
    String defaultRealm;
+
+   @ConfigProperty(name = "quantum.security.policy-store-realm")
+   Optional<String> policyStoreRealm = Optional.empty();
+
+   @ConfigProperty(name = "quantum.security.policy-admission.enabled", defaultValue = "false")
+   boolean policyAdmissionEnabled;
+
+   @Inject
+   ApplicationRepo applicationRepo;
    @Override
    public String getSecurityContextRealmId() {
-      return defaultRealm;
+      return policyStoreRealm
+         .filter(value -> !value.isBlank())
+         .map(String::trim)
+         .orElse(defaultRealm);
+   }
+
+   @Override
+   protected void setDefaultValues(FunctionalDomain model) {
+      super.setDefaultValues(model);
+      if (!policyAdmissionEnabled) return;
+      if (model.getApplicationId() == null || model.getApplicationId().isBlank()) {
+         throw new IllegalArgumentException("FunctionalDomain.applicationId is required");
+      }
+      if (!"*".equals(model.getApplicationId().trim())
+            && applicationRepo.findByRefNameWithIgnoreRules(model.getApplicationId()).isEmpty()) {
+         throw new IllegalArgumentException(
+            "FunctionalDomain references unknown application: " + model.getApplicationId());
+      }
+   }
+
+   public List<FunctionalDomain> findForApplicationWithIgnoreRules(String applicationId) {
+      if (applicationId == null || applicationId.isBlank()) return List.of();
+      dev.morphia.query.MorphiaCursor<FunctionalDomain> cursor =
+         morphiaDataStoreWrapper.getDataStore(getSecurityContextRealmId())
+         .find(FunctionalDomain.class)
+         .iterator();
+      try (cursor) {
+         return cursor.toList().stream()
+            .filter(domain -> domain.getApplicationId() != null
+               && ("*".equals(domain.getApplicationId().trim())
+                  || domain.getApplicationId().trim().equalsIgnoreCase(applicationId.trim())))
+            .toList();
+      }
    }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolver.java
@@ -79,6 +79,14 @@ public class IdentityRoleResolver {
                                           CredentialUserIdPassword credential,
                                           String authorityRealm,
                                           String effectiveRealm) {
+        return resolveEffectiveRoles(identity, credential, authorityRealm, effectiveRealm, null);
+    }
+
+    public String[] resolveEffectiveRoles(SecurityIdentity identity,
+                                          CredentialUserIdPassword credential,
+                                          String authorityRealm,
+                                          String effectiveRealm,
+                                          String applicationId) {
         String targetRealm = requireRealm(effectiveRealm);
         LinkedHashMap<String, EnumSet<RoleSource>> provenance = new LinkedHashMap<>();
         if (identity != null) {
@@ -94,9 +102,9 @@ public class IdentityRoleResolver {
                                 credential.getUserId(), targetRealm, envConfigUtils.getSystemRealm())
                         .ifPresent(assignment -> addRoles(provenance, assignment.getRoles(), RoleSource.REALM));
 
-                addUserGroupRoles(provenance, credential, envConfigUtils.getSystemRealm());
+                addUserGroupRoles(provenance, credential, envConfigUtils.getSystemRealm(), applicationId);
                 if (!sameRealm(targetRealm, envConfigUtils.getSystemRealm())) {
-                    addUserGroupRoles(provenance, credential, targetRealm);
+                    addUserGroupRoles(provenance, credential, targetRealm, applicationId);
                 }
             } catch (RuntimeException e) {
                 throw new IllegalStateException(String.format(
@@ -134,6 +142,13 @@ public class IdentityRoleResolver {
      * only as a compatibility fallback for embedded auth mode.
      */
     public Map<String, EnumSet<RoleSource>> resolveRoleSources(String identity, String realm, SecurityIdentity securityIdentity) {
+        return resolveRoleSources(identity, realm, null, securityIdentity);
+    }
+
+    public Map<String, EnumSet<RoleSource>> resolveRoleSources(String identity,
+                                                               String realm,
+                                                               String applicationId,
+                                                               SecurityIdentity securityIdentity) {
         LinkedHashMap<String, EnumSet<RoleSource>> out = new LinkedHashMap<>();
         String targetRealm = requireRealm(realm);
         String systemRealm = envConfigUtils.getSystemRealm();
@@ -154,9 +169,9 @@ public class IdentityRoleResolver {
                             cred.getUserId(), targetRealm, systemRealm)
                     .ifPresent(assignment -> addRoles(out, assignment.getRoles(), RoleSource.REALM));
 
-            addUserGroupRoles(out, cred, systemRealm);
+            addUserGroupRoles(out, cred, systemRealm, applicationId);
             if (!sameRealm(targetRealm, systemRealm)) {
-                addUserGroupRoles(out, cred, targetRealm);
+                addUserGroupRoles(out, cred, targetRealm, applicationId);
             }
         }
         return out;
@@ -164,7 +179,8 @@ public class IdentityRoleResolver {
 
     private void addUserGroupRoles(Map<String, EnumSet<RoleSource>> target,
                                    CredentialUserIdPassword credential,
-                                   String groupRealm) {
+                                   String groupRealm,
+                                   String applicationId) {
         if (credential == null || credential.getSubject() == null || groupRealm == null || groupRealm.isBlank()) {
             return;
         }
@@ -178,10 +194,20 @@ public class IdentityRoleResolver {
             return;
         }
         for (UserGroup group : groups) {
-            if (group != null) {
+            if (group != null && groupAppliesToApplication(group, applicationId)) {
                 addRoles(target, group.getRoles(), RoleSource.USERGROUP);
             }
         }
+    }
+
+    static boolean groupAppliesToApplication(UserGroup group, String applicationId) {
+        String groupApplication = group.getApplicationId();
+        if (applicationId == null || applicationId.isBlank()) {
+            return true;
+        }
+        return groupApplication != null
+                && ("*".equals(groupApplication.trim())
+                    || groupApplication.trim().equalsIgnoreCase(applicationId.trim()));
     }
 
     private String credentialHomeRealm(CredentialUserIdPassword credential) {
@@ -257,6 +283,19 @@ public class IdentityRoleResolver {
         }
         java.util.List<RoleAssignment> assignments = toAssignments(provenance);
         return new RoleResolutionResult(roles, assignments);
+    }
+
+    public RoleResolutionResult buildRoleResolution(String identity,
+                                                     String realm,
+                                                     String applicationId,
+                                                     SecurityIdentity securityIdentity) {
+        Map<String, EnumSet<RoleSource>> provenance = resolveRoleSources(
+                identity, realm, applicationId, securityIdentity);
+        java.util.LinkedHashSet<String> roles = new java.util.LinkedHashSet<>();
+        for (String role : provenance.keySet()) {
+            if (role != null && !role.isBlank()) roles.add(role);
+        }
+        return new RoleResolutionResult(roles, toAssignments(provenance));
     }
 
     /** Utility to convert provenance map to role assignments list. */

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/MorphiaRepo.java
@@ -805,6 +805,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
                             "Governed aggregation requires a ResourceContext"));
             ResourceContext targetContext = new ResourceContext.Builder()
                     .withRealm(current.getRealm())
+                    .withApplicationId(current.getApplicationId())
                     .withArea(mapping.area())
                     .withFunctionalDomain(mapping.domain())
                     .withAction(current.getAction())
@@ -2119,6 +2120,7 @@ public  abstract class MorphiaRepo<T extends UnversionedBaseModel> implements Ba
                 String actionString = action.getLabel().toUpperCase().replace(" ", "_");
 
                 ResourceContext rcontext = new ResourceContext.Builder()
+                        .withApplicationId(pcontext.getApplicationId())
                         .withFunctionalDomain(domain)
                         .withArea(area)
                         .withAction(actionString)

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/PolicyRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/PolicyRepo.java
@@ -6,17 +6,104 @@ import com.e2eq.framework.model.securityrules.SecurityURIHeader;
 
 import dev.morphia.query.filters.Filters;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class PolicyRepo extends MorphiaRepo<Policy> {
+   @ConfigProperty(name = "quantum.security.policy-store-realm")
+   Optional<String> policyStoreRealm = Optional.empty();
+
+   @ConfigProperty(name = "quantum.security.policy-admission.enabled", defaultValue = "false")
+   boolean policyAdmissionEnabled;
+
+   @Inject
+   ApplicationRepo applicationRepo;
+
+   @Inject
+   FunctionalDomainRepo functionalDomainRepo;
+
+   @Override
+   public String getSecurityContextRealmId() {
+      return policyStoreRealm
+         .filter(value -> !value.isBlank())
+         .map(String::trim)
+         .orElseGet(super::getSecurityContextRealmId);
+   }
+
+   @Override
+   protected void setDefaultValues(Policy policy) {
+      super.setDefaultValues(policy);
+      if (policyAdmissionEnabled) validatePolicyScopeAndVocabulary(policy);
+   }
+
+   private void validatePolicyScopeAndVocabulary(Policy policy) {
+      String applicationId = required(policy.getApplicationId(), "Policy.applicationId is required");
+      required(policy.getRealmRefName(), "Policy.realmRefName is required (use * for every realm)");
+      if (!"*".equals(applicationId)
+            && applicationRepo.findByRefNameWithIgnoreRules(applicationId).isEmpty()) {
+         throw new IllegalArgumentException("Policy references unknown application: " + applicationId);
+      }
+      if ("*".equals(applicationId)) return;
+
+      Map<String, Set<String>> vocabulary = new HashMap<>();
+      for (var domain : functionalDomainRepo.findForApplicationWithIgnoreRules(applicationId)) {
+         if (domain.getArea() == null || domain.getRefName() == null) continue;
+         String key = axis(domain.getArea()) + "/" + axis(domain.getRefName());
+         Set<String> actions = vocabulary.computeIfAbsent(key, ignored -> new java.util.HashSet<>());
+         if (domain.getFunctionalActions() != null) {
+            for (var action : domain.getFunctionalActions()) {
+               if (action != null && action.getRefName() != null) actions.add(axis(action.getRefName()));
+            }
+         }
+      }
+      if (vocabulary.isEmpty()) {
+         throw new IllegalArgumentException(
+            "No functional-domain vocabulary is registered for application: " + applicationId);
+      }
+      if (policy.getRules() == null) return;
+      for (Rule rule : policy.getRules()) {
+         if (rule == null || rule.getSecurityURI() == null || rule.getSecurityURI().getHeader() == null) {
+            throw new IllegalArgumentException("Every policy rule must declare a SecurityURI header");
+         }
+         SecurityURIHeader header = rule.getSecurityURI().getHeader();
+         if (wildcard(header.getArea()) || wildcard(header.getFunctionalDomain())) continue;
+         String key = axis(header.getArea()) + "/" + axis(header.getFunctionalDomain());
+         Set<String> actions = vocabulary.get(key);
+         if (actions == null) {
+            throw new IllegalArgumentException(
+               "Policy rule '" + rule.getName() + "' references unknown functional area/domain: " + key);
+         }
+         if (!wildcard(header.getAction()) && !actions.contains(axis(header.getAction()))) {
+            throw new IllegalArgumentException(
+               "Policy rule '" + rule.getName() + "' references unknown action '"
+                  + header.getAction() + "' for " + key);
+         }
+      }
+   }
+
+   private static String required(String value, String message) {
+      if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+      return value.trim();
+   }
+
+   private static String axis(String value) {
+      return value.trim().toLowerCase(Locale.ROOT);
+   }
+
+   private static boolean wildcard(String value) {
+      return value == null || value.isBlank() || "*".equals(value.trim());
+   }
+
    /**
     * Returns all policies in the given realm bypassing permission filters and SecurityIdentity.
     * Intended for internal hydration of RuleContext.
@@ -27,6 +114,20 @@ public class PolicyRepo extends MorphiaRepo<Policy> {
       try (cursor) {
          return cursor.toList();
       }
+   }
+
+   /**
+    * Reads centrally stored policies for one application/operating-realm scope.
+    * The datastore realm identifies where policy is stored; {@code targetRealm}
+    * identifies the tenant realm to which a policy applies.
+    */
+   public List<Policy> getAllListIgnoreRules(String datastoreRealm,
+                                             String applicationId,
+                                             String targetRealm,
+                                             boolean includeLegacyUnscoped) {
+      return getAllListIgnoreRules(datastoreRealm).stream()
+         .filter(policy -> matchesScope(policy, applicationId, targetRealm, includeLegacyUnscoped))
+         .toList();
    }
 
    /**
@@ -53,6 +154,16 @@ public class PolicyRepo extends MorphiaRepo<Policy> {
       try (cursor) {
          return cursor.toList();
       }
+   }
+
+   public List<Policy> getPoliciesForIdentities(String datastoreRealm,
+                                                 Collection<String> identities,
+                                                 String applicationId,
+                                                 String targetRealm,
+                                                 boolean includeLegacyUnscoped) {
+      return getPoliciesForIdentities(datastoreRealm, identities).stream()
+         .filter(policy -> matchesScope(policy, applicationId, targetRealm, includeLegacyUnscoped))
+         .toList();
    }
 
    /**
@@ -116,6 +227,27 @@ public class PolicyRepo extends MorphiaRepo<Policy> {
       return rules;
    }
 
+   public Map<String, List<Rule>> getEffectiveRulesForIdentities(
+         String datastoreRealm,
+         List<Policy> defaultSystemPolicies,
+         Collection<String> identities,
+         String applicationId,
+         String targetRealm,
+         boolean includeLegacyUnscoped) {
+
+      List<Policy> scopedDefaults = defaultSystemPolicies == null
+         ? List.of()
+         : defaultSystemPolicies.stream()
+            .filter(policy -> matchesScope(policy, applicationId, targetRealm, includeLegacyUnscoped))
+            .toList();
+      Map<String, List<Rule>> rules = effectiveRulesFromPolicies(scopedDefaults, identities, false);
+      List<Policy> databasePolicies = getPoliciesForIdentities(
+         datastoreRealm, identities, applicationId, targetRealm, includeLegacyUnscoped);
+      mergePolicies(rules, databasePolicies, identities, true);
+      sortRules(rules);
+      return rules;
+   }
+
    /**
     * Returns effective policies: default system policies merged with database policies.
     * Database policies are always fetched fresh from the collection.
@@ -161,6 +293,78 @@ public class PolicyRepo extends MorphiaRepo<Policy> {
       }
       
       return rules;
+   }
+
+   public Map<String, List<Rule>> getEffectiveRules(String datastoreRealm,
+                                                     List<Policy> defaultSystemPolicies,
+                                                     String applicationId,
+                                                     String targetRealm,
+                                                     boolean includeLegacyUnscoped) {
+      Map<String, List<Rule>> rules = new HashMap<>();
+      mergePolicies(rules,
+         defaultSystemPolicies == null ? List.of() : defaultSystemPolicies.stream()
+            .filter(policy -> matchesScope(policy, applicationId, targetRealm, includeLegacyUnscoped))
+            .toList(),
+         null,
+         false);
+      mergePolicies(rules,
+         getAllListIgnoreRules(datastoreRealm, applicationId, targetRealm, includeLegacyUnscoped),
+         null,
+         true);
+      sortRules(rules);
+      return rules;
+   }
+
+   private Map<String, List<Rule>> effectiveRulesFromPolicies(List<Policy> policies,
+                                                               Collection<String> identities,
+                                                               boolean databasePolicy) {
+      Map<String, List<Rule>> rules = new HashMap<>();
+      mergePolicies(rules, policies, identities, databasePolicy);
+      return rules;
+   }
+
+   private void mergePolicies(Map<String, List<Rule>> rules,
+                              Collection<Policy> policies,
+                              Collection<String> identities,
+                              boolean databasePolicy) {
+      if (policies == null) return;
+      Set<String> identitySet = identities == null ? null : identities.stream()
+         .filter(identity -> identity != null && !identity.isBlank())
+         .map(identity -> identity.toLowerCase(Locale.ROOT))
+         .collect(Collectors.toSet());
+      for (Policy policy : policies) {
+         if (policy == null || policy.getRules() == null) continue;
+         if (databasePolicy) policy.setPolicySource("POLICY_COLLECTION");
+         for (Rule rule : policy.getRules()) {
+            String identity = extractIdentity(rule, policy);
+            if (identity == null || identity.isBlank()) continue;
+            if (identitySet != null && !identitySet.contains(identity)) continue;
+            rules.computeIfAbsent(identity, ignored -> new ArrayList<>()).add(rule);
+         }
+      }
+   }
+
+   private void sortRules(Map<String, List<Rule>> rules) {
+      for (List<Rule> list : rules.values()) {
+         if (list != null && list.size() > 1) {
+            list.sort((left, right) -> Integer.compare(left.getPriority(), right.getPriority()));
+         }
+      }
+   }
+
+   boolean matchesScope(Policy policy,
+                                String applicationId,
+                                String targetRealm,
+                                boolean includeLegacyUnscoped) {
+      return policy != null
+         && matchesValue(policy.getApplicationId(), applicationId, includeLegacyUnscoped)
+         && matchesValue(policy.getRealmRefName(), targetRealm, includeLegacyUnscoped);
+   }
+
+   private boolean matchesValue(String policyValue, String requestedValue, boolean includeLegacyUnscoped) {
+      if (policyValue == null || policyValue.isBlank()) return includeLegacyUnscoped;
+      if ("*".equals(policyValue.trim())) return true;
+      return requestedValue != null && policyValue.trim().equalsIgnoreCase(requestedValue.trim());
    }
    
    private String extractIdentity(Rule r, Policy p) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RepoSecurityContextResolver.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/RepoSecurityContextResolver.java
@@ -118,6 +118,7 @@ final class RepoSecurityContextResolver {
 
         PrincipalContext rebuiltContext = new PrincipalContext.Builder()
                 .withDefaultRealm(contextRealm)
+                .withApplicationId(identityAttribute("azp"))
                 .withDataDomain(dataDomain)
                 .withUserId(userId)
                 .withRoles(roles)
@@ -135,6 +136,14 @@ final class RepoSecurityContextResolver {
             Log.debugf("[MorphiaRepo] Principal Context %s from SecurityIdentity for user %s, roles=%s",
                     principalContext.isEmpty() ? "built" : "rebuilt", userId, Arrays.toString(roles));
         }
+    }
+
+    private String identityAttribute(String name) {
+        if (securityIdentity == null) return null;
+        Object value = securityIdentity.getAttribute(name);
+        if (value == null) return null;
+        String text = String.valueOf(value).trim();
+        return text.isEmpty() ? null : text;
     }
 
     String getSecurityContextRealmId() {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserGroupRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserGroupRepo.java
@@ -9,12 +9,37 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @ApplicationScoped
 public class UserGroupRepo extends MorphiaRepo<UserGroup> {
+   @ConfigProperty(name = "quantum.security.identity-store-realm")
+   Optional<String> identityStoreRealm = Optional.empty();
+
+   @ConfigProperty(name = "quantum.security.group-scope.require-application", defaultValue = "false")
+   boolean requireApplicationScope;
+
+   @Override
+   public String getSecurityContextRealmId() {
+      return identityStoreRealm
+         .filter(value -> !value.isBlank())
+         .map(String::trim)
+         .orElseGet(super::getSecurityContextRealmId);
+   }
+
+   @Override
+   protected void setDefaultValues(UserGroup model) {
+      super.setDefaultValues(model);
+      if (requireApplicationScope
+            && (model.getApplicationId() == null || model.getApplicationId().isBlank())) {
+         throw new IllegalArgumentException("UserGroup.applicationId is required");
+      }
+   }
+
    // given a UserProfileEntityReference find all the userGroups associated with it
    public List<UserGroup> findByUserProfileRef(@Valid @NotNull EntityReference userProfileRef) {
       // query userGroups.userProfiles.entityRefName == userProfileRef.entityRefName
@@ -46,7 +71,11 @@ public class UserGroupRepo extends MorphiaRepo<UserGroup> {
       Query<UserGroup> query = ds.find(getPersistentClass())
           .filter(Filters.eq("userProfiles.entityRefName", userProfileRef.getEntityRefName()));
 
-      List<UserGroup> userGroups = query.iterator().toList();
+      List<UserGroup> userGroups;
+      dev.morphia.query.MorphiaCursor<UserGroup> cursor = query.iterator();
+      try (cursor) {
+         userGroups = cursor.toList();
+      }
 
       if (userGroups.isEmpty()) {
          Log.warnf("No userGroups found for userProfileRef:\"%s\" in realm:%s (ignoreRules=true)", userProfileRef.getEntityRefName(), realm);

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContext.java
@@ -3,6 +3,9 @@ package com.e2eq.framework.security.runtime;
 import com.e2eq.framework.model.persistent.base.UnversionedBaseModel;
 import com.e2eq.framework.model.persistent.morphia.MorphiaUtils;
 import com.e2eq.framework.model.persistent.morphia.PolicyRepo;
+import com.e2eq.framework.model.auth.AuthProvider;
+import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.auth.AuthorizationProvider;
 import com.e2eq.framework.model.security.Policy;
 import com.e2eq.framework.model.security.Rule;
 import com.e2eq.framework.model.securityrules.*;
@@ -83,6 +86,9 @@ public class RuleContext {
      @Inject
      PolicyRepo policyRepo;
 
+     @Inject
+     AuthProviderFactory authProviderFactory;
+
     /**
      * This holds ONLY the default system rules, indexed by identity.
      * Using ConcurrentHashMap for thread-safe access during concurrent requests.
@@ -128,6 +134,17 @@ public class RuleContext {
     @ConfigProperty(name = "quantum.realmConfig.defaultRealm", defaultValue = "system-com")
     protected String defaultRealm;
 
+    /**
+     * Optional central datastore realm for policy documents. When blank, embedded
+     * mode retains the historical behavior of reading policy from the request realm.
+     */
+    @ConfigProperty(name = "quantum.security.policy-store-realm")
+    Optional<String> policyStoreRealm = Optional.empty();
+
+    /** Fail closed when application-scoped policy evaluation has no application id. */
+    @ConfigProperty(name = "quantum.security.policy-scope.require-application", defaultValue = "false")
+    boolean requireApplicationScope;
+
     // Scripting controls (sandbox & timeout)
     @ConfigProperty(name = "quantum.security.scripting.enabled", defaultValue = "true")
     boolean scriptingEnabled;
@@ -166,6 +183,39 @@ public class RuleContext {
         return RuleContextRequestCache.buildPermissionCacheKey(pctx, rctx, defaultEffect)
                 + "|" + policyVersion
                 + "|" + getEvalModeForThread().name();
+    }
+
+    private String resolveApplicationId(PrincipalContext principalContext, ResourceContext resourceContext) {
+        String principalApplication = normalizeScope(principalContext == null ? null : principalContext.getApplicationId());
+        String resourceApplication = normalizeScope(resourceContext == null ? null : resourceContext.getApplicationId());
+        if (principalApplication != null && resourceApplication != null
+                && !principalApplication.equals(resourceApplication)) {
+            throw new IllegalArgumentException(
+                    "Principal and resource application scopes do not match: "
+                            + principalApplication + " != " + resourceApplication);
+        }
+        String applicationId = resourceApplication != null ? resourceApplication : principalApplication;
+        if (requireApplicationScope && applicationId == null) {
+            throw new IllegalStateException("Application-scoped authorization requires an applicationId");
+        }
+        return applicationId;
+    }
+
+    private String policyDatastoreRealm(String requestRealm) {
+        return policyStoreRealm
+                .filter(value -> !value.isBlank())
+                .map(String::trim)
+                .orElse(requestRealm);
+    }
+
+    private String policyScopeKey(String requestRealm, String applicationId) {
+        return policyDatastoreRealm(requestRealm) + "|"
+                + (applicationId == null ? "<legacy>" : applicationId) + "|"
+                + requestRealm;
+    }
+
+    private static String normalizeScope(String value) {
+        return value == null || value.isBlank() ? null : value.trim().toLowerCase(java.util.Locale.ROOT);
     }
 
 
@@ -618,6 +668,8 @@ public class RuleContext {
             policy.setRefName("system-default-" + identity);
             policy.setDisplayName("System Default: " + identity);
             policy.setDescription("Default system rules for " + identity);
+            policy.setApplicationId("*");
+            policy.setRealmRefName("*");
             policy.setPrincipalType("system".equals(identity) ?
                 com.e2eq.framework.model.security.Policy.PrincipalType.USER :
                 com.e2eq.framework.model.security.Policy.PrincipalType.ROLE);
@@ -793,14 +845,17 @@ public class RuleContext {
      */
     public void clearCacheForRealm(String realm) {
         if (realm != null) {
-            compiledIndexes.remove(realm);
-            cachedEffectiveRules.remove(realm);
-            realmBuildLocks.remove(realm);
+            java.util.function.Predicate<String> matchesRealm = key -> key.equals(realm)
+                    || key.startsWith(realm + "|")
+                    || key.endsWith("|" + realm);
+            compiledIndexes.keySet().removeIf(matchesRealm);
+            cachedEffectiveRules.keySet().removeIf(matchesRealm);
+            realmBuildLocks.keySet().removeIf(matchesRealm);
             synchronized (evictionLock) {
-                realmAccessOrder.remove(realm);
+                realmAccessOrder.keySet().removeIf(matchesRealm);
             }
             // Also clear legacy single-index if it matches
-            if (realm.equals(compiledIndexRealm)) {
+            if (compiledIndexRealm != null && matchesRealm.test(compiledIndexRealm)) {
                 compiledIndex = null;
                 compiledIndexRealm = null;
             }
@@ -883,6 +938,10 @@ public class RuleContext {
      * @return the built RuleIndex, or null if building failed
      */
     public RuleIndex rebuildIndex(@NotNull String realm) {
+        return rebuildIndex(realm, null);
+    }
+
+    private RuleIndex rebuildIndex(String realm, String applicationId) {
         if (!indexEnabled) {
             Log.debug("RuleContext: index rebuild skipped - indexEnabled is false");
             return null;
@@ -890,11 +949,12 @@ public class RuleContext {
 
         // Get or create a lock object for this specific realm
         // This allows different realms to build indexes concurrently
-        Object realmLock = realmBuildLocks.computeIfAbsent(realm, k -> new Object());
+        String scopeKey = policyScopeKey(realm, applicationId);
+        Object realmLock = realmBuildLocks.computeIfAbsent(scopeKey, k -> new Object());
 
         synchronized (realmLock) {
             // Double-check: another thread may have built the index while we were waiting
-            RuleIndex existingIndex = compiledIndexes.get(realm);
+            RuleIndex existingIndex = compiledIndexes.get(scopeKey);
             if (existingIndex != null) {
                 Log.debugf("RuleContext: index for realm %s was built by another thread", realm);
                 return existingIndex;
@@ -905,7 +965,8 @@ public class RuleContext {
                 Map<String, List<Rule>> effectiveRules;
                 if (policyRepo != null) {
                     List<Policy> defaults = getDefaultSystemPolicies();
-                    effectiveRules = policyRepo.getEffectiveRules(realm, defaults);
+                    effectiveRules = policyRepo.getEffectiveRules(
+                            policyDatastoreRealm(realm), defaults, applicationId, realm, !requireApplicationScope);
                 } else {
                     effectiveRules = new HashMap<>(defaultSystemRules);
                 }
@@ -922,19 +983,19 @@ public class RuleContext {
                 RuleIndex newIndex = RuleIndex.build(allRules);
 
                 // Store in per-realm cache (atomic put)
-                compiledIndexes.put(realm, newIndex);
+                compiledIndexes.put(scopeKey, newIndex);
 
                 // Update LRU tracking and handle eviction
                 synchronized (evictionLock) {
                     // LinkedHashMap with accessOrder=true automatically moves accessed entries to end
-                    realmAccessOrder.put(realm, Boolean.TRUE);
+                    realmAccessOrder.put(scopeKey, Boolean.TRUE);
 
                     // Evict oldest entries if we exceed maxRealms
                     if (realmAccessOrder.size() > indexMaxRealms) {
                         Iterator<String> it = realmAccessOrder.keySet().iterator();
                         while (it.hasNext() && realmAccessOrder.size() > indexMaxRealms) {
                             String oldestRealm = it.next();
-                            if (!oldestRealm.equals(realm)) {
+                            if (!oldestRealm.equals(scopeKey)) {
                                 it.remove();
                                 compiledIndexes.remove(oldestRealm);
                                 realmBuildLocks.remove(oldestRealm);
@@ -946,16 +1007,16 @@ public class RuleContext {
 
                 // Update legacy single-index fields for backward compatibility
                 compiledIndex = newIndex;
-                compiledIndexRealm = realm;
+                compiledIndexRealm = scopeKey;
 
                 Log.infof("RuleContext: rebuilt compiled index with %d rules for realm %s (cached realms: %d)",
                     allRules.size(), realm, compiledIndexes.size());
                 return newIndex;
             } catch (Exception e) {
                 Log.warnf(e, "RuleContext: failed to rebuild index for realm %s; index will remain null", realm);
-                compiledIndexes.remove(realm);
+                compiledIndexes.remove(scopeKey);
                 synchronized (evictionLock) {
-                    realmAccessOrder.remove(realm);
+                    realmAccessOrder.remove(scopeKey);
                 }
                 compiledIndex = null;
                 compiledIndexRealm = null;
@@ -1077,22 +1138,24 @@ public class RuleContext {
         String requestRealm = pcontext != null && pcontext.getDefaultRealm() != null
             ? pcontext.getDefaultRealm()
             : defaultRealm;
+        String applicationId = resolveApplicationId(pcontext, rcontext);
+        String scopeKey = policyScopeKey(requestRealm, applicationId);
 
         // If the compiled index is enabled, try to use per-realm cached index
         if (indexEnabled) {
             // Check per-realm cache first (atomic get from ConcurrentHashMap)
-            RuleIndex realmIndex = compiledIndexes.get(requestRealm);
+            RuleIndex realmIndex = compiledIndexes.get(scopeKey);
 
             if (realmIndex == null) {
                 // No cached index for this realm - rebuild it
                 // rebuildIndex handles its own locking per-realm
                 Log.debugf("RuleContext: no cached index for realm=%s, building...", requestRealm);
-                realmIndex = rebuildIndex(requestRealm);
+                realmIndex = rebuildIndex(requestRealm, applicationId);
             } else {
                 // Update LRU tracking for cache hit (lightweight operation)
                 synchronized (evictionLock) {
                     // LinkedHashMap with accessOrder=true moves entry to end on access
-                    realmAccessOrder.get(requestRealm);
+                    realmAccessOrder.get(scopeKey);
                 }
             }
 
@@ -1107,7 +1170,7 @@ public class RuleContext {
         }
 
         // Legacy/fallback behavior: get fresh effective rules and gather by identity/roles
-        Map<String, List<Rule>> effectiveRules = getEffectiveRulesForRequest(pcontext);
+        Map<String, List<Rule>> effectiveRules = getEffectiveRulesForRequest(pcontext, rcontext);
 
         // Legacy behavior: gather rules by identity and roles, then sort by priority
         List<Rule> applicableRules = new ArrayList<Rule>();
@@ -1182,7 +1245,7 @@ public class RuleContext {
      *
      * Thread-safe: Uses per-realm locking for cache building.
      */
-    private Map<String, List<Rule>> getEffectiveRulesForRequest(PrincipalContext pcontext) {
+    private Map<String, List<Rule>> getEffectiveRulesForRequest(PrincipalContext pcontext, ResourceContext rcontext) {
         // In test contexts without CDI, fall back to in-memory rules only
         if (policyRepo == null) {
             return new HashMap<>(defaultSystemRules);
@@ -1191,6 +1254,8 @@ public class RuleContext {
         String realm = pcontext != null && pcontext.getDefaultRealm() != null
             ? pcontext.getDefaultRealm()
             : defaultRealm;
+        String applicationId = resolveApplicationId(pcontext, rcontext);
+        String scopeKey = policyScopeKey(realm, applicationId);
 
         // If realm caching is disabled, fetch only rules matching this user's identities
         if (!realmCacheEnabled) {
@@ -1202,7 +1267,9 @@ public class RuleContext {
                     pcontext != null ? java.util.Arrays.toString(pcontext.getRoles()) : "null",
                     identities, realm);
             }
-            Map<String, List<Rule>> result = policyRepo.getEffectiveRulesForIdentities(realm, defaults, identities);
+            Map<String, List<Rule>> result = policyRepo.getEffectiveRulesForIdentities(
+                    policyDatastoreRealm(realm), defaults, identities,
+                    applicationId, realm, !requireApplicationScope);
             if (Log.isDebugEnabled()) {
                 Log.debugf("RuleContext: getEffectiveRulesForIdentities returned %d identity->rules mappings: %s",
                     result.size(), result.keySet());
@@ -1211,42 +1278,43 @@ public class RuleContext {
         }
 
         // Check cache first
-        Map<String, List<Rule>> cached = cachedEffectiveRules.get(realm);
+        Map<String, List<Rule>> cached = cachedEffectiveRules.get(scopeKey);
         if (cached != null) {
             // Update LRU tracking for cache hit
             synchronized (evictionLock) {
-                realmAccessOrder.get(realm);
+                realmAccessOrder.get(scopeKey);
             }
             return cached;
         }
 
         // Cache miss - need to build. Use per-realm lock to prevent duplicate work
-        Object realmLock = realmBuildLocks.computeIfAbsent(realm, k -> new Object());
+        Object realmLock = realmBuildLocks.computeIfAbsent(scopeKey, k -> new Object());
 
         synchronized (realmLock) {
             // Double-check after acquiring lock
-            cached = cachedEffectiveRules.get(realm);
+            cached = cachedEffectiveRules.get(scopeKey);
             if (cached != null) {
                 return cached;
             }
 
             // Fetch from database
             List<Policy> defaults = getDefaultSystemPolicies();
-            Map<String, List<Rule>> effectiveRules = policyRepo.getEffectiveRules(realm, defaults);
+            Map<String, List<Rule>> effectiveRules = policyRepo.getEffectiveRules(
+                    policyDatastoreRealm(realm), defaults, applicationId, realm, !requireApplicationScope);
 
             // Store in cache
-            cachedEffectiveRules.put(realm, effectiveRules);
+            cachedEffectiveRules.put(scopeKey, effectiveRules);
 
             // Update LRU tracking and handle eviction
             synchronized (evictionLock) {
-                realmAccessOrder.put(realm, Boolean.TRUE);
+                realmAccessOrder.put(scopeKey, Boolean.TRUE);
 
                 // Evict oldest entries if we exceed maxRealms
                 if (realmAccessOrder.size() > indexMaxRealms) {
                     Iterator<String> it = realmAccessOrder.keySet().iterator();
                     while (it.hasNext() && realmAccessOrder.size() > indexMaxRealms) {
                         String oldestRealm = it.next();
-                        if (!oldestRealm.equals(realm)) {
+                        if (!oldestRealm.equals(scopeKey)) {
                             it.remove();
                             cachedEffectiveRules.remove(oldestRealm);
                             compiledIndexes.remove(oldestRealm);
@@ -1298,6 +1366,24 @@ public class RuleContext {
             Class<? extends UnversionedBaseModel> modelClass,
             Object resourceInstance,
             @NotNull RuleEffect defaultFinalEffect) {
+
+        AuthProvider selectedProvider = authProviderFactory == null
+                ? null
+                : authProviderFactory.getAuthProvider();
+        if (selectedProvider instanceof AuthorizationProvider authorizationProvider) {
+            SecurityCheckResponse delegated = authorizationProvider.checkRules(
+                    pcontext,
+                    rcontext,
+                    modelClass == null ? null : modelClass.getName(),
+                    resourceInstance,
+                    defaultFinalEffect,
+                    getEvalModeForThread());
+            if (delegated == null) {
+                throw new IllegalStateException(
+                        "Authorization provider returned no decision: " + selectedProvider.getName());
+            }
+            return delegated;
+        }
 
         // Request-scope memoization: return cached result if enabled and present
         if (requestCacheEnabled && !shouldSkipRequestCache()) {

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContextRequestCache.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/securityrules/RuleContextRequestCache.java
@@ -58,12 +58,15 @@ final class RuleContextRequestCache {
             RuleEffect defaultEffect) {
         String user = String.valueOf(pctx != null ? pctx.getUserId() : "<anon>");
         String realm = String.valueOf(pctx != null ? pctx.getDefaultRealm() : "<realm>");
+        String principalApplication = String.valueOf(pctx != null ? pctx.getApplicationId() : "<application>");
+        String resourceApplication = String.valueOf(rctx != null ? rctx.getApplicationId() : "<resource-application>");
         String scope = String.valueOf(pctx != null ? pctx.getScope() : "<scope>");
         String roles = Arrays.toString(pctx != null ? pctx.getRoles() : new String[0]);
         String area = String.valueOf(rctx != null ? rctx.getArea() : "<area>");
         String domain = String.valueOf(rctx != null ? rctx.getFunctionalDomain() : "<domain>");
         String action = String.valueOf(rctx != null ? rctx.getAction() : "<action>");
         String dd = String.valueOf(pctx != null && pctx.getDataDomain() != null ? pctx.getDataDomain().toString() : "<dd>");
-        return String.join("|", user, realm, scope, roles, area, domain, action, dd, String.valueOf(defaultEffect));
+        return String.join("|", user, realm, principalApplication, resourceApplication,
+                scope, roles, area, domain, action, dd, String.valueOf(defaultEffect));
     }
 }

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolverApplicationScopeTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/IdentityRoleResolverApplicationScopeTest.java
@@ -1,0 +1,29 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.security.UserGroup;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IdentityRoleResolverApplicationScopeTest {
+
+    @Test
+    void groupRolesDoNotCrossApplicationBoundaries() {
+        UserGroup scheduler = new UserGroup();
+        scheduler.setApplicationId("scheduler");
+
+        assertTrue(IdentityRoleResolver.groupAppliesToApplication(scheduler, "scheduler"));
+        assertFalse(IdentityRoleResolver.groupAppliesToApplication(scheduler, "reporting"));
+    }
+
+    @Test
+    void wildcardGroupIsExplicitlyGlobalButLegacyGroupIsNot() {
+        UserGroup wildcard = new UserGroup();
+        wildcard.setApplicationId("*");
+        UserGroup legacy = new UserGroup();
+
+        assertTrue(IdentityRoleResolver.groupAppliesToApplication(wildcard, "scheduler"));
+        assertFalse(IdentityRoleResolver.groupAppliesToApplication(legacy, "scheduler"));
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/PolicyRepoApplicationScopeTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/PolicyRepoApplicationScopeTest.java
@@ -1,0 +1,119 @@
+package com.e2eq.framework.model.persistent.morphia;
+
+import com.e2eq.framework.model.security.Application;
+import com.e2eq.framework.model.security.FunctionalAction;
+import com.e2eq.framework.model.security.FunctionalDomain;
+import com.e2eq.framework.model.security.Policy;
+import com.e2eq.framework.model.security.Rule;
+import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.SecurityURI;
+import com.e2eq.framework.model.securityrules.SecurityURIBody;
+import com.e2eq.framework.model.securityrules.SecurityURIHeader;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PolicyRepoApplicationScopeTest {
+
+    private final PolicyRepo repo = new PolicyRepo();
+
+    @Test
+    void policyMustMatchBothApplicationAndOperatingRealm() {
+        Policy schedulerAcme = policy("scheduler", "acme-com");
+
+        assertTrue(repo.matchesScope(schedulerAcme, "scheduler", "acme-com", false));
+        assertFalse(repo.matchesScope(schedulerAcme, "reporting", "acme-com", false));
+        assertFalse(repo.matchesScope(schedulerAcme, "scheduler", "other-com", false));
+    }
+
+    @Test
+    void wildcardPolicyAppliesAcrossApplicationsAndRealms() {
+        assertTrue(repo.matchesScope(policy("*", "*"), "scheduler", "acme-com", false));
+    }
+
+    @Test
+    void strictModeRejectsLegacyUnscopedPolicies() {
+        Policy legacy = policy(null, null);
+
+        assertFalse(repo.matchesScope(legacy, "scheduler", "acme-com", false));
+        assertTrue(repo.matchesScope(legacy, "scheduler", "acme-com", true));
+    }
+
+    @Test
+    void admissionRejectsActionsOutsideTheApplicationVocabulary() {
+        PolicyRepo admissionRepo = admissionRepo("read");
+        Policy invalid = policy("scheduler", "acme-com");
+        invalid.setRules(List.of(rule("delete")));
+
+        assertThrows(IllegalArgumentException.class, () -> admissionRepo.setDefaultValues(invalid));
+    }
+
+    @Test
+    void admissionAcceptsApplicationScopedCatalogActions() {
+        PolicyRepo admissionRepo = admissionRepo("read");
+        Policy valid = policy("scheduler", "acme-com");
+        valid.setRules(List.of(rule("read")));
+
+        admissionRepo.setDefaultValues(valid);
+        assertTrue(valid.getId() != null);
+    }
+
+    @Test
+    void functionalCatalogUsesTheConfiguredCentralPolicyStore() {
+        FunctionalDomainRepo functionalDomainRepo = new FunctionalDomainRepo();
+        functionalDomainRepo.defaultRealm = "scheduler-tenant-acme";
+        functionalDomainRepo.policyStoreRealm = Optional.of("quantum-auth");
+
+        assertTrue("quantum-auth".equals(functionalDomainRepo.getSecurityContextRealmId()));
+    }
+
+    private static Policy policy(String applicationId, String realmRefName) {
+        Policy policy = new Policy();
+        policy.setApplicationId(applicationId);
+        policy.setRealmRefName(realmRefName);
+        return policy;
+    }
+
+    private static PolicyRepo admissionRepo(String allowedAction) {
+        Application application = new Application();
+        application.setRefName("scheduler");
+
+        FunctionalAction action = new FunctionalAction();
+        action.setRefName(allowedAction);
+        FunctionalDomain domain = new FunctionalDomain();
+        domain.setApplicationId("scheduler");
+        domain.setArea("workforce");
+        domain.setRefName("schedule");
+        domain.setFunctionalActions(List.of(action));
+
+        PolicyRepo admissionRepo = new PolicyRepo();
+        admissionRepo.policyAdmissionEnabled = true;
+        admissionRepo.applicationRepo = new ApplicationRepo() {
+            @Override
+            public Optional<Application> findByRefNameWithIgnoreRules(String refName) {
+                return "scheduler".equals(refName) ? Optional.of(application) : Optional.empty();
+            }
+        };
+        admissionRepo.functionalDomainRepo = new FunctionalDomainRepo() {
+            @Override
+            public List<FunctionalDomain> findForApplicationWithIgnoreRules(String applicationId) {
+                return "scheduler".equals(applicationId) ? List.of(domain) : List.of();
+            }
+        };
+        return admissionRepo;
+    }
+
+    private static Rule rule(String action) {
+        SecurityURIHeader header = new SecurityURIHeader("scheduler-user", "workforce", "schedule", action);
+        return new Rule.Builder()
+            .withName("scheduler-" + action)
+            .withSecurityURI(new SecurityURI(header, new SecurityURIBody()))
+            .withEffect(RuleEffect.ALLOW)
+            .build();
+    }
+}

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/changesets/BackfillRealmDeploymentTypeIT.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/changesets/BackfillRealmDeploymentTypeIT.java
@@ -21,7 +21,7 @@ class BackfillRealmDeploymentTypeIT {
     @Test
     void backfillsOnlyMissingAndNullValuesAndPreservesShared() {
         String databaseName =
-            "quantum_realm_type_migration_" + UUID.randomUUID().toString().replace("-", "");
+            "test-quantum-realm-type-migration-" + UUID.randomUUID().toString().replace("-", "");
         try (MongoClient mongoClient = MongoClients.create("mongodb://localhost:27017")) {
             MongoDatabase database = mongoClient.getDatabase(databaseName);
             database.getCollection("realm").insertMany(List.of(

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/securityrules/RuleContextAuthorizationProviderTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/securityrules/RuleContextAuthorizationProviderTest.java
@@ -1,0 +1,111 @@
+package com.e2eq.framework.security.runtime;
+
+import com.e2eq.framework.model.auth.AuthProvider;
+import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.auth.AuthorizationProvider;
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.securityrules.EvalMode;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.RuleEffect;
+import com.e2eq.framework.model.securityrules.SecurityCheckResponse;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class RuleContextAuthorizationProviderTest {
+
+    @Test
+    void configuredAuthorizationProviderOwnsTheDecision() {
+        AtomicInteger calls = new AtomicInteger();
+        SecurityCheckResponse expected = new SecurityCheckResponse();
+        expected.setFinalEffect(RuleEffect.ALLOW);
+        expected.setDecision("ALLOW");
+
+        AuthorizationProvider provider = new StubAuthorizationProvider(calls, expected);
+        RuleContext ruleContext = new RuleContext();
+        ruleContext.authProviderFactory = new StubAuthProviderFactory(provider);
+
+        DataDomain domain = new DataDomain("acme", "acme", "acme", 0, "alice@example.com");
+        PrincipalContext principal = new PrincipalContext.Builder()
+                .withDefaultRealm("acme")
+                .withApplicationId("scheduler")
+                .withDataDomain(domain)
+                .withUserId("alice@example.com")
+                .withRoles(new String[]{"user"})
+                .withScope("AUTHENTICATED")
+                .build();
+        ResourceContext resource = new ResourceContext.Builder()
+                .withRealm("acme")
+                .withApplicationId("scheduler")
+                .withArea("scheduler")
+                .withFunctionalDomain("shift")
+                .withAction("create")
+                .withDataDomain(domain)
+                .build();
+
+        SecurityCheckResponse actual = ruleContext.checkRules(principal, resource);
+
+        assertSame(expected, actual);
+        assertEquals(1, calls.get());
+    }
+
+    private static final class StubAuthProviderFactory extends AuthProviderFactory {
+        private final AuthProvider provider;
+
+        private StubAuthProviderFactory(AuthProvider provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public AuthProvider getAuthProvider() {
+            return provider;
+        }
+    }
+
+    private static final class StubAuthorizationProvider implements AuthorizationProvider {
+        private final AtomicInteger calls;
+        private final SecurityCheckResponse response;
+
+        private StubAuthorizationProvider(AtomicInteger calls, SecurityCheckResponse response) {
+            this.calls = calls;
+            this.response = response;
+        }
+
+        @Override
+        public SecurityCheckResponse checkRules(
+                PrincipalContext principalContext,
+                ResourceContext resourceContext,
+                String modelClass,
+                Object resourceInstance,
+                RuleEffect defaultFinalEffect,
+                EvalMode evalMode) {
+            calls.incrementAndGet();
+            return response;
+        }
+
+        @Override
+        public SecurityIdentity validateAccessToken(String token) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getName() {
+            return "stub-authorization";
+        }
+
+        @Override
+        public LoginResponse login(String userId, String password) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoginResponse refreshTokens(String refreshToken) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 public class OntologyEdgeIngestQuarantineTest {
 
-    private static final String REALM = "ingest-quarantine-test";
+    private static final String REALM = "test-ingest-quarantine";
 
     @Inject
     OntologyEdgeRepo edgeRepo;

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/it/ChainInferenceAndReindexIT.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/it/ChainInferenceAndReindexIT.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 public class ChainInferenceAndReindexIT {
 
-    private static final String REALM = "chain-inference-test";
+    private static final String REALM = "test-chain-inference";
 
     @Inject
     MorphiaDataStoreWrapper dataStoreWrapper;

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/it/TerritoryHierarchyComputedIT.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/it/TerritoryHierarchyComputedIT.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 public class TerritoryHierarchyComputedIT {
 
-    private static final String REALM = "territory-hierarchy-test";
+    private static final String REALM = "test-territory-hierarchy";
 
     @Inject
     MorphiaDataStoreWrapper dataStoreWrapper;

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/it/TerritoryLocationPermissionIT.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/it/TerritoryLocationPermissionIT.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 public class TerritoryLocationPermissionIT {
 
-    private static final String REALM = "territory-permission-test";
+    private static final String REALM = "test-territory-permission";
 
     @Inject
     MorphiaDataStoreWrapper dataStoreWrapper;

--- a/quantum-ontology-mongo/src/test/resources/application.properties
+++ b/quantum-ontology-mongo/src/test/resources/application.properties
@@ -1,20 +1,20 @@
 quarkus.mongodb.devservices.enabled=false
 quarkus.mongodb.connection-string=${MONGODB_CONNECTION_STRING:mongodb://localhost:27017/?retryWrites=false}
-quarkus.mongodb.database=${MONGODB_DEFAULT_SCHEMA:ontology-it}
+quarkus.mongodb.database=${MONGODB_DEFAULT_SCHEMA:test-ontology-it}
 # Minimal framework config for tests
 quantum.database.version=1.0.3
 quantum.database.scope=DEV
 quantum.database.migration.enabled=false
 quantum.database.migration.changeset.package=com.e2eq.framework.model.persistent.morphia.changesets
-quantum.realmConfig.systemRealm=system-quantum-com
+quantum.realmConfig.systemRealm=test-system-quantum-com
 quantum.realmConfig.testRealm=test-quantum-com
-quantum.realmConfig.defaultRealm=ontology-it
+quantum.realmConfig.defaultRealm=test-ontology-it
 quantum.anonymousUserId=anonymous@system.com
 quantum.defaultSystemPassword=test123456
 quantum.defaultTestPassword=Test123456
 
 quarkus.morphia.packages=com.e2eq.ontology.model,com.e2eq.ontology.mongo.it
-quarkus.morphia.database=${MONGODB_DEFAULT_SCHEMA:ontology-it}
+quarkus.morphia.database=${MONGODB_DEFAULT_SCHEMA:test-ontology-it}
 quarkus.morphia.create-indexes=true
 
 quantum.ontology.scan.packages=com.e2eq.ontology.mongo.it

--- a/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/it/FulfillmentCollaborationIT.java
+++ b/quantum-ontology-policy-bridge/src/test/java/com/e2eq/ontology/it/FulfillmentCollaborationIT.java
@@ -56,7 +56,7 @@ public class FulfillmentCollaborationIT {
     @BeforeEach
     public void seedRealm() {
         edgeRepo.deleteAll();
-        dataStoreWrapper.getDataStore("fulfillment-demo").getDatabase().getCollection("edges").drop();
+        dataStoreWrapper.getDataStore("test-fulfillment-demo").getDatabase().getCollection("edges").drop();
         datastore.getDatabase().getCollection("demo_sales_orders").drop();
         datastore.getDatabase().getCollection("demo_fulfillment_plans").drop();
 

--- a/quantum-ontology-policy-bridge/src/test/resources/application.properties
+++ b/quantum-ontology-policy-bridge/src/test/resources/application.properties
@@ -1,20 +1,20 @@
 quarkus.mongodb.devservices.enabled=false
 quarkus.mongodb.connection-string=${MONGODB_CONNECTION_STRING:mongodb://localhost:27017/?retryWrites=false}
-quarkus.mongodb.database=${MONGODB_DEFAULT_SCHEMA:ontology-it}
+quarkus.mongodb.database=${MONGODB_DEFAULT_SCHEMA:test-ontology-policy-it}
 # Minimal framework config for tests
 quantum.database.version=1.0.3
 quantum.database.scope=DEV
 quantum.database.migration.enabled=false
 quantum.database.migration.changeset.package=com.e2eq.framework.model.persistent.morphia.changesets
-quantum.realmConfig.systemRealm=system-quantum-com
+quantum.realmConfig.systemRealm=test-system-quantum-com
 quantum.realmConfig.testRealm=test-quantum-com
-quantum.realmConfig.defaultRealm=ontology-it
+quantum.realmConfig.defaultRealm=test-ontology-policy-it
 quantum.anonymousUserId=anonymous@system.com
 quantum.defaultSystemPassword=test123456
 quantum.defaultTestPassword=Test123456
 
 quarkus.morphia.packages=com.e2eq.ontology.it
-quarkus.morphia.database=${MONGODB_DEFAULT_SCHEMA:ontology-it}
+quarkus.morphia.database=${MONGODB_DEFAULT_SCHEMA:test-ontology-policy-it}
 
 # JWT/Auth minimal
 quarkus.smallrye-jwt.enabled=false

--- a/quantum-security-runtime/pom.xml
+++ b/quantum-security-runtime/pom.xml
@@ -50,12 +50,6 @@
             <version>${quantum.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.end2endlogic</groupId>
-            <artifactId>quantum-system-management</artifactId>
-            <version>${quantum.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/quantum-security-runtime/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
+++ b/quantum-security-runtime/src/main/java/com/e2eq/framework/rest/filters/SecurityFilter.java
@@ -3,6 +3,8 @@ package com.e2eq.framework.rest.filters;
 
 import com.e2eq.framework.model.auth.AuthProvider;
 import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.auth.ClaimsAuthProvider;
+import com.e2eq.framework.model.auth.ProviderClaims;
 import com.e2eq.framework.model.persistent.morphia.IdentityRoleResolver;
 import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.persistent.morphia.UserGroupRepo;
@@ -105,11 +107,10 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     @ConfigProperty(name = "quantum.security.filter.enforcePreAuth", defaultValue = "true")
     boolean enforcePreAuth;
 
-    // Delegated identity: when true, a token from the trusted central issuer whose subject is NOT
-    // present in the local credential store is trusted by its (already JWKS-validated) claims, and the
-    // principal is built from those claims — no local credential/database lookup. This lets a service
-    // delegate identity entirely to the central auth service (via its REST API/SDK) without sharing a
-    // database. Default false preserves the strict local-credential behavior.
+    // Delegated identity: when true, the configured ClaimsAuthProvider validates the bearer token and
+    // supplies provider-neutral claims before any local identity repository is touched. This lets a
+    // service delegate identity entirely to its provider without sharing a credential database.
+    // Default false preserves the embedded/local-credential behavior.
     @ConfigProperty(name = "quantum.auth.trust-token-claims", defaultValue = "false")
     boolean trustTokenClaims;
 
@@ -317,6 +318,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
                             action = "LIST";
                         }
                         rcontext = new ResourceContext.Builder()
+                                .withApplicationId(currentApplicationId())
                                 .withArea(area)
                                 .withFunctionalDomain(functionalDomain)
                                 .withAction(action)
@@ -613,6 +615,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
             PrincipalContext context = new PrincipalContext.Builder()
                     .withDefaultRealm(credentialRealm)
+                    .withApplicationId(currentApplicationId())
                     .withDomainContext(creds.getDomainContext())
                     .withDataDomain(dataDomain)
                     .withUserId(creds.getUserId())
@@ -627,8 +630,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     }
 
     private ContextBuildResult buildJwtContextWithCredentials(String authHeader, String realmOverride) {
-        // Extract token (variable kept for potential future use)
-        @SuppressWarnings("unused")
         String token = authHeader.substring(AUTHENTICATION_SCHEME.length()).trim();
         String sub = jwt.getClaim("sub");
 
@@ -643,6 +644,19 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             return buildServiceClaimsContext(sub, realmOverride);
         }
 
+        // A delegated provider owns identity data. Resolve its provider-neutral claims
+        // before touching any local credential/profile/realm repository.
+        if (trustTokenClaims) {
+            AuthProvider selectedProvider = authProviderFactory.getAuthProvider();
+            if (!(selectedProvider instanceof ClaimsAuthProvider claimsProvider)) {
+                throw new jakarta.ws.rs.ForbiddenException(
+                        "Configured auth provider does not support delegated token claims: "
+                                + selectedProvider.getName());
+            }
+            ProviderClaims providerClaims = claimsProvider.validateTokenToClaims(token);
+            return buildDelegatedClaimsContext(providerClaims, realmOverride);
+        }
+
         // Credentials are looked up from the configured system realm (global credential store)
         Optional<CredentialUserIdPassword> ocreds = credentialRepo.findBySubject(sub, envConfigUtils.getSystemRealm(), true);
         if (!ocreds.isPresent()) {
@@ -650,11 +664,6 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         }
 
         if (!ocreds.isPresent()) {
-            // Delegated identity: the credential store may live in another service/database we must not
-            // reach. When enabled, build the principal from the already-JWKS-validated token claims.
-            if (trustTokenClaims) {
-                return buildDelegatedClaimsContext(sub, realmOverride);
-            }
             throw new IllegalStateException(String.format(
                 "Subject %s not found in credentialUserIdPassword collection in realm:%s",
                 sub, envConfigUtils.getSystemRealm()));
@@ -689,6 +698,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         DataDomain dataDomain = effectiveDomainContext.toDataDomain(creds.getUserId());
         PrincipalContext context = new PrincipalContext.Builder()
                 .withDefaultRealm(authorityRealm)
+                .withApplicationId(currentApplicationId())
                 .withDomainContext(effectiveDomainContext)
                 .withDataDomain(dataDomain)
                 .withUserId(creds.getUserId())
@@ -701,22 +711,21 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
     }
 
     /**
-     * Builds a PrincipalContext purely from a validated central-issuer token's claims, with NO local
-     * credential/database lookup. Used when {@code quantum.auth.trust-token-claims=true} and the token's
-     * subject is not present locally: the service delegates identity to the issuer (whose token is
-     * already JWKS-validated for signature/issuer/audience). Identity = userId/preferred_username claim
-     * (or the subject), roles = the token groups; the operating data realm comes from X-Realm, else the
-     * service's configured system realm. Richer profile data, if needed, is fetched from the issuer's
-     * REST API via the generated SDK — never from a shared database.
+     * Builds a PrincipalContext purely from claims validated by the configured provider, with no local
+     * credential/profile lookup. Used when {@code quantum.auth.trust-token-claims=true}. Identity comes
+     * from userId/preferred_username/username (or the subject), and roles come from the provider claims.
      */
-    private ContextBuildResult buildDelegatedClaimsContext(String sub, String realmOverride) {
-        String userId = claimString("userId");
-        if (userId == null) userId = claimString("preferred_username");
-        if (userId == null) userId = claimString("username");
+    private ContextBuildResult buildDelegatedClaimsContext(ProviderClaims claims, String realmOverride) {
+        Objects.requireNonNull(claims, "Delegated provider claims are required");
+        String sub = claims.getSubject();
+        String userId = providerClaim(claims, "userId");
+        if (userId == null) userId = providerClaim(claims, "preferred_username");
+        if (userId == null) userId = claims.getUsername();
+        if (userId == null) userId = providerClaim(claims, "username");
         if (userId == null) userId = sub;
 
         String systemRealm = envConfigUtils.getSystemRealm();
-        String signedRealm = claimString("realm");
+        String signedRealm = providerClaim(claims, "realm");
         if (signedRealm == null) {
             throw new jakarta.ws.rs.ForbiddenException(
                     "Trusted-issuer token is missing the required realm claim");
@@ -729,7 +738,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         String contextRealm = signedRealm;
         if (realmOverride != null && !realmOverride.isBlank()
                 && !realmOverride.equalsIgnoreCase(signedRealm)) {
-            String realmBoundary = claimString("realmRegEx");
+            String realmBoundary = providerClaim(claims, "realmRegEx");
             boolean withinBoundary = false;
             if (realmBoundary != null && !realmOverride.equalsIgnoreCase(systemRealm)) {
                 if ("*".equals(realmBoundary)) {
@@ -750,11 +759,10 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             contextRealm = realmOverride;
             realmSwitched = true;
         }
-        String[] roles = resolveEffectiveRoles(
-                securityIdentity, null, signedRealm, contextRealm);
+        String[] roles = claims.getTokenRoles().toArray(String[]::new);
 
         Log.infof("Delegated identity: principal from trusted-issuer token claims (iss=%s, sub=%s, userId=%s, realm=%s, roles=%s)",
-                jwt.getIssuer(), sub, userId, contextRealm, java.util.Arrays.toString(roles));
+                claims.getIssuer(), sub, userId, contextRealm, java.util.Arrays.toString(roles));
 
         // A delegated principal adopts the DATA DOMAIN of the tenant realm it operates in
         // (from the realm's registered DomainContext), not the cross-tenant system domain.
@@ -770,9 +778,9 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             }
             dataDomain = securityUtils.getSystemDataDomain();
         } else {
-            String tenantId = claimString("tenantId");
-            String orgRefName = claimString("orgRefName");
-            String accountNum = claimString("accountNum");
+            String tenantId = providerClaim(claims, "tenantId");
+            String orgRefName = providerClaim(claims, "orgRefName");
+            String accountNum = providerClaim(claims, "accountNum");
             // Token data-domain claims describe the LOGIN realm; a switched
             // realm's data domain must come from the realm catalog below.
             if (!realmSwitched && tenantId != null && orgRefName != null && accountNum != null) {
@@ -793,12 +801,22 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
         PrincipalContext context = new PrincipalContext.Builder()
                 .withDefaultRealm(contextRealm)
+                .withApplicationId(providerClaim(claims, "azp"))
                 .withDataDomain(dataDomain)
                 .withUserId(userId)
                 .withRoles(roles)
                 .withScope("AUTHENTICATED")
                 .build();
         return new ContextBuildResult(context, null);
+    }
+
+    private static String providerClaim(ProviderClaims claims, String name) {
+        Object value = claims.getAttributes().get(name);
+        if (value == null) {
+            return null;
+        }
+        String text = String.valueOf(value).trim();
+        return text.isEmpty() ? null : text;
     }
 
     /**
@@ -831,6 +849,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
         PrincipalContext context = new PrincipalContext.Builder()
                 .withDefaultRealm(contextRealm)
+                .withApplicationId(currentApplicationId())
                 .withDataDomain(dataDomain)
                 .withUserId(serviceUserId)
                 .withRoles(roles)
@@ -849,6 +868,22 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         if (v == null) return null;
         String s = v.toString();
         return s.isBlank() ? null : s;
+    }
+
+    private String currentApplicationId() {
+        String tokenApplication = claimString("azp");
+        if (tokenApplication != null) {
+            return tokenApplication;
+        }
+        if (securityIdentity == null) {
+            return null;
+        }
+        Object value = securityIdentity.getAttribute("azp");
+        if (value == null) {
+            return null;
+        }
+        String applicationId = String.valueOf(value).trim();
+        return applicationId.isEmpty() ? null : applicationId;
     }
 
     /**
@@ -922,6 +957,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         // Rebuild context with custom properties
         return new PrincipalContext.Builder()
                 .withDefaultRealm(context.getDefaultRealm())
+                .withApplicationId(context.getApplicationId())
                 .withDataDomain(context.getDataDomain())
                 .withDomainContext(context.getDomainContext())
                 .withUserId(context.getUserId())
@@ -1053,7 +1089,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
             throw new IllegalStateException("IdentityRoleResolver is required to build an authenticated principal");
         }
         return identityRoleResolver.resolveEffectiveRoles(
-                identity, credential, authorityRealm, effectiveRealm);
+                identity, credential, authorityRealm, effectiveRealm, currentApplicationId());
     }
 
     private void validateRealmAccess(CredentialUserIdPassword creds, String realm) {
@@ -1103,6 +1139,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         if (impersonateSubject == null && impersonateUserId == null) {
             return new PrincipalContext.Builder()
                     .withDefaultRealm(baseContext.getDefaultRealm())
+                    .withApplicationId(baseContext.getApplicationId())
                     .withDomainContext(baseContext.getDomainContext())
                     .withDataDomain(baseContext.getDataDomain())
                     .withUserId(baseContext.getUserId())
@@ -1177,6 +1214,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
 
         return new PrincipalContext.Builder()
                 .withDefaultRealm(targetRealm)
+                .withApplicationId(currentApplicationId())
                 .withDomainContext(targetCreds.getDomainContext())
                 .withDataDomain(dataDomain)
                 .withUserId(targetCreds.getUserId())
@@ -1248,6 +1286,7 @@ public class SecurityFilter implements ContainerRequestFilter, jakarta.ws.rs.con
         // Rebuild the context with the target realm's DataDomain and DomainContext
         return new PrincipalContext.Builder()
                 .withDefaultRealm(realm)
+                .withApplicationId(context.getApplicationId())
                 .withDomainContext(targetDomainContext)
                 .withDataDomain(effectiveDataDomain)
                 .withUserId(context.getUserId())

--- a/quantum-security-runtime/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterDelegatedProviderTest.java
+++ b/quantum-security-runtime/src/test/java/com/e2eq/framework/rest/filters/SecurityFilterDelegatedProviderTest.java
@@ -1,0 +1,122 @@
+package com.e2eq.framework.rest.filters;
+
+import com.e2eq.framework.model.auth.AuthProvider;
+import com.e2eq.framework.model.auth.AuthProviderFactory;
+import com.e2eq.framework.model.auth.ClaimsAuthProvider;
+import com.e2eq.framework.model.auth.ProviderClaims;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.util.EnvConfigUtils;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SecurityFilterDelegatedProviderTest {
+
+    @Test
+    void trustedClaimsUseProviderBeforeAnyLocalIdentityRepository() throws Exception {
+        SecurityFilter filter = new SecurityFilter();
+        filter.trustTokenClaims = true;
+        filter.authProviderFactory = new StubAuthProviderFactory(new StubClaimsProvider());
+        filter.jwt = jwtWithSubject("subject-123");
+
+        EnvConfigUtils envConfigUtils = new EnvConfigUtils();
+        envConfigUtils.setSystemRealm("system-auth-shared");
+        filter.envConfigUtils = envConfigUtils;
+
+        // credentialRepo, profile/group repos, and SystemDirectory deliberately remain null.
+        // Reaching any local identity/catalog path would make this test fail immediately.
+        Method method = SecurityFilter.class.getDeclaredMethod(
+                "buildJwtContextWithCredentials", String.class, String.class);
+        method.setAccessible(true);
+        Object result = method.invoke(filter, "Bearer delegated-token", null);
+
+        Field contextField = result.getClass().getDeclaredField("context");
+        contextField.setAccessible(true);
+        PrincipalContext context = (PrincipalContext) contextField.get(result);
+
+        assertEquals("alice", context.getUserId());
+        assertEquals("tenant-acme", context.getDefaultRealm());
+        assertEquals("tenant-acme", context.getDataDomain().getTenantId());
+        assertEquals("acme", context.getDataDomain().getOrgRefName());
+        assertEquals("account-1", context.getDataDomain().getAccountNum());
+        assertArrayEquals(new String[]{"scheduler-user"}, context.getRoles());
+    }
+
+    private static JsonWebToken jwtWithSubject(String subject) {
+        return (JsonWebToken) Proxy.newProxyInstance(
+                JsonWebToken.class.getClassLoader(),
+                new Class<?>[]{JsonWebToken.class},
+                (proxy, method, args) -> {
+                    if ("getClaim".equals(method.getName()) && "sub".equals(args[0])) {
+                        return subject;
+                    }
+                    if ("getName".equals(method.getName())) {
+                        return subject;
+                    }
+                    if (method.getReturnType().equals(Set.class)) {
+                        return Set.of();
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    return null;
+                });
+    }
+
+    private static final class StubAuthProviderFactory extends AuthProviderFactory {
+        private final AuthProvider provider;
+
+        private StubAuthProviderFactory(AuthProvider provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public AuthProvider getAuthProvider() {
+            return provider;
+        }
+    }
+
+    private static final class StubClaimsProvider implements ClaimsAuthProvider {
+        @Override
+        public ProviderClaims validateTokenToClaims(String token) {
+            assertEquals("delegated-token", token);
+            return ProviderClaims.builder("subject-123")
+                    .username("alice")
+                    .issuer("https://auth.example.test")
+                    .tokenRoles(Set.of("scheduler-user"))
+                    .putAttribute("realm", "tenant-acme")
+                    .putAttribute("tenantId", "tenant-acme")
+                    .putAttribute("orgRefName", "acme")
+                    .putAttribute("accountNum", "account-1")
+                    .build();
+        }
+
+        @Override
+        public SecurityIdentity validateAccessToken(String token) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getName() {
+            return "stub-claims";
+        }
+
+        @Override
+        public LoginResponse login(String userId, String password) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoginResponse refreshTokens(String refreshToken) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/quantum-seed-core/src/main/java/com/e2eq/framework/service/seed/SeedContextVariableResolver.java
+++ b/quantum-seed-core/src/main/java/com/e2eq/framework/service/seed/SeedContextVariableResolver.java
@@ -12,6 +12,7 @@ import java.util.Optional;
  *   <li>{@code orgRefName} - the organization reference name</li>
  *   <li>{@code accountId} - the account identifier</li>
  *   <li>{@code ownerId} - the owner identifier</li>
+ *   <li>{@code adminUserId} - alias for the seed admin / principal owner</li>
  * </ul>
  *
  * <p>This resolver has the lowest priority (-100) so custom resolvers can override
@@ -40,7 +41,9 @@ public final class SeedContextVariableResolver implements SeedVariableResolver {
             case "tenantId" -> context.getTenantId();
             case "orgRefName" -> context.getOrgRefName();
             case "accountId" -> context.getAccountId();
-            case "ownerId" -> context.getOwnerId();
+            // Seed packs (e.g. quantum-billing-reference) use {adminUserId}; REST seed apply
+            // sets ownerId from the principal, so alias it here for startup/REST parity.
+            case "ownerId", "adminUserId" -> context.getOwnerId();
             default -> Optional.empty();
         };
     }

--- a/quantum-seed-rest/src/main/java/com/e2eq/framework/rest/resources/SeedAdminResource.java
+++ b/quantum-seed-rest/src/main/java/com/e2eq/framework/rest/resources/SeedAdminResource.java
@@ -285,10 +285,14 @@ public class SeedAdminResource {
             PrincipalContext pc = principalContext.get();
             DataDomain dd = pc.getDataDomain();
             if (dd != null) {
+                String principalUserId = pc.getUserId();
                 builder.tenantId(dd.getTenantId())
                        .orgRefName(dd.getOrgRefName())
                        .accountId(dd.getAccountNum())
-                       .ownerId(pc.getUserId());
+                       .ownerId(principalUserId)
+                       // Match SeedStartupRunner so packs using {adminUserId} resolve under REST apply.
+                       .variable("adminUserId", principalUserId)
+                       .variable("ownerId", principalUserId);
             }
         } else {
             Log.warnf("SeedAdminResource: No security context available for realm %s. " +

--- a/quantum-system/src/test/java/com/e2eq/framework/system/tenant/MongoTenantDataExpirationProviderIT.java
+++ b/quantum-system/src/test/java/com/e2eq/framework/system/tenant/MongoTenantDataExpirationProviderIT.java
@@ -19,7 +19,7 @@ class MongoTenantDataExpirationProviderIT {
 
     @Test
     void stampsOnlyRequestedTenantAndCreatesAbsoluteTimeTtlIndex() {
-        String databaseName = "tenant-expiration-it-"
+        String databaseName = "test-tenant-expiration-it-"
             + UUID.randomUUID().toString().replace("-", "");
         try (MongoClient client = MongoClients.create("mongodb://localhost:27017")) {
             var collection = client.getDatabase(databaseName).getCollection("orders");


### PR DESCRIPTION
## Summary
- introduce the provider-backed application authorization contract
- scope functional domains, policies, user groups, and rule contexts by application
- delegate security resolution through providers
- prefix test-created Mongo databases with test ownership names

## Validation
- Maven reactor tests for models, Morphia repositories, security runtime, and JWT provider
- targeted authorization and database naming tests