### PR TITLE
fix(query): BIAPI text(...) review follow-ups from #35

### DIFF
--- a/quantum-docs/src/docs/ai-docs/TEXT_SEARCH_QUERY_LANGUAGE_DESIGN.md
+++ b/quantum-docs/src/docs/ai-docs/TEXT_SEARCH_QUERY_LANGUAGE_DESIGN.md
@@ -1,18 +1,19 @@
 # Design: Text Search in BIAPI Query Language
 
 ## Overview
-This document proposes adding MongoDB text search support to the existing BIAPI (ANTLR) query language so that `$text` queries can be composed with other filters (eq/in/regex/etc.) and remain consistent across Morphia (database-side) and in-memory evaluation paths. The intent is to keep the grammar backwards compatible, introduce a clear syntax for text search, and ensure validation and execution parity across listeners.
+This document describes MongoDB text search support in the BIAPI (ANTLR) query language so that `$text` queries can be composed with other filters (eq/in/regex/etc.) and remain consistent across Morphia (database-side) and in-memory evaluation paths. The intent is to keep the grammar backwards compatible, introduce a clear syntax for text search, and ensure validation and execution parity across listeners.
 
 ## Goals
 - Add a **text search expression** to the BIAPI grammar that composes with existing `&&`/`||` logic.
 - Translate the new expression to MongoDB `$text` via Morphia filters.
 - Provide a deterministic in-memory fallback for test and policy evaluation.
-- Preserve existing query semantics and avoid breaking changes.
+- Preserve existing query semantics and avoid breaking changes (including unquoted `text` as a field/value).
 
 ## Non-Goals
 - Replacing the existing regex/wildcard search semantics.
 - Supporting multiple `$text` expressions in a single query (MongoDB limitation).
 - Implementing Atlas Search or advanced scoring/ranking features.
+- Perfect parity with MongoDB language-specific stemming and stop-word removal.
 
 ## Proposed Syntax
 Introduce a function-style expression:
@@ -25,7 +26,9 @@ text("search terms")
 ```
 text("john doe") && status:Assigned
 text("priority") && (status:"OPEN" || status:"PENDING")
-text(${"query"}) && type:^ ["user", "group"]
+text(${query}) && type:^ ["user", "group"]
+type:text
+text:active
 ```
 
 **Note**: `text(...)` cannot be used inside OR expressions. Use AND to combine text search with other conditions, and place OR logic in a separate grouping.
@@ -35,39 +38,42 @@ text(${"query"}) && type:^ ["user", "group"]
 - Avoids ambiguity with field-based comparisons.
 - Natural mapping to MongoDB `$text`, which does not target a single field.
 
-## Grammar Changes (BIAPIQuery.g4)
-Add a `textExpr` to `allowedExpr` and introduce a `TEXT` token:
+## Grammar Changes (`quantum-models/src/main/antlr4/com/e2eq/framework/grammar/BIAPIQuery.g4`)
+Add `textExpr` to `allowedExpr` and introduce a `TEXT` token **before** `STRING` so the keyword is recognized for `text(...)`. Because `text` is a common English word, accept the `TEXT` token wherever a free identifier (`STRING`) may appear as a field name or unquoted value:
 
 ```antlr
-allowedExpr: ... | textExpr;
-textExpr: TEXT LPAREN value=(STRING|QUOTED_STRING|VARIABLE) RPAREN;
+allowedExpr: inExpr | basicExpr | nullExpr | existsExpr | booleanExpr | notExpr
+  | regexExpr | elemMatchExpr | hasEdgeExpr | hasOutgoingEdgeExpr
+  | hasIncomingEdgeExpr | expandExpr | textExpr;
+
+textExpr: TEXT LPAREN value=(STRING|TEXT|QUOTED_STRING|VARIABLE) RPAREN;
 TEXT: 'text';
+
+// Examples of identifier positions that also accept TEXT:
+// existsExpr: field=(STRING|TEXT) op=EXISTS;
+// basicExpr: field=(STRING|TEXT) ... value=(STRING|TEXT|VARIABLE|OID) ...
+// valueListExpr values include TEXT so type:^ [text] works.
 ```
 
-> NOTE: Ensure the new token does not conflict with existing `STRING` tokenization rules.
+> **Keyword collision**: Without accepting `TEXT` in field/value positions, queries such as `type:text` or `text:active` would fail to parse. Accepting `TEXT` as an identifier keeps those queries working; `getText()` still yields `"text"`.
 
 ## Listener Updates
 
 ### Morphia Query Translation
-File: `quantum-morphia-repos/.../QueryToFilterListener.java`
+File: `quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListener.java`
 - Add `enterTextExpr(...)` handler.
 - Build `Filters.text(value)` and push onto the filter stack.
-- Enforce **single text clause** per query. If a second text clause is encountered, raise a validation error.
-
-### Query Validation (Morphia)
-File: `quantum-morphia-repos/.../ValidatingQueryToFilterListener.java`
-- Track if a text expression has been seen.
-- Throw a validation error on the second occurrence.
+- Treat lexer token `TEXT` like `STRING` when coercing field values / IN-list members.
+- Enforce **single text clause** per query with `IllegalStateException` and a message that mentions the MongoDB one-`$text` limit.
+- Reject `text(...)` nested inside NOT, OR, or elemMatch (see Validation Rules).
 
 ### In-Memory Predicate
-File: `quantum-framework/.../QueryToPredicateJsonListener.java`
+File: `quantum-framework/src/main/java/com/e2eq/framework/query/QueryToPredicateJsonListener.java`
+(package: `com.e2eq.framework.query.runtime`)
 - Define a fallback evaluation method for `text(...)`.
-- Implement `text("foo bar")` as **tokenized contains-any** across all textual values in the JSON payload.
+- Implement `text("foo bar")` as **tokenized contains-any** with **whole-word** matching across textual values in the JSON payload.
 - Perform case-insensitive matches.
-
-### In-Memory Validation
-File: `quantum-framework/.../ValidatingQueryToPredicateJsonListener.java`
-- Reject multiple `text(...)` occurrences (same rule as Morphia).
+- Enforce the same nesting / multiplicity rules as Morphia for execution parity.
 
 ## Execution Semantics
 
@@ -75,54 +81,83 @@ File: `quantum-framework/.../ValidatingQueryToPredicateJsonListener.java`
 - Text search is case-insensitive by default (MongoDB behavior).
 - `$text` can be combined with other filters using `Filters.and(...)` or implicit AND in the top-level query.
 - MongoDB supports only **one `$text` expression** per query.
+- Valid: `text("search") && (status:OPEN || status:PENDING)` (OR is not around `$text`).
 
 ### In-Memory Behavior
-- Behavior should be clearly documented to avoid mismatches with MongoDB tokenization.
-- Split search string into tokens by whitespace and require **any token match**.
-- Perform case-insensitive matches across textual values in the JSON payload.
+Approximation of MongoDB `$text` (documented divergences):
+
+1. **Tokenization of the search string**
+   - Lower-case the string.
+   - Split on Unicode whitespace.
+   - Strip leading/trailing punctuation from each token.
+2. **Matching against field values**
+   - Collect all textual values in the JSON payload (recursive).
+   - Split each value into words on non-letter/non-digit boundaries (`[^\p{L}\p{N}]+`).
+   - Case-insensitive **whole-word equality** (not substring): `text("cat")` matches `"the cat sat"` but **not** `"category"`.
+   - Predicate matches if **any** search term equals **any** word in **any** textual field.
+3. **Relation to MongoDB `$text`**
+   - Does **not** implement stemming, stop-word removal, language-specific tokenization, or text scores.
+   - Intent is parity for common tokenized contains-any tests and policy evaluation, not a full search engine clone.
 
 ## Index Requirements
 - MongoDB allows **one text index per collection**, which can cover multiple fields.
 - The index must be provisioned via existing Morphia annotations and/or migration tooling.
-- Ensure documentation includes example index configuration and notes about weights.
+- If a `text(...)` / `$text` query runs against a collection **without** a text index, MongoDB returns an error (text index required). Quantum does not pre-validate index existence in the query pipeline today; the MongoDB error is surfaced to the caller. Operators should ensure indexes exist before enabling `text(...)` in production.
+- Documentation should include example index configuration and notes about weights.
 
 ## API / Configuration Hooks (Future)
-- Consider a config entry (e.g., `quantum.query.textSearch.fields`) to restrict in-memory evaluation to a specific field list.
+- Optional config (Quarkus `application.properties`), e.g.:
+  ```properties
+  quantum.query.textSearch.fields=title,description,tags
+  ```
+  to restrict in-memory evaluation to a specific field list (today: all textual fields).
 - Optionally allow per-query overrides via a `TextSearchConfig` object passed into `QueryPredicates.compilePredicate(...)`.
+- Feature-flagging `text(...)` parsing/execution per environment or tenant is optional for rollout; not required for correctness once tests cover the constraint set.
 
 ## Validation Rules
-MongoDB requires `$text` to be a top-level query operator. The following constraints are enforced at parse time:
+MongoDB requires `$text` to be a top-level query operator. The following are enforced at parse/compile time on **both** Morphia and in-memory listeners:
 
-- **Multiple text clauses**: Reject multiple `text(...)` expressions in a single query.
-- **Empty search strings**: Reject `text("")` (empty search string).
-- **Inside NOT**: Reject `text(...)` inside NOT (`!!`) expressions. MongoDB does not support `$text` inside `$not` or `$nor`.
-- **Inside OR**: Reject `text(...)` inside OR (`||`) expressions. MongoDB does not allow `$text` inside `$or`.
-- **Inside elemMatch**: Reject `text(...)` inside elemMatch expressions (`field:{...}`). MongoDB does not support `$text` inside `$elemMatch`.
+| Rule | Exception | Message intent |
+|------|-----------|----------------|
+| Multiple `text(...)` | `IllegalStateException` | Multiple clauses not supported; one `$text` per query |
+| Empty / whitespace-only search | `IllegalArgumentException` | `text(...)` value must be non-empty |
+| Inside NOT (`!!`) | `IllegalStateException` | Cannot negate `text(...)` |
+| Inside OR (`||`) | `IllegalStateException` | Cannot use `text(...)` inside OR |
+| Inside elemMatch (`field:{...}`) | `IllegalStateException` | Cannot use `text(...)` inside elemMatch |
+
+Empty-string validation: literals are rejected after trim (`isBlank()`). Variables that resolve to empty/blank at runtime are also rejected. Whitespace-only strings count as empty.
 
 **Valid usage**: `text(...)` combined with `&&` (AND) at the top level is supported because MongoDB allows `$text` alongside other top-level conditions.
 
 ## Documentation Updates
 - Add `text(...)` to the query language guide with syntax and examples.
-- Document limitations (single text clause, MongoDB tokenization differences).
-- Mention index requirements and example Morphia annotations.
+- Document limitations (single text clause, nesting rules, word-level in-memory matching, keyword-as-identifier).
+- Mention index requirements and missing-index behavior.
 
 ## Testing Plan
 1. **Grammar tests**
-   - Parse `text("foo")` alone and with `&&`/`||` operators.
+   - Parse `text("foo")` alone and with `&&` / grouped `||`.
+   - Parse `type:text`, `text:active`, `type:^ [text]`.
 2. **Morphia listener tests**
-   - Ensure `text("foo") && status:Active` produces `Filters.text` combined with `Filters.eq`.
-   - Ensure duplicate `text(...)` is rejected.
+   - Ensure `text("foo") && status:Active` produces `$text` combined with equality.
+   - Ensure duplicate `text(...)`, NOT, OR, and elemMatch nesting are rejected.
+   - Ensure keyword-as-identifier queries parse.
 3. **In-memory predicate tests**
-   - Verify case-insensitive token matching across configured fields.
-   - Validate rejection of duplicate `text(...)`.
+   - Case-insensitive whole-word matching; `cat` does not match `category`.
+   - Reject duplicate / NOT / OR / elemMatch / empty `text(...)`.
+   - Accept `text(...) && (a || b)` composition.
+4. **Composition with advanced expressions** (where environment supports it)
+   - `text("search") && hasEdge(...)` parses; evaluation depends on ontology wiring.
 
 ## Rollout Plan
-1. Update grammar + regenerate ANTLR artifacts if needed.
+1. Update grammar and regenerate ANTLR artifacts (required for any grammar change).
 2. Implement Morphia translation and validation.
-3. Implement in-memory predicate + validation.
+3. Implement in-memory predicate + validation (parity with Morphia constraints).
 4. Update docs and add tests.
+5. Ensure target collections have a text index before enabling `text(...)` in production; be prepared to roll back by stopping use of `text(...)` if query errors spike.
 
 ## Open Questions
 - Should we allow phrase search with quotes to map to MongoDB phrase semantics?
 - Should we expose `language` or `caseSensitive` flags for text search?
 - How should field selection for in-memory evaluation be configured or overridden?
+- Should we expose text search scoring (MongoDB `$meta: "textScore"`) in the query language, and if so how should it integrate with result ordering and the in-memory path?

--- a/quantum-docs/src/docs/asciidoc/user-guide/query-language.adoc
+++ b/quantum-docs/src/docs/asciidoc/user-guide/query-language.adoc
@@ -80,13 +80,18 @@ text("priority escalation")
 
 # Combine text search with other filters
 text("priority escalation") && status:"OPEN"
+
+# Valid: top-level text AND a grouped OR of non-text predicates
+text("priority") && (status:"OPEN" || status:"PENDING")
 ----
 
 Notes:
 
 - `text(...)` maps to MongoDB `$text` queries and is case-insensitive by default.
 - MongoDB allows only one `text(...)` clause per query.
-- Text search must be backed by a text index on the target collection.
+- Text search must be backed by a text index on the target collection. If the collection has no text index, MongoDB returns an error (Quantum does not pre-check index existence).
+- The lexer keyword `text` is also accepted as a normal field name or unquoted value, so queries such as `type:text` and `text:active` remain valid.
+- In-memory evaluation (policy/tests) approximates `$text` with case-insensitive **whole-word** matching (tokenized contains-any). It does not implement stemming or stop words. Example: `text("cat")` matches `"the cat sat"` but not `"category"`.
 
 IMPORTANT: MongoDB requires `$text` to be a top-level query operator. The following usages are **not allowed** and will be rejected at parse time:
 

--- a/quantum-framework/src/main/java/com/e2eq/framework/query/QueryToPredicateJsonListener.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/query/QueryToPredicateJsonListener.java
@@ -34,7 +34,13 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
     private int queryDepth = 0;
     private boolean textClauseSeen = false;
 
+    // Track nesting so text(...) is rejected in positions MongoDB forbids for $text.
+    private int notNestingDepth = 0;
+    private int elemMatchNestingDepth = 0;
+
     private static final Pattern SPECIAL_REGEX_CHARS = Pattern.compile("[{}()\\[\\].+*?^$\\\\|\\-]");
+    /** Split field values into word tokens (letters/digits); approximates MongoDB $text word matching. */
+    private static final Pattern WORD_SPLIT = Pattern.compile("[^\\p{L}\\p{N}]+");
 
     /**
      * Creates a listener with no variable substitution. Useful for queries without ${vars} or object variables.
@@ -75,9 +81,62 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
 
     private void registerTextClause() {
         if (textClauseSeen) {
-            throw new IllegalStateException("Multiple text(...) clauses are not supported in a single query.");
+            throw new IllegalStateException(
+                    "Multiple text(...) clauses are not supported in a single query; MongoDB allows only one $text operator per query.");
+        }
+        // MongoDB requires $text to be a top-level query operator.
+        if (notNestingDepth > 0) {
+            throw new IllegalStateException(
+                    "text(...) cannot be negated with NOT (!!). " +
+                    "MongoDB requires $text to be a top-level query operator. " +
+                    "Example invalid query: !!text(\"foo\")");
+        }
+        if (elemMatchNestingDepth > 0) {
+            throw new IllegalStateException(
+                    "text(...) cannot be used inside an elemMatch expression. " +
+                    "MongoDB requires $text to be a top-level query operator. " +
+                    "Example invalid query: arrayField:{text(\"foo\")}");
         }
         textClauseSeen = true;
+    }
+
+    /**
+     * Marker for predicates that include text(...) so OR composition can reject
+     * nesting that MongoDB forbids for $text.
+     */
+    private interface TextBearing {
+        boolean containsText();
+    }
+
+    private static final class TextBearingPredicate implements Predicate<JsonNode>, TextBearing {
+        private final Predicate<JsonNode> delegate;
+        private final boolean containsText;
+
+        TextBearingPredicate(Predicate<JsonNode> delegate, boolean containsText) {
+            this.delegate = delegate;
+            this.containsText = containsText;
+        }
+
+        @Override
+        public boolean test(JsonNode node) {
+            return delegate.test(node);
+        }
+
+        @Override
+        public boolean containsText() {
+            return containsText;
+        }
+    }
+
+    private static boolean isTextBearing(Predicate<JsonNode> p) {
+        return p instanceof TextBearing tb && tb.containsText();
+    }
+
+    private static Predicate<JsonNode> wrap(Predicate<JsonNode> p, boolean containsText) {
+        if (p instanceof TextBearingPredicate tbp && tbp.containsText == containsText) {
+            return tbp;
+        }
+        return new TextBearingPredicate(p, containsText);
     }
 
     // ---- Parsing lifecycle ----
@@ -173,10 +232,20 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
     }
 
     private static Predicate<JsonNode> allOf(List<Predicate<JsonNode>> list) {
-        return obj -> list.stream().allMatch(p -> p.test(obj));
+        boolean text = list.stream().anyMatch(QueryToPredicateJsonListener::isTextBearing);
+        return wrap(obj -> list.stream().allMatch(p -> p.test(obj)), text);
     }
     private static Predicate<JsonNode> anyOf(List<Predicate<JsonNode>> list) {
-        return obj -> list.stream().anyMatch(p -> p.test(obj));
+        // MongoDB requires $text to be top-level; it cannot appear inside $or.
+        for (Predicate<JsonNode> p : list) {
+            if (isTextBearing(p)) {
+                throw new IllegalStateException(
+                        "text(...) cannot be used inside an OR expression. " +
+                        "MongoDB requires $text to be a top-level query operator. " +
+                        "Example invalid query: text(\"foo\") || status:OPEN");
+            }
+        }
+        return wrap(obj -> list.stream().anyMatch(p -> p.test(obj)), false);
     }
 
     // ---- Operators and groups ----
@@ -188,10 +257,17 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
     @Override public void enterExprOp(BIAPIQueryParser.ExprOpContext ctx) { opTypeStack.push(ctx.op.getType()); }
 
     /** {@inheritDoc} */
+    @Override public void enterNotExpr(BIAPIQueryParser.NotExprContext ctx) {
+        notNestingDepth++;
+    }
+
+    /** {@inheritDoc} */
     @Override public void exitNotExpr(BIAPIQueryParser.NotExprContext ctx) {
+        notNestingDepth--;
         if (predicateStack.isEmpty()) throw new IllegalStateException("NOT with empty stack");
         Predicate<JsonNode> inner = predicateStack.pop();
-        predicateStack.push(inner.negate());
+        // Negation preserves text-bearing-ness for nested OR validation edge cases.
+        predicateStack.push(wrap(inner.negate(), isTextBearing(inner)));
     }
 
     // ---- Leaf expressions ----
@@ -245,12 +321,12 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
         if (trimmed.isBlank()) {
             throw new IllegalArgumentException("text(...) search value must be non-empty.");
         }
-        List<String> terms = Arrays.stream(trimmed.split("\\s+"))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .map(String::toLowerCase)
-                .toList();
-        predicateStack.push(node -> matchesTextSearch(node, terms));
+        List<String> terms = tokenizeSearchTerms(trimmed);
+        if (terms.isEmpty()) {
+            throw new IllegalArgumentException("text(...) search value must be non-empty.");
+        }
+        // Tag as text-bearing so OR composition can reject MongoDB-illegal nesting.
+        predicateStack.push(wrap(node -> matchesTextSearch(node, terms), true));
     }
 
     /** {@inheritDoc} */
@@ -291,22 +367,24 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
     @Override public void enterElemMatchExpr(BIAPIQueryParser.ElemMatchExprContext ctx) {
         opTypeMarkers.push(opTypeStack.size());
         predStackMarkers.push(predicateStack.size());
+        elemMatchNestingDepth++;
     }
     /** {@inheritDoc} */
     @Override public void exitElemMatchExpr(BIAPIQueryParser.ElemMatchExprContext ctx) {
+        elemMatchNestingDepth--;
         int startOp = opTypeMarkers.pop();
         int startPred = predStackMarkers.pop();
         buildCompositeSince(startOp, startPred);
         if (predicateStack.size() <= startPred) throw new IllegalStateException("elemMatch produced no inner predicate");
         Predicate<JsonNode> inner = predicateStack.pop();
         String field = ctx.field.getText();
-        predicateStack.push(node -> {
+        predicateStack.push(wrap(node -> {
             JsonNode fv = getNodeAt(node, field);
             if (fv != null && fv.isArray()) {
                 for (JsonNode el : fv) if (inner.test(el)) return true;
             }
             return false;
-        });
+        }, isTextBearing(inner)));
     }
 
     // ---- helpers ----
@@ -324,7 +402,9 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
         boolean caseInsensitiveStringEquality = originalToken != null
                 && !caseSensitive
                 && (opTok.getType() == BIAPIQueryParser.EQ || opTok.getType() == BIAPIQueryParser.NEQ)
-                && (originalToken.getType() == BIAPIQueryParser.STRING || originalToken.getType() == BIAPIQueryParser.QUOTED_STRING);
+                && (originalToken.getType() == BIAPIQueryParser.STRING
+                        || originalToken.getType() == BIAPIQueryParser.TEXT
+                        || originalToken.getType() == BIAPIQueryParser.QUOTED_STRING);
         Object value = coerceFromTokenMaybeSubstitute(valueObj);
         return switch (opTok.getType()) {
             case BIAPIQueryParser.EQ -> node -> compare(node, field, value, caseInsensitiveStringEquality);
@@ -344,7 +424,7 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
                 tokenOrValue = sub.replace(tok.getText());
             }
             switch (t) {
-                case BIAPIQueryParser.STRING, BIAPIQueryParser.QUOTED_STRING -> { return tok.getText(); }
+                case BIAPIQueryParser.STRING, BIAPIQueryParser.TEXT, BIAPIQueryParser.QUOTED_STRING -> { return tok.getText(); }
                 case BIAPIQueryParser.OID -> { return new ObjectId(tok.getText()); }
                 case BIAPIQueryParser.VARIABLE -> { String rep = (sub != null) ? sub.replace(tok.getText()) : tok.getText(); return coerceValue(rep); }
                 case BIAPIQueryParser.NUMBER -> { return Double.parseDouble(tok.getText()); }
@@ -400,6 +480,25 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
         return SPECIAL_REGEX_CHARS.matcher(input).replaceAll("\\\\$0");
     }
 
+    /**
+     * Tokenize a text(...) search string into lower-case word terms.
+     * Whitespace-separated; leading/trailing punctuation on each token is stripped.
+     */
+    static List<String> tokenizeSearchTerms(String search) {
+        if (search == null || search.isBlank()) return List.of();
+        return Arrays.stream(search.trim().split("\\s+"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.replaceAll("^[\\p{Punct}]+|[\\p{Punct}]+$", ""))
+                .filter(s -> !s.isEmpty())
+                .map(String::toLowerCase)
+                .toList();
+    }
+
+    /**
+     * In-memory approximation of MongoDB $text: tokenized contains-any with
+     * whole-word matching (not substring). Does not implement stemming/stop words.
+     */
     private boolean matchesTextSearch(JsonNode node, List<String> terms) {
         if (node == null || terms == null || terms.isEmpty()) return false;
         List<String> values = new ArrayList<>();
@@ -407,9 +506,20 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
         if (values.isEmpty()) return false;
         for (String term : terms) {
             for (String value : values) {
-                if (value.toLowerCase().contains(term)) {
+                if (valueHasWord(value, term)) {
                     return true;
                 }
+            }
+        }
+        return false;
+    }
+
+    /** True if {@code value} contains {@code term} as a whole word (case-insensitive). */
+    static boolean valueHasWord(String value, String term) {
+        if (value == null || term == null || term.isEmpty()) return false;
+        for (String word : WORD_SPLIT.split(value.toLowerCase())) {
+            if (!word.isEmpty() && word.equals(term)) {
+                return true;
             }
         }
         return false;
@@ -560,7 +670,7 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
         if (list != null && list.children != null) {
             long varCount = list.children.stream().filter(c -> c instanceof org.antlr.v4.runtime.tree.TerminalNode tn && tn.getSymbol().getType() == BIAPIQueryParser.VARIABLE).count();
             long valCount = list.children.stream().filter(c -> c instanceof org.antlr.v4.runtime.tree.TerminalNode tn && switch (tn.getSymbol().getType()) {
-                case BIAPIQueryParser.STRING, BIAPIQueryParser.QUOTED_STRING, BIAPIQueryParser.VARIABLE, BIAPIQueryParser.OID, BIAPIQueryParser.REFERENCE -> true; default -> false; }).count();
+                case BIAPIQueryParser.STRING, BIAPIQueryParser.TEXT, BIAPIQueryParser.QUOTED_STRING, BIAPIQueryParser.VARIABLE, BIAPIQueryParser.OID, BIAPIQueryParser.REFERENCE -> true; default -> false; }).count();
             singleVarOnly = (varCount == 1 && valCount == 1);
         }
         if (singleVarOnly && sub != null) {
@@ -580,7 +690,7 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
                 int t = tn.getSymbol().getType();
                 switch (t) {
                     case BIAPIQueryParser.QUOTED_STRING -> values.add(tn.getText());
-                    case BIAPIQueryParser.STRING -> values.add(coerceValue(tn.getText()));
+                    case BIAPIQueryParser.STRING, BIAPIQueryParser.TEXT -> values.add(coerceValue(tn.getText()));
                     case BIAPIQueryParser.OID -> values.add(new ObjectId(tn.getText()));
                     case BIAPIQueryParser.REFERENCE -> values.add(tn.getText());
                     case BIAPIQueryParser.VARIABLE -> { String replaced = (sub != null) ? sub.replace(tn.getText()) : tn.getText(); if (replaced != null && !replaced.isBlank()) for (String part : replaced.split(",")) values.add(coerceValue(part.trim())); }

--- a/quantum-framework/src/test/java/com/e2eq/framework/query/QueryToPredicateJsonListenerTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/query/QueryToPredicateJsonListenerTest.java
@@ -169,6 +169,30 @@ public class QueryToPredicateJsonListenerTest {
     }
 
     @Test
+    void testTextSearchUsesWordBoundariesNotSubstrings() {
+        // MongoDB $text is word-oriented; in-memory must not match substrings.
+        JsonNode category = nodeOf(Map.of("title", "category"));
+        JsonNode cat = nodeOf(Map.of("title", "cat"));
+        JsonNode catInSentence = nodeOf(Map.of("title", "the cat sat"));
+
+        assertFalse(pred("text(\"cat\")").test(category));
+        assertTrue(pred("text(\"cat\")").test(cat));
+        assertTrue(pred("text(\"cat\")").test(catInSentence));
+    }
+
+    @Test
+    void testTextKeywordAsFieldAndValueStillParses() {
+        // TEXT is a lexer keyword for text(...), but "text" remains a valid
+        // unquoted field name / value so existing queries keep working.
+        JsonNode n = nodeOf(Map.of("type", "text", "text", "active"));
+
+        assertTrue(pred("type:text").test(n));
+        assertTrue(pred("text:active").test(n));
+        assertTrue(pred("type:^ [text]").test(n));
+        assertFalse(pred("type:plain").test(n));
+    }
+
+    @Test
     void testTextSearchCombinedWithOtherFilters() {
         Map<String, Object> m = Map.of(
                 "title", "Priority Escalation Runbook",
@@ -178,12 +202,43 @@ public class QueryToPredicateJsonListenerTest {
 
         assertTrue(pred("text(\"priority escalation\")&&status:OPEN").test(n));
         assertFalse(pred("text(\"priority escalation\")&&status:CLOSED").test(n));
+        // Valid: text at top level AND'd with an OR group of non-text predicates
+        assertTrue(pred("text(\"priority\")&&(status:OPEN||status:CLOSED)").test(n));
     }
 
     @Test
     void testDuplicateTextSearchThrows() {
         IllegalStateException ex = assertThrows(IllegalStateException.class,
                 () -> pred("text(\"one\")&&text(\"two\")"));
-        assertTrue(ex.getMessage().contains("text"));
+        assertTrue(ex.getMessage().toLowerCase().contains("multiple"));
+    }
+
+    @Test
+    void testTextInsideNotThrows() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> pred("!!text(\"foo\")"));
+        assertTrue(ex.getMessage().contains("text(...)"));
+        assertTrue(ex.getMessage().contains("NOT") || ex.getMessage().toLowerCase().contains("negat"));
+    }
+
+    @Test
+    void testTextInsideOrThrows() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> pred("text(\"foo\")||status:OPEN"));
+        assertTrue(ex.getMessage().toLowerCase().contains("or"));
+    }
+
+    @Test
+    void testTextInsideElemMatchThrows() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> pred("tags:{text(\"foo\")}"));
+        assertTrue(ex.getMessage().toLowerCase().contains("elemmatch"));
+    }
+
+    @Test
+    void testEmptyTextSearchThrows() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> pred("text(\"\")"));
+        assertTrue(ex.getMessage().toLowerCase().contains("empty") || ex.getMessage().contains("non-empty"));
     }
 }

--- a/quantum-framework/src/test/resources/testQueryStrings.txt
+++ b/quantum-framework/src/test/resources/testQueryStrings.txt
@@ -170,3 +170,8 @@ hasEdge(placedInOrg, ORG-ACME)
 #-- Text search
 text("priority escalation")
 text("priority escalation")&&status:"OPEN"
+type:text
+text:active
+type:^ [text]
+text("search")&&(status:OPEN||status:PENDING)
+text("cat")

--- a/quantum-models/src/main/antlr4/com/e2eq/framework/grammar/BIAPIQuery.g4
+++ b/quantum-models/src/main/antlr4/com/e2eq/framework/grammar/BIAPIQuery.g4
@@ -5,60 +5,66 @@ exprGroup: lp=LPAREN (exprGroup | compoundExpr) (exprOp (exprGroup | compoundExp
 compoundExpr: allowedExpr (exprOp allowedExpr)*;
 allowedExpr:   inExpr |  basicExpr |  nullExpr | existsExpr | booleanExpr | notExpr | regexExpr | elemMatchExpr | hasEdgeExpr | hasOutgoingEdgeExpr | hasIncomingEdgeExpr | expandExpr | textExpr;
 exprOp: op=(AND | OR);
-existsExpr: field=STRING op=EXISTS;
-booleanExpr: field=STRING op=(EQ | NEQ) value=(TRUE | FALSE);
-inExpr : field=STRING op=(IN|NIN) value=valueListExpr;
+
+// TEXT is a lexer keyword so text(...) can be recognized, but "text" is also a common
+// field name / unquoted value (e.g. type:text). Allow TEXT wherever STRING may appear
+// as an identifier so those queries remain valid.
+existsExpr: field=(STRING|TEXT) op=EXISTS;
+booleanExpr: field=(STRING|TEXT) op=(EQ | NEQ) value=(TRUE | FALSE);
+inExpr : field=(STRING|TEXT) op=(IN|NIN) value=valueListExpr;
 valueListExpr:
     lp=LBRKT
-    value=(STRING | QUOTED_STRING | VARIABLE | OID | REFERENCE) (COMMA value=(STRING | QUOTED_STRING | VARIABLE | OID | REFERENCE))*
+    value=(STRING | TEXT | QUOTED_STRING | VARIABLE | OID | REFERENCE) (COMMA value=(STRING | TEXT | QUOTED_STRING | VARIABLE | OID | REFERENCE))*
     rp=RBRKT;
 
-basicExpr: field=STRING op=(EQ|NEQ|LT|GT|LTE|GTE|EXISTS|IN) value=(STRING|VARIABLE|OID) caseMode? #stringExpr
-| field=STRING op=(EQ | NEQ ) value=QUOTED_STRING caseMode? #quotedExpr
-| field=STRING op=(EQ | LT | GT | NEQ | LTE | GTE) value=NUMBER #numberExpr
-| field=STRING op=(EQ | LT | GT | NEQ | LTE | GTE) value=WHOLENUMBER #wholenumberExpr
-| field=STRING op=(EQ | LT | GT | NEQ | LTE | GTE) value=DATE #dateExpr
-| field=STRING op=(EQ | LT | GT | NEQ | LTE | GTE) value=DATETIME #dateTimeExpr
-| field=STRING op=(EQ | NEQ) value=REFERENCE #referenceExpr;
+basicExpr: field=(STRING|TEXT) op=(EQ|NEQ|LT|GT|LTE|GTE|EXISTS|IN) value=(STRING|TEXT|VARIABLE|OID) caseMode? #stringExpr
+| field=(STRING|TEXT) op=(EQ | NEQ ) value=QUOTED_STRING caseMode? #quotedExpr
+| field=(STRING|TEXT) op=(EQ | LT | GT | NEQ | LTE | GTE) value=NUMBER #numberExpr
+| field=(STRING|TEXT) op=(EQ | LT | GT | NEQ | LTE | GTE) value=WHOLENUMBER #wholenumberExpr
+| field=(STRING|TEXT) op=(EQ | LT | GT | NEQ | LTE | GTE) value=DATE #dateExpr
+| field=(STRING|TEXT) op=(EQ | LT | GT | NEQ | LTE | GTE) value=DATETIME #dateTimeExpr
+| field=(STRING|TEXT) op=(EQ | NEQ) value=REFERENCE #referenceExpr;
 
 notExpr: NOT allowedExpr;
 
-regex: ((leftW=WILDCARD value=STRING rightW=WILDCARD)
+regex: ((leftW=WILDCARD value=(STRING|TEXT) rightW=WILDCARD)
 | (leftW=WILDCARD value=QUOTED_STRING rightW=WILDCARD)
-| (leftW=WILDCARD value=STRING)
+| (leftW=WILDCARD value=(STRING|TEXT))
 | (leftW=WILDCARD value=QUOTED_STRING)
-| (value=STRING rightW=WILDCARD)
+| (value=(STRING|TEXT) rightW=WILDCARD)
 | (value=QUOTED_STRING rightW=WILDCARD)) caseMode?;
 
 caseMode: CASE_SENSITIVE | CASE_INSENSITIVE;
 
-regexExpr: field=STRING op=(EQ | NEQ) regex;
+regexExpr: field=(STRING|TEXT) op=(EQ | NEQ) regex;
 
-nullExpr: field=STRING op=(EQ | NEQ) value=NULL;
+nullExpr: field=(STRING|TEXT) op=(EQ | NEQ) value=NULL;
 
-elemMatchExpr: field=STRING op=EQ lp=LBRCE nested=query rp=RBRCE;
+elemMatchExpr: field=(STRING|TEXT) op=EQ lp=LBRCE nested=query rp=RBRCE;
 
 // Ontology functions
 // hasEdge(predicate, dst) - find entities that have outgoing edges TO the given destination
 // Example: hasEdge(assignedTo, territoryId) finds associates assigned to that territory
-hasEdgeExpr: HASEDGE LPAREN predicate=(STRING|QUOTED_STRING|VARIABLE) COMMA dst=(STRING|QUOTED_STRING|VARIABLE|OID|REFERENCE) RPAREN;
+hasEdgeExpr: HASEDGE LPAREN predicate=(STRING|TEXT|QUOTED_STRING|VARIABLE) COMMA dst=(STRING|TEXT|QUOTED_STRING|VARIABLE|OID|REFERENCE) RPAREN;
 // hasOutgoingEdge(predicate, dst) - alias for hasEdge for symmetry with hasIncomingEdge
 // Example: hasOutgoingEdge(assignedTo, territoryId) finds associates assigned to that territory
-hasOutgoingEdgeExpr: HASOUTGOINGEDGE LPAREN predicate=(STRING|QUOTED_STRING|VARIABLE) COMMA dst=(STRING|QUOTED_STRING|VARIABLE|OID|REFERENCE) RPAREN;
+hasOutgoingEdgeExpr: HASOUTGOINGEDGE LPAREN predicate=(STRING|TEXT|QUOTED_STRING|VARIABLE) COMMA dst=(STRING|TEXT|QUOTED_STRING|VARIABLE|OID|REFERENCE) RPAREN;
 // hasIncomingEdge(predicate, src) - find entities that the given source has edges TO (inverse direction)
 // Example: hasIncomingEdge(canSeeLocation, associateId) finds locations the associate can see
-hasIncomingEdgeExpr: HASINCOMGINEDGE LPAREN predicate=(STRING|QUOTED_STRING|VARIABLE) COMMA src=(STRING|QUOTED_STRING|VARIABLE|OID|REFERENCE) RPAREN;
+hasIncomingEdgeExpr: HASINCOMGINEDGE LPAREN predicate=(STRING|TEXT|QUOTED_STRING|VARIABLE) COMMA src=(STRING|TEXT|QUOTED_STRING|VARIABLE|OID|REFERENCE) RPAREN;
 
 // Expansion directive (parsed but evaluation is handled elsewhere)
 // Support simple dotted paths and optional array wildcards [*] between segments.
 // Tokens come in as: STRING ('[' '*' ']')? (STRING ('[' '*' ']')? )*
-expandExpr: EXPAND LPAREN head=(STRING|VARIABLE) (LBRKT WILDCARD RBRKT)? ((seg=(STRING|VARIABLE)) (LBRKT WILDCARD RBRKT)? )* RPAREN;
-textExpr: TEXT LPAREN value=(STRING|QUOTED_STRING|VARIABLE) RPAREN;
+expandExpr: EXPAND LPAREN head=(STRING|TEXT|VARIABLE) (LBRKT WILDCARD RBRKT)? ((seg=(STRING|TEXT|VARIABLE)) (LBRKT WILDCARD RBRKT)? )* RPAREN;
+textExpr: TEXT LPAREN value=(STRING|TEXT|QUOTED_STRING|VARIABLE) RPAREN;
 
 HASEDGE: 'hasEdge';
 HASOUTGOINGEDGE: 'hasOutgoingEdge';
 HASINCOMGINEDGE: 'hasIncomingEdge';
 EXPAND: 'expand';
+// Must be declared before STRING so "text" is tokenized as TEXT (function keyword).
+// Field/value positions also accept TEXT so type:text and text:active remain valid.
 TEXT: 'text';
 CASE_SENSITIVE: '~cs';
 CASE_INSENSITIVE: '~ci';

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListener.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListener.java
@@ -274,7 +274,8 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
 
     private void registerTextClause() {
         if (textClauseSeen) {
-            throw new IllegalStateException("Multiple text(...) clauses are not supported in a single query.");
+            throw new IllegalStateException(
+                "Multiple text(...) clauses are not supported in a single query; MongoDB allows only one $text operator per query.");
         }
         // MongoDB requires $text to be a top-level query operator.
         // It cannot be nested inside $not/$nor or $elemMatch.
@@ -721,6 +722,7 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
                               .filter(c -> c instanceof org.antlr.v4.runtime.tree.TerminalNode tn &&
                                               switch (tn.getSymbol().getType()) {
                                                  case BIAPIQueryParser.STRING,
+                                                      BIAPIQueryParser.TEXT,
                                                       BIAPIQueryParser.QUOTED_STRING,
                                                       BIAPIQueryParser.VARIABLE,
                                                       BIAPIQueryParser.OID,
@@ -793,8 +795,10 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
                   values.add(coerceValue(new StringLiteral(tn.getText())));
                   break;
                }
-               case BIAPIQueryParser.STRING: {
+               case BIAPIQueryParser.STRING:
+               case BIAPIQueryParser.TEXT: {
                   // Allow coercion (numbers, booleans, dates, ObjectId, etc.)
+                  // TEXT is the keyword token for "text" used as an unquoted value.
                   values.add(coerceValue(tn.getText()));
                   break;
                }
@@ -979,11 +983,15 @@ public class QueryToFilterListener extends BIAPIQueryBaseListener {
         caseInsensitiveStringEquality = originalToken != null
                 && !caseSensitive
                 && (op.getType() == BIAPIQueryParser.EQ || op.getType() == BIAPIQueryParser.NEQ)
-                && (originalToken.getType() == BIAPIQueryParser.STRING || originalToken.getType() == BIAPIQueryParser.QUOTED_STRING);
+                && (originalToken.getType() == BIAPIQueryParser.STRING
+                        || originalToken.getType() == BIAPIQueryParser.TEXT
+                        || originalToken.getType() == BIAPIQueryParser.QUOTED_STRING);
 
         if (value instanceof CommonToken tok) {
             switch (tok.getType()) {
                 case BIAPIQueryParser.STRING:
+                case BIAPIQueryParser.TEXT:
+                    // TEXT is the keyword token for the literal "text" used as a field value.
                     value = tok.getText();
                     break;
                 case BIAPIQueryParser.QUOTED_STRING:

--- a/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListenerTextValidationTest.java
+++ b/quantum-morphia-repos/src/test/java/com/e2eq/framework/model/persistent/morphia/QueryToFilterListenerTextValidationTest.java
@@ -123,4 +123,45 @@ public class QueryToFilterListenerTextValidationTest {
         assertNotNull(f);
         assertEquals("$text", f.getName());
     }
+
+    @Test
+    public void testTextKeywordAsFieldAndValueStillParses() {
+        // TEXT is a lexer keyword for text(...), but unquoted "text" remains
+        // valid as a field name and as a comparison value.
+        Filter typeIsText = MorphiaUtils.convertToFilter("type:text", DummyModel.class);
+        assertNotNull(typeIsText);
+        // Case-insensitive string equality may be implemented as $eq or $regex.
+        assertTrue("$eq".equals(typeIsText.getName()) || "$regex".equals(typeIsText.getName()),
+            "Expected equality/regex filter for type:text, got: " + typeIsText.getName());
+
+        Filter textField = MorphiaUtils.convertToFilter("text:active", DummyModel.class);
+        assertNotNull(textField);
+        assertTrue("$eq".equals(textField.getName()) || "$regex".equals(textField.getName()),
+            "Expected equality/regex filter for text:active, got: " + textField.getName());
+
+        Filter inList = MorphiaUtils.convertToFilter("type:^ [text]", DummyModel.class);
+        assertNotNull(inList);
+        assertEquals("$in", inList.getName());
+    }
+
+    @Test
+    public void testTextCombinedWithAndAndGroupedOr() {
+        // Valid MongoDB shape: top-level $text AND'd with a nested non-text OR
+        String q = "text(\"search\")&&(status:OPEN||status:PENDING)";
+        Filter f = MorphiaUtils.convertToFilter(q, DummyModel.class);
+        assertNotNull(f);
+        String filterStr = f.toString();
+        assertTrue(filterStr.contains("$text") || "$and".equals(f.getName()) || "$text".equals(f.getName()),
+            "Expected combined filter containing $text: " + filterStr);
+    }
+
+    @Test
+    public void testTextInsideOrThrows() {
+        String q = "text(\"foo\")||status:OPEN";
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+            MorphiaUtils.convertToFilter(q, DummyModel.class);
+        });
+        assertTrue(ex.getMessage().toLowerCase().contains("or") || ex.getMessage().contains("text(...)"),
+            "Error should mention OR or text(): " + ex.getMessage());
+    }
 }


### PR DESCRIPTION
## Summary
Closes out the open review findings from the superseded text-search design/implementation work (PR #35) on the `1.4.2-SNAPSHOT` line:

- **TEXT keyword collision**: accept the `TEXT` lexer token as a normal field name / unquoted value (and IN-list member) so queries like `type:text` and `text:active` still parse while `text(...)` remains the function form.
- **In-memory word matching**: switch from substring `contains` to whole-word token matching so `text("cat")` no longer matches `"category"` (closer parity with MongoDB `$text`).
- **In-memory validation parity**: reject `text(...)` inside NOT, OR, and elemMatch the same way Morphia already does; keep empty / multi-clause rejection.
- **Docs**: refresh the design doc (paths, variable example, tokenization, missing-index behavior, testing) and the user-guide text-search section.

## Test plan
- [x] `mvn -pl quantum-models,quantum-framework,quantum-morphia-repos -am test -Dtest=QueryToPredicateJsonListenerTest,QueryToFilterListenerTextValidationTest,TestGrammar -Dsurefire.failIfNoSpecifiedTests=false`
- [x] Grammar samples include `type:text`, `text:active`, `type:^ [text]`, and `text(...)&&(a||b)`
- [ ] Spot-check a collection with a text index: `text("term") && status:OPEN`
- [ ] Confirm `type:text` / `text:active` still work in an app filter if used