### PR TITLE
Advance Quantum Framework reactor to 1.4.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -58,7 +58,7 @@
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
         <lombrok.version>1.18.38</lombrok.version>
-        <quantum.version>1.4.1-SNAPSHOT</quantum.version>
+        <quantum.version>1.4.2-SNAPSHOT</quantum.version>
         <apachecommons.lang3.version>3.18.0</apachecommons.lang3.version>
     </properties>
 

--- a/quantum-action-enablement-models/pom.xml
+++ b/quantum-action-enablement-models/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-action-enablement-quarkus/pom.xml
+++ b/quantum-action-enablement-quarkus/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-bootstrap-core/pom.xml
+++ b/quantum-bootstrap-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-bootstrap-rest/pom.xml
+++ b/quantum-bootstrap-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-cli/pom.xml
+++ b/quantum-cli/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>quantum-cli</artifactId>

--- a/quantum-contract-core/pom.xml
+++ b/quantum-contract-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-contract-rest/pom.xml
+++ b/quantum-contract-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-control-plane-client/pom.xml
+++ b/quantum-control-plane-client/pom.xml
@@ -7,12 +7,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.end2endlogic</groupId>
   <artifactId>quantum-control-plane-client</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
   </parent>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/quantum-default-keys/pom.xml
+++ b/quantum-default-keys/pom.xml
@@ -7,12 +7,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-default-keys</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
 
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/quantum-docs/pom.xml
+++ b/quantum-docs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -176,7 +176,7 @@
                     <subDirectory>${docs.ghpages.subdir}</subDirectory>
                     <!-- When LTS publishes to root, do not remove the in-progress docs tree. -->
                     <ignorePathsToDelete>
-                        <string>1.4.1-SNAPSHOT</string>
+                        <string>1.4.2-SNAPSHOT</string>
                     </ignorePathsToDelete>
                 </configuration>
                 <executions>
@@ -239,11 +239,11 @@
                 <docs.ghpages.skip.versioned.publish>false</docs.ghpages.skip.versioned.publish>
             </properties>
         </profile>
-        <!-- In-progress 1.4 line: non-default URL …/1.4.1-SNAPSHOT/ only. Build from git branch 1.4.1-SNAPSHOT. -->
+        <!-- In-progress 1.4 line: non-default URL …/1.4.2-SNAPSHOT/ only. Build from git branch 1.4.2-SNAPSHOT. -->
         <profile>
             <id>docs-ghpages-1.4</id>
             <properties>
-                <docs.ghpages.subdir>1.4.1-SNAPSHOT</docs.ghpages.subdir>
+                <docs.ghpages.subdir>1.4.2-SNAPSHOT</docs.ghpages.subdir>
                 <docs.ghpages.skip.versioned.publish>false</docs.ghpages.skip.versioned.publish>
             </properties>
         </profile>

--- a/quantum-framework/pom.xml
+++ b/quantum-framework/pom.xml
@@ -7,12 +7,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.end2endlogic</groupId>
   <artifactId>quantum-framework</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
   </parent>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>com.end2endlogic</groupId>
       <artifactId>quantum-extension</artifactId>
-      <version>1.4.1-SNAPSHOT</version>
+      <version>1.4.2-SNAPSHOT</version>
     </dependency>
    <!--
     Not needed here is in the quantum extension

--- a/quantum-jwt-provider/pom.xml
+++ b/quantum-jwt-provider/pom.xml
@@ -7,12 +7,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-jwt-provider</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
 
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>com.end2endlogic</groupId>
             <artifactId>quantum-extension</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.2-SNAPSHOT</version>
         </dependency>
         <!--
          Not needed here is in the quantum extension

--- a/quantum-mcp-server/pom.xml
+++ b/quantum-mcp-server/pom.xml
@@ -7,12 +7,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.end2endlogic</groupId>
   <artifactId>quantum-mcp-server</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
   </parent>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/quantum-migration-rest/pom.xml
+++ b/quantum-migration-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-models/pom.xml
+++ b/quantum-models/pom.xml
@@ -8,13 +8,13 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>quantum-models</artifactId>
     <groupId>com.end2endlogic</groupId>
     <packaging>jar</packaging>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
 
     <name>com.end2endlogic:quantum-models</name>
 

--- a/quantum-morphia-repos/pom.xml
+++ b/quantum-morphia-repos/pom.xml
@@ -7,12 +7,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.end2endlogic</groupId>
   <artifactId>quantum-morphia-repos</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
   </parent>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.end2endlogic</groupId>
       <artifactId>quantum-extension</artifactId>
-      <version>1.4.1-SNAPSHOT</version>
+      <version>1.4.2-SNAPSHOT</version>
     </dependency>
    <!--
     Not needed here is in the quantum extension

--- a/quantum-oauth-server/pom.xml
+++ b/quantum-oauth-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>quantum-oauth-server</artifactId>

--- a/quantum-observability-quarkus/pom.xml
+++ b/quantum-observability-quarkus/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-ontology-core/pom.xml
+++ b/quantum-ontology-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-ontology-mongo/pom.xml
+++ b/quantum-ontology-mongo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -17,22 +17,22 @@
         <dependency>
             <groupId>com.end2endlogic</groupId>
             <artifactId>quantum-extension</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.end2endlogic</groupId>
             <artifactId>quantum-ontology-core</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.end2endlogic</groupId>
             <artifactId>quantum-models</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.end2endlogic</groupId>
             <artifactId>quantum-morphia-repos</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.2-SNAPSHOT</version>
         </dependency>
         <!-- Quarkus test framework for @QuarkusTest -->
         <dependency>

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/OntologyEdgeIngestQuarantineTest.java
@@ -7,6 +7,7 @@ import com.e2eq.framework.model.security.DataDomainPolicyEntry;
 import com.e2eq.framework.model.security.DomainContext;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.ResourceContext;
+import com.e2eq.framework.model.securityrules.SecurityCallScope;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.ontology.core.DataDomainInfo;
 import com.e2eq.ontology.core.EdgeRecord;
@@ -50,14 +51,23 @@ public class OntologyEdgeIngestQuarantineTest {
     OntologyEdgeRepo edgeRepo;
 
     private DataDomain principalDD;
+    private SecurityCallScope.Scope privilegedRepoScope;
 
     @AfterEach
     void clearSecurityContext() {
+        if (privilegedRepoScope != null) {
+            privilegedRepoScope.close();
+            privilegedRepoScope = null;
+        }
         SecurityContext.clear();
     }
 
     @BeforeEach
     void setup() {
+        // This acceptance test exercises repository persistence directly, outside an authenticated
+        // resource request. Declare that privileged test boundary explicitly.
+        privilegedRepoScope = SecurityCallScope.openIgnoringRules();
+
         // A principal/security context so ingestEdges' upsert and ds() resolve to a known realm.
         principalDD = new DataDomain();
         principalDD.setOrgRefName("ingest-org");

--- a/quantum-ontology-policy-bridge/pom.xml
+++ b/quantum-ontology-policy-bridge/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -18,17 +18,17 @@
        <dependency>
            <groupId>com.end2endlogic</groupId>
            <artifactId>quantum-extension</artifactId>
-           <version>1.4.1-SNAPSHOT</version>
+           <version>1.4.2-SNAPSHOT</version>
        </dependency>
        <dependency>
            <groupId>com.end2endlogic</groupId>
            <artifactId>quantum-ontology-mongo</artifactId>
-           <version>1.4.1-SNAPSHOT</version>
+           <version>1.4.2-SNAPSHOT</version>
        </dependency>
        <dependency>
            <groupId>com.end2endlogic</groupId>
            <artifactId>quantum-rest-core</artifactId>
-           <version>1.4.1-SNAPSHOT</version>
+           <version>1.4.2-SNAPSHOT</version>
        </dependency>
        <dependency>
            <groupId>org.junit.jupiter</groupId>

--- a/quantum-ontology-rest/pom.xml
+++ b/quantum-ontology-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-query-rest/pom.xml
+++ b/quantum-query-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-rest-core/pom.xml
+++ b/quantum-rest-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-secrets/pom.xml
+++ b/quantum-secrets/pom.xml
@@ -9,12 +9,12 @@
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
   </parent>
 
   <groupId>com.end2endlogic</groupId>
   <artifactId>quantum-secrets</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>com.end2endlogic:quantum-secrets</name>

--- a/quantum-security-runtime/pom.xml
+++ b/quantum-security-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-seed-core/pom.xml
+++ b/quantum-seed-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-seed-rest/pom.xml
+++ b/quantum-seed-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-seed-s3/pom.xml
+++ b/quantum-seed-s3/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/quantum-system-management/pom.xml
+++ b/quantum-system-management/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quantum-system-rest/pom.xml
+++ b/quantum-system-rest/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/quantum-system/pom.xml
+++ b/quantum-system/pom.xml
@@ -7,12 +7,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.end2endlogic</groupId>
   <artifactId>quantum-system</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
   </parent>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/quantum-util/pom.xml
+++ b/quantum-util/pom.xml
@@ -7,12 +7,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.end2endlogic</groupId>
     <artifactId>quantum-util</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
 
     <parent>
         <groupId>com.end2endlogic</groupId>
         <artifactId>quantum-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.end2endlogic</groupId>
             <artifactId>quantum-extension</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.2-SNAPSHOT</version>
         </dependency>
         <!--
          Not needed here is in the quantum extension


### PR DESCRIPTION
## Summary
- advance all Framework reactor projects, internal dependencies, and docs from 1.4.1-SNAPSHOT to 1.4.2-SNAPSHOT
- make the ontology ingest acceptance test declare and close its privileged repository scope explicitly

## Validation (login zsh)
- OntologyEdgeIngestQuarantineTest: 3 passed
- full reactor reached module 29/34 and ran 411 quantum-framework tests
- six auth/system failures reproduce identically on an untouched origin/1.4.2-SNAPSHOT worktree: SecurityTest (2), SystemAPITest (1), SecureResourceTest (1), TestCustTokenAuthProvider (2)
- no 1.4.1-SNAPSHOT references remain in reactor POMs

A complete 34-module JAR install is run separately with tests skipped after establishing the baseline failures.