### PR TITLE
Fix anonymous registration application context

### DIFF
--- a/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/SecurityCallScope.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/model/securityrules/SecurityCallScope.java
@@ -438,8 +438,17 @@ public final class SecurityCallScope {
   public static PrincipalContext anonymous(String realm,
                                            DataDomain dataDomain,
                                            String anonymousUserId) {
+    return anonymous(realm, dataDomain, anonymousUserId, null);
+  }
+
+  /** Creates an application-scoped anonymous principal for public application endpoints. */
+  public static PrincipalContext anonymous(String realm,
+                                           DataDomain dataDomain,
+                                           String anonymousUserId,
+                                           String applicationId) {
     return new PrincipalContext.Builder()
         .withDefaultRealm(realm)
+        .withApplicationId(applicationId)
         .withDataDomain(dataDomain)
         .withUserId(anonymousUserId)
         .withRoles(new String[]{"ANONYMOUS"})
@@ -494,6 +503,7 @@ public final class SecurityCallScope {
     String realm = (realmOrNull != null) ? realmOrNull : principal.getDefaultRealm();
     return new ResourceContext.Builder()
         .withRealm(realm)
+        .withApplicationId(principal.getApplicationId())
         .withArea(area)
         .withFunctionalDomain(functionalDomain)
         .withAction(action)
@@ -511,6 +521,7 @@ public final class SecurityCallScope {
     String realm = (realmOrNull != null) ? realmOrNull : principal.getDefaultRealm();
     return new ResourceContext.Builder()
         .withRealm(realm)
+        .withApplicationId(principal.getApplicationId())
         .withArea(area)
         .withFunctionalDomain(functionalDomain)
         .withAction(action)

--- a/quantum-models/src/test/java/com/e2eq/framework/model/securityrules/ApplicationScopedSecurityContextTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/model/securityrules/ApplicationScopedSecurityContextTest.java
@@ -41,6 +41,19 @@ class ApplicationScopedSecurityContextTest {
         assertNotEquals(scheduler, reporting);
     }
 
+    @Test
+    void applicationScopedAnonymousPrincipalPropagatesToResources() {
+        DataDomain dataDomain = new DataDomain("system", "0001", "system", 0, "system");
+        PrincipalContext principal = SecurityCallScope.anonymous(
+                "quantum-auth", dataDomain, "anonymous-registration", "quantum-auth");
+
+        ResourceContext resource = SecurityCallScope.resource(
+                principal, null, "SECURITY", "APPLICATION_REGISTRATION", "CREATE");
+
+        assertEquals("quantum-auth", principal.getApplicationId());
+        assertEquals("quantum-auth", resource.getApplicationId());
+    }
+
     private static PrincipalContext principal(DataDomain dataDomain, String applicationId) {
         return new PrincipalContext.Builder()
                 .withDefaultRealm("acme-com")

--- a/quantum-system-rest/src/main/java/com/e2eq/framework/rest/resources/security/SecurityResource.java
+++ b/quantum-system-rest/src/main/java/com/e2eq/framework/rest/resources/security/SecurityResource.java
@@ -121,11 +121,15 @@ public class SecurityResource {
     @ConfigProperty(name = "com.b2bi.jwt.duration")
     protected long tokenDuration;
 
+    @ConfigProperty(name = "quantum.security.anonymous-registration-application", defaultValue = "quantum-auth")
+    protected String anonymousRegistrationApplication;
+
     private <T> T withAnonymousRegistrationAccess(String action, Supplier<T> supplier) {
         var principal = SecurityCallScope.anonymous(
                 envConfigUtils.getSystemRealm(),
                 securityUtils.getSystemDataDomain(),
-                "anonymous-registration");
+                "anonymous-registration",
+                anonymousRegistrationApplication);
         var resource = SecurityCallScope.resource(
               principal,
               null,


### PR DESCRIPTION
Scopes anonymous registration principals and resources to the configured auth application so application-specific policy resolution remains fail-closed without breaking public registration. Includes propagation coverage.