### PR TITLE
fix(ontology): PR #49 calculated-relations review follow-ups

### DIFF
--- a/quantum-docs/src/docs/asciidoc/design/calculated-relations-roadmap.adoc
+++ b/quantum-docs/src/docs/asciidoc/design/calculated-relations-roadmap.adoc
@@ -28,8 +28,10 @@ the current implementation, proposes targeted enhancements, and sequences them
 into a phased roadmap.
 
 For a usage-level introduction to ontology relationships, see
-`user-guide/ontology.adoc`. For the territory/location reference
-implementation, see `implementing-territory-location-edges.md`.
+xref:../user-guide/ontology.adoc[user-guide/ontology.adoc]
+(including the Territory → Location computed-edge example under
+_Custom Edge Providers_). A longer narrative guide also lives at
+link:../../implementing-territory-location-edges.md[`quantum-docs/src/docs/implementing-territory-location-edges.md`].
 
 == Background
 
@@ -79,8 +81,11 @@ edge sets grow:
   hierarchy node, node carries list of targets" pattern is implemented by
   hand in every provider, even though `HierarchyListEdgeProvider` already
   shapes the structure.
-. *No automatic cycle/depth guards in compute.* The reasoner caps iteration
-  at 10, but provider-side compute relies on the implementer to terminate.
+. *No automatic cycle/depth guards in compute.* The reasoner
+  (`ForwardChainingReasoner`) guards transitive expansion with
+  `MAX_TRANSITIVE_STEP_VISITS = 10_000` (visit budget, not a 10-iteration
+  cap), but provider-side compute historically relied on the implementer
+  to terminate (addressed by D4).
 . *Provenance bloat.* Per-edge provenance maps are stored inline on every
   `EdgeRecord`, inflating the working set for high-fanout providers.
 . *No bulk recompute / reconciliation tool.* When provider logic changes,
@@ -119,8 +124,9 @@ edge sets grow:
 * `ComputedEdgeCache` (per-process TTL'd map) at `quantum-ontology-core/.../core/ComputedEdgeCache.java`.
 * `OntologyWriteHook` skips non-EAGER providers at write time.
 * `ComputedEdgeReader` (in `quantum-ontology-mongo`) is the read-side
-  facade; `ComputedEdgeRecomputeHandler` punches the cache for LAZY and
-  no-ops for ONDEMAND on dependency changes.
+  facade for source-keyed *and* destination-keyed lookups used by
+  policy/`hasEdge` rewrites; `ComputedEdgeRecomputeHandler` punches the
+  cache for LAZY and no-ops for ONDEMAND on dependency changes.
 ====
 
 Add a `MaterializationMode` enum returned by a new
@@ -135,15 +141,37 @@ public enum MaterializationMode {
 }
 ----
 
-`OntologyEdgeRepo` gains a thin facade that, for `LAZY`/`ONDEMAND` providers,
-short-circuits a `findBySrcAndP` to the provider rather than the collection.
-The `LAZY` cache lives in a `ComputedEdgeCache` (Caffeine, per-realm,
-TTL-configurable per provider). Cache invalidation reuses the existing
+`ComputedEdgeReader` is the mode-aware facade. Callers that need correctness
+across all modes must use it (or APIs wired through it) rather than
+`OntologyEdgeRepo` alone:
+
+* *Source-keyed reads* (`edgesFor` / `dstIdsBySrc`): for `LAZY`/`ONDEMAND`,
+  short-circuit to the provider (with TTL cache for `LAZY`) instead of the
+  collection.
+* *Destination-keyed reads* (`srcIdsByDst`, used by `hasEdge` /
+  `ListQueryRewriter`, MCP incoming-graph tools, and similar): for
+  `LAZY`/`ONDEMAND`, enumerate candidate sources via
+  `SourceEntityEnumerator`, compute provider edges, and union with any
+  EAGER rows still in `ontology_edges`. Without an enumerator, inverse
+  results fall back to store-only and log a warning (incomplete for pure
+  LAZY providers).
+* `OntologyEdgeRepo` remains the pure store. Direct repo reads do *not*
+  see unmaterialized LAZY/ONDEMAND edges.
+
+The `LAZY` cache lives in a `ComputedEdgeCache` (per-process, TTL-
+configurable per provider). Cache invalidation reuses the existing
 `getAffectedSourceIds` machinery.
 
-*Acceptance:* an existing provider can opt into `LAZY` by overriding one
-method; reads return the same edges as before; writes that previously fanned
-out N edges no longer write any rows for that provider.
+*Acceptance:*
+
+* An existing provider can opt into `LAZY` by overriding one method.
+* Source-keyed and destination-keyed reads return the same edges as the
+  EAGER path when a `SourceEntityEnumerator` (and source loader) is
+  registered for the provider's source type.
+* Writes that previously fanned out N edges no longer write any rows for
+  that provider.
+* Inverse enumeration is bounded (visit budget) and may be expensive;
+  prefer `EAGER` when destination-side policy filters are hot paths.
 
 === D2. Dependency Validation and Loud Staleness
 
@@ -471,8 +499,11 @@ a|
   static/dynamic list machinery?
 . Should the recompute CLI emit an idempotent ledger so re-runs converge,
   or is the diff-and-apply path sufficient?
+. Should inverse LAZY scans maintain a secondary index (dst → src) instead
+  of enumerating sources on each `srcIdsByDst` call?
 
-These are deferred to the design discussion at the start of M1.
+These are deferred to design discussion as follow-ups after the initial
+modes land.
 
 == Out of Scope (For Now)
 

--- a/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/MaterializationMode.java
+++ b/quantum-ontology-core/src/main/java/com/e2eq/ontology/core/MaterializationMode.java
@@ -16,6 +16,15 @@ package com.e2eq.ontology.core;
  *       provider. Choose this only for inexpensive providers where freshness
  *       beats latency.</li>
  * </ul>
+ *
+ * <p><b>Read-path requirement:</b> LAZY and ONDEMAND edges are invisible to
+ * direct {@code OntologyEdgeRepo} queries. Callers that need the same edges
+ * for both source-keyed and destination-keyed lookups (including
+ * {@code hasEdge} / policy rewrites that use {@code srcIdsByDst}) must go
+ * through the mode-aware read facade ({@code ComputedEdgeReader}) with a
+ * registered source-entity loader and, for inverse lookups, a
+ * {@code SourceEntityEnumerator}. Prefer EAGER when destination-side filters
+ * are on a hot path.</p>
  */
 public enum MaterializationMode {
     EAGER,

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -7,6 +7,7 @@ import com.e2eq.ontology.model.OntologyEdge;
 import com.e2eq.ontology.repo.OntologyEdgeRepo;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import java.util.*;
@@ -26,19 +27,47 @@ import java.util.*;
  *
  * <p>For {@code LAZY} and {@code ONDEMAND}, source-entity loading uses the
  * {@link ComputedEdgeRecomputeHandler.SourceEntityLoader} that the application
- * registers at startup.</p>
+ * registers at startup. Destination-keyed lookups additionally need a
+ * {@link SourceEntityEnumerator} so candidate sources can be walked when no
+ * rows exist in {@code ontology_edges}.</p>
  *
- * <p>Callers that don't care about mode can keep using the repo directly; this
- * facade is the right entry when correctness across all modes matters.</p>
+ * <p><b>Why this facade exists:</b> policy rewrites ({@code hasEdge} /
+ * {@code ListQueryRewriter}), MCP graph tools, and similar callers query edges
+ * both by source ({@code findBySrcAndP} / {@code dstIdsBySrc}) and by
+ * destination ({@code findByDst*} / {@code srcIdsByDst}). Pure repo reads miss
+ * unmaterialized LAZY/ONDEMAND edges. Use this facade (or APIs wired through
+ * it) whenever correctness across all materialization modes matters.</p>
  */
 @ApplicationScoped
 public class ComputedEdgeReader {
+
+    /** Hard cap on source IDs walked for a single inverse LAZY/ONDEMAND query. */
+    public static final int DEFAULT_INVERSE_SOURCE_SCAN_LIMIT = 10_000;
 
     @Inject ComputedEdgeRegistry registry;
     @Inject ComputedEdgeRecomputeHandler recomputeHandler;
     @Inject OntologyEdgeRepo edgeRepo;
     @Inject ComputedEdgeCache cache;
     @Inject OntologyMetrics metrics;
+    @Inject Instance<SourceEntityEnumerator> enumerators;
+
+    /** CDI */
+    public ComputedEdgeReader() {}
+
+    /** Test-friendly constructor. */
+    ComputedEdgeReader(ComputedEdgeRegistry registry,
+                       ComputedEdgeRecomputeHandler recomputeHandler,
+                       OntologyEdgeRepo edgeRepo,
+                       ComputedEdgeCache cache,
+                       OntologyMetrics metrics,
+                       Instance<SourceEntityEnumerator> enumerators) {
+        this.registry = registry;
+        this.recomputeHandler = recomputeHandler;
+        this.edgeRepo = edgeRepo;
+        this.cache = cache;
+        this.metrics = metrics;
+        this.enumerators = enumerators;
+    }
 
     /** Edges produced by {@code provider} for {@code sourceId} under {@code dataDomain}. */
     @SuppressWarnings("unchecked")
@@ -81,6 +110,81 @@ public class ComputedEdgeReader {
     }
 
     /**
+     * Destination IDs reachable from {@code sourceId} via {@code predicate},
+     * unioning EAGER store rows with LAZY/ONDEMAND provider computation.
+     */
+    public Set<String> dstIdsBySrc(String realmId, DataDomain dataDomain,
+                                   String predicate, String sourceId) {
+        Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(sourceId, "sourceId");
+
+        Set<String> ids = new LinkedHashSet<>(edgeRepo.dstIdsBySrc(dataDomain, predicate, sourceId));
+        for (ComputedEdgeProvider<?> provider : providersForPredicate(predicate)) {
+            if (provider.getMaterializationMode() == MaterializationMode.EAGER) {
+                continue; // already represented in the store (when write path ran)
+            }
+            for (Reasoner.Edge e : edgesFor(realmId, dataDomain, provider, sourceId)) {
+                if (predicate.equals(e.p()) && sourceId.equals(e.srcId()) && e.dstId() != null) {
+                    ids.add(e.dstId());
+                }
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Source IDs that have an edge with {@code predicate} pointing to {@code dstId}.
+     *
+     * <p>Unions store rows with LAZY/ONDEMAND providers. Non-EAGER providers require a
+     * {@link SourceEntityEnumerator} for their source type; without one, only store
+     * rows are returned and a warning is logged (policy {@code hasEdge} would otherwise
+     * silently miss computed edges).</p>
+     */
+    public Set<String> srcIdsByDst(String realmId, DataDomain dataDomain,
+                                   String predicate, String dstId) {
+        return srcIdsByDst(realmId, dataDomain, predicate, dstId, DEFAULT_INVERSE_SOURCE_SCAN_LIMIT);
+    }
+
+    public Set<String> srcIdsByDst(String realmId, DataDomain dataDomain,
+                                   String predicate, String dstId, int sourceScanLimit) {
+        Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(dstId, "dstId");
+        int limit = Math.max(1, sourceScanLimit);
+
+        Set<String> ids = new LinkedHashSet<>(edgeRepo.srcIdsByDst(dataDomain, predicate, dstId));
+        for (ComputedEdgeProvider<?> provider : providersForPredicate(predicate)) {
+            if (provider.getMaterializationMode() == MaterializationMode.EAGER) {
+                continue;
+            }
+            ids.addAll(srcIdsByDstFromProvider(realmId, dataDomain, provider, dstId, limit));
+        }
+        return ids;
+    }
+
+    /**
+     * Bulk form of {@link #srcIdsByDst(String, DataDomain, String, String)} for a set of destinations.
+     */
+    public Set<String> srcIdsByDstIn(String realmId, DataDomain dataDomain,
+                                     String predicate, Collection<String> dstIds) {
+        if (dstIds == null || dstIds.isEmpty()) return Set.of();
+        Set<String> ids = new LinkedHashSet<>(edgeRepo.srcIdsByDstIn(dataDomain, predicate, dstIds));
+        Set<String> wanted = new HashSet<>(dstIds);
+        for (ComputedEdgeProvider<?> provider : providersForPredicate(predicate)) {
+            if (provider.getMaterializationMode() == MaterializationMode.EAGER) {
+                continue;
+            }
+            for (String srcId : enumerateSourceIds(realmId, dataDomain, provider, DEFAULT_INVERSE_SOURCE_SCAN_LIMIT)) {
+                for (Reasoner.Edge e : edgesFor(realmId, dataDomain, provider, srcId)) {
+                    if (predicate.equals(e.p()) && e.dstId() != null && wanted.contains(e.dstId()) && e.srcId() != null) {
+                        ids.add(e.srcId());
+                    }
+                }
+            }
+        }
+        return ids;
+    }
+
+    /**
      * Invalidate the cached entry for a (provider, source) pair.
      * No-op for non-LAZY providers.
      */
@@ -91,6 +195,73 @@ public class ComputedEdgeReader {
     }
 
     // ────────── internal ──────────
+
+    private List<ComputedEdgeProvider<?>> providersForPredicate(String predicate) {
+        List<ComputedEdgeProvider<?>> out = new ArrayList<>();
+        for (ComputedEdgeProvider<?> p : registry.getAllProviders()) {
+            if (predicate.equals(p.getPredicate())) {
+                out.add(p);
+            }
+        }
+        return out;
+    }
+
+    private Set<String> srcIdsByDstFromProvider(String realmId, DataDomain dataDomain,
+                                                ComputedEdgeProvider<?> provider,
+                                                String dstId, int sourceScanLimit) {
+        Set<String> ids = new LinkedHashSet<>();
+        for (String srcId : enumerateSourceIds(realmId, dataDomain, provider, sourceScanLimit)) {
+            for (Reasoner.Edge e : edgesFor(realmId, dataDomain, provider, srcId)) {
+                if (dstId.equals(e.dstId()) && e.srcId() != null) {
+                    ids.add(e.srcId());
+                }
+            }
+        }
+        return ids;
+    }
+
+    private List<String> enumerateSourceIds(String realmId, DataDomain dataDomain,
+                                            ComputedEdgeProvider<?> provider, int sourceScanLimit) {
+        SourceEntityEnumerator enumerator = pickEnumerator(provider.getSourceType());
+        if (enumerator == null) {
+            Log.warnf(
+                    "ComputedEdgeReader: no SourceEntityEnumerator for %s (provider %s, mode %s). " +
+                    "Destination-keyed reads (srcIdsByDst / hasEdge) will miss unmaterialized edges. " +
+                    "Register an enumerator or use MaterializationMode.EAGER for this predicate.",
+                    provider.getSourceType().getName(),
+                    provider.getProviderId(),
+                    provider.getMaterializationMode());
+            return List.of();
+        }
+
+        List<String> all = new ArrayList<>();
+        String after = null;
+        int pageSize = Math.min(500, sourceScanLimit);
+        while (all.size() < sourceScanLimit) {
+            int remaining = sourceScanLimit - all.size();
+            List<String> page = enumerator.listIds(
+                    realmId, dataDomain, provider.getSourceType(), after, Math.min(pageSize, remaining));
+            if (page == null || page.isEmpty()) break;
+            all.addAll(page);
+            after = page.get(page.size() - 1);
+            if (page.size() < pageSize) break;
+        }
+        if (all.size() >= sourceScanLimit) {
+            Log.warnf(
+                    "ComputedEdgeReader: inverse source scan hit limit %d for provider %s predicate %s; " +
+                    "results may be incomplete. Prefer EAGER materialization for high-cardinality inverse queries.",
+                    sourceScanLimit, provider.getProviderId(), provider.getPredicate());
+        }
+        return all;
+    }
+
+    private SourceEntityEnumerator pickEnumerator(Class<?> sourceType) {
+        if (enumerators == null || enumerators.isUnsatisfied()) return null;
+        for (SourceEntityEnumerator e : enumerators) {
+            if (e.supports(sourceType)) return e;
+        }
+        return null;
+    }
 
     private List<Reasoner.Edge> readFromRepo(String realmId, DataDomain dataDomain,
                                              ComputedEdgeProvider<?> provider, String sourceId) {

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -77,6 +77,7 @@ public class ComputedEdgeReader {
                                         String sourceId) {
         Objects.requireNonNull(provider, "provider");
         Objects.requireNonNull(sourceId, "sourceId");
+        realmId = normalizeRealmId(realmId);
 
         MaterializationMode mode = provider.getMaterializationMode();
         switch (mode) {
@@ -111,14 +112,16 @@ public class ComputedEdgeReader {
 
     /**
      * Destination IDs reachable from {@code sourceId} via {@code predicate},
-     * unioning EAGER store rows with LAZY/ONDEMAND provider computation.
+     * unioning store rows (excluding stale non-EAGER provider rows) with
+     * LAZY/ONDEMAND provider computation.
      */
     public Set<String> dstIdsBySrc(String realmId, DataDomain dataDomain,
                                    String predicate, String sourceId) {
         Objects.requireNonNull(predicate, "predicate");
         Objects.requireNonNull(sourceId, "sourceId");
+        realmId = normalizeRealmId(realmId);
 
-        Set<String> ids = new LinkedHashSet<>(edgeRepo.dstIdsBySrc(dataDomain, predicate, sourceId));
+        Set<String> ids = storeDstIdsExcludingNonEager(dataDomain, predicate, sourceId);
         for (ComputedEdgeProvider<?> provider : providersForPredicate(predicate)) {
             if (provider.getMaterializationMode() == MaterializationMode.EAGER) {
                 continue; // already represented in the store (when write path ran)
@@ -135,10 +138,11 @@ public class ComputedEdgeReader {
     /**
      * Source IDs that have an edge with {@code predicate} pointing to {@code dstId}.
      *
-     * <p>Unions store rows with LAZY/ONDEMAND providers. Non-EAGER providers require a
-     * {@link SourceEntityEnumerator} for their source type; without one, only store
-     * rows are returned and a warning is logged (policy {@code hasEdge} would otherwise
-     * silently miss computed edges).</p>
+     * <p>Unions store rows with LAZY/ONDEMAND providers. Store rows attributed to a
+     * currently non-EAGER provider are excluded so a mode switch EAGER→LAZY/ONDEMAND
+     * does not keep granting access via stale materialized rows. Non-EAGER providers
+     * require a {@link SourceEntityEnumerator}; without one, only eligible store rows
+     * are returned and a warning is logged.</p>
      */
     public Set<String> srcIdsByDst(String realmId, DataDomain dataDomain,
                                    String predicate, String dstId) {
@@ -149,9 +153,10 @@ public class ComputedEdgeReader {
                                    String predicate, String dstId, int sourceScanLimit) {
         Objects.requireNonNull(predicate, "predicate");
         Objects.requireNonNull(dstId, "dstId");
+        realmId = normalizeRealmId(realmId);
         int limit = Math.max(1, sourceScanLimit);
 
-        Set<String> ids = new LinkedHashSet<>(edgeRepo.srcIdsByDst(dataDomain, predicate, dstId));
+        Set<String> ids = storeSrcIdsExcludingNonEager(dataDomain, predicate, dstId);
         for (ComputedEdgeProvider<?> provider : providersForPredicate(predicate)) {
             if (provider.getMaterializationMode() == MaterializationMode.EAGER) {
                 continue;
@@ -167,8 +172,12 @@ public class ComputedEdgeReader {
     public Set<String> srcIdsByDstIn(String realmId, DataDomain dataDomain,
                                      String predicate, Collection<String> dstIds) {
         if (dstIds == null || dstIds.isEmpty()) return Set.of();
-        Set<String> ids = new LinkedHashSet<>(edgeRepo.srcIdsByDstIn(dataDomain, predicate, dstIds));
+        realmId = normalizeRealmId(realmId);
         Set<String> wanted = new HashSet<>(dstIds);
+        Set<String> ids = new LinkedHashSet<>();
+        for (String dstId : wanted) {
+            ids.addAll(storeSrcIdsExcludingNonEager(dataDomain, predicate, dstId));
+        }
         for (ComputedEdgeProvider<?> provider : providersForPredicate(predicate)) {
             if (provider.getMaterializationMode() == MaterializationMode.EAGER) {
                 continue;
@@ -182,6 +191,16 @@ public class ComputedEdgeReader {
             }
         }
         return ids;
+    }
+
+    /**
+     * Normalize a realm/tenant id the same way {@code OntologyEdgeRepo} does:
+     * MongoDB database names cannot contain dots, so dots become hyphens.
+     * Package-visible for policy-bridge realm hints and tests.
+     */
+    public static String normalizeRealmId(String realmOrTenantId) {
+        if (realmOrTenantId == null || realmOrTenantId.isBlank()) return realmOrTenantId;
+        return realmOrTenantId.replace('.', '-');
     }
 
     /**
@@ -204,6 +223,56 @@ public class ComputedEdgeReader {
             }
         }
         return out;
+    }
+
+    /** Provider ids currently registered as LAZY/ONDEMAND for {@code predicate}. */
+    private Set<String> nonEagerProviderIds(String predicate) {
+        Set<String> ids = new HashSet<>();
+        for (ComputedEdgeProvider<?> p : providersForPredicate(predicate)) {
+            if (p.getMaterializationMode() != MaterializationMode.EAGER) {
+                ids.add(p.getProviderId());
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Store contribution for inverse queries: drop rows still attributed to a
+     * provider that is no longer EAGER (stale after an EAGER→LAZY/ONDEMAND switch).
+     */
+    private Set<String> storeSrcIdsExcludingNonEager(DataDomain dataDomain, String predicate, String dstId) {
+        Set<String> nonEager = nonEagerProviderIds(predicate);
+        if (nonEager.isEmpty()) {
+            return new LinkedHashSet<>(edgeRepo.srcIdsByDst(dataDomain, predicate, dstId));
+        }
+        List<OntologyEdge> rows = edgeRepo.findByDstAndP(dataDomain, dstId, predicate);
+        Set<String> ids = new LinkedHashSet<>();
+        for (OntologyEdge e : rows) {
+            if (isStaleNonEagerStoreRow(e, nonEager)) continue;
+            if (e.getSrc() != null) ids.add(e.getSrc());
+        }
+        return ids;
+    }
+
+    private Set<String> storeDstIdsExcludingNonEager(DataDomain dataDomain, String predicate, String sourceId) {
+        Set<String> nonEager = nonEagerProviderIds(predicate);
+        if (nonEager.isEmpty()) {
+            return new LinkedHashSet<>(edgeRepo.dstIdsBySrc(dataDomain, predicate, sourceId));
+        }
+        // Prefer realm-aware overload when possible; DataDomain-only path resolves realm internally.
+        List<OntologyEdge> rows = edgeRepo.findBySrcAndP(dataDomain, sourceId, predicate);
+        Set<String> ids = new LinkedHashSet<>();
+        for (OntologyEdge e : rows) {
+            if (isStaleNonEagerStoreRow(e, nonEager)) continue;
+            if (e.getDst() != null) ids.add(e.getDst());
+        }
+        return ids;
+    }
+
+    private static boolean isStaleNonEagerStoreRow(OntologyEdge e, Set<String> nonEagerProviderIds) {
+        if (e == null || nonEagerProviderIds.isEmpty()) return false;
+        String pid = extractProviderId(e.getProv());
+        return pid != null && nonEagerProviderIds.contains(pid);
     }
 
     private Set<String> srcIdsByDstFromProvider(String realmId, DataDomain dataDomain,

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeRepo.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/repo/OntologyEdgeRepo.java
@@ -761,6 +761,12 @@ public class OntologyEdgeRepo extends MorphiaRepo<OntologyEdge> {
     /**
      * Find source IDs for edges with given predicate pointing to destination, within the DataDomain.
      * Use case: hasEdge(predicate, dst) - find entities that have edges TO the given destination.
+     *
+     * <p><b>Materialization note:</b> this is a pure store read. LAZY/ONDEMAND
+     * computed edges that were never written to {@code ontology_edges} will not
+     * appear here. Callers that must honor all {@link com.e2eq.ontology.core.MaterializationMode}
+     * values should use {@code ComputedEdgeReader#srcIdsByDst} (wired through
+     * {@code ListQueryRewriter} for policy hasEdge rewrites).</p>
      */
     public Set<String> srcIdsByDst(DataDomain dataDomain, String p, String dst) {
         validateDataDomain(dataDomain);

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
@@ -1,0 +1,164 @@
+package com.e2eq.ontology.mongo;
+
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.ontology.core.ComputedEdgeCache;
+import com.e2eq.ontology.core.ComputedEdgeProvider;
+import com.e2eq.ontology.core.ComputedEdgeRegistry;
+import com.e2eq.ontology.core.MaterializationMode;
+import com.e2eq.ontology.metrics.OntologyMetrics;
+import com.e2eq.ontology.repo.OntologyEdgeRepo;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that destination-keyed and source-keyed reads honor LAZY/ONDEMAND
+ * providers (the PR #49 review gap: inverse hasEdge paths must not miss
+ * unmaterialized computed edges).
+ */
+public class ComputedEdgeReaderInverseTest {
+
+    private DataDomain domain;
+    private ComputedEdgeRegistry registry;
+    private OntologyEdgeRepo edgeRepo;
+    private ComputedEdgeReader reader;
+    private Map<String, SourceEntity> sources;
+
+    @BeforeEach
+    void setUp() {
+        domain = new DataDomain();
+        domain.setOrgRefName("org");
+        domain.setAccountNum("0001");
+        domain.setTenantId("tenant");
+        domain.setDataSegment(0);
+
+        registry = new ComputedEdgeRegistry();
+        edgeRepo = mock(OntologyEdgeRepo.class);
+        when(edgeRepo.srcIdsByDst(any(DataDomain.class), anyString(), anyString())).thenReturn(Set.of());
+        when(edgeRepo.srcIdsByDstIn(any(DataDomain.class), anyString(), any())).thenReturn(Set.of());
+        when(edgeRepo.dstIdsBySrc(any(DataDomain.class), anyString(), anyString())).thenReturn(Set.of());
+        when(edgeRepo.findBySrcAndP(anyString(), any(DataDomain.class), anyString(), anyString())).thenReturn(List.of());
+
+        sources = new ConcurrentHashMap<>();
+
+        LazyProvider provider = new LazyProvider();
+        registry.register(provider);
+
+        ComputedEdgeRecomputeHandler recompute = new ComputedEdgeRecomputeHandler();
+        recompute.setSourceEntityLoader((realmId, dd, type, id) -> Optional.ofNullable(sources.get(id)));
+
+        SourceEntityEnumerator enumerator = new SourceEntityEnumerator() {
+            @Override public boolean supports(Class<?> entityType) {
+                return SourceEntity.class.equals(entityType);
+            }
+            @Override public List<String> listIds(String realmId, DataDomain dataDomain,
+                                                  Class<?> entityType, String afterId, int limit) {
+                List<String> ids = sources.keySet().stream().sorted().toList();
+                int start = 0;
+                if (afterId != null) {
+                    int idx = ids.indexOf(afterId);
+                    start = idx < 0 ? ids.size() : idx + 1;
+                }
+                if (start >= ids.size()) return List.of();
+                return ids.subList(start, Math.min(ids.size(), start + limit));
+            }
+        };
+
+        reader = new ComputedEdgeReader(
+                registry,
+                recompute,
+                edgeRepo,
+                new ComputedEdgeCache(),
+                new OntologyMetrics(),
+                new SingleInstance<>(enumerator));
+    }
+
+    @Test
+    void srcIdsByDstIncludesLazyProviderEdgesNotInStore() {
+        sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A", "loc-B")));
+        sources.put("assoc-2", new SourceEntity("assoc-2", List.of("loc-B")));
+
+        Set<String> forA = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-A");
+        Set<String> forB = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-B");
+        Set<String> forZ = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-Z");
+
+        assertEquals(Set.of("assoc-1"), forA);
+        assertEquals(Set.of("assoc-1", "assoc-2"), forB);
+        assertTrue(forZ.isEmpty());
+    }
+
+    @Test
+    void dstIdsBySrcIncludesLazyProviderEdges() {
+        sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A", "loc-B")));
+
+        Set<String> dsts = reader.dstIdsBySrc("realm", domain, "canSeeLocation", "assoc-1");
+        assertEquals(Set.of("loc-A", "loc-B"), dsts);
+    }
+
+    @Test
+    void srcIdsByDstUnionsStoreEagerRowsWithLazy() {
+        sources.put("assoc-lazy", new SourceEntity("assoc-lazy", List.of("loc-X")));
+        when(edgeRepo.srcIdsByDst(eq(domain), eq("canSeeLocation"), eq("loc-X")))
+                .thenReturn(new LinkedHashSet<>(Set.of("assoc-store")));
+
+        Set<String> ids = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-X");
+        assertEquals(Set.of("assoc-lazy", "assoc-store"), ids);
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────
+
+    static final class SourceEntity {
+        final String id;
+        final List<String> locations;
+        SourceEntity(String id, List<String> locations) {
+            this.id = id;
+            this.locations = locations;
+        }
+        public String getId() { return id; }
+    }
+
+    static final class LazyProvider extends ComputedEdgeProvider<SourceEntity> {
+        @Override public MaterializationMode getMaterializationMode() { return MaterializationMode.LAZY; }
+        @Override public Class<SourceEntity> getSourceType() { return SourceEntity.class; }
+        @Override public String getPredicate() { return "canSeeLocation"; }
+        @Override public String getTargetTypeName() { return "Location"; }
+        @Override
+        protected Set<ComputedTarget> computeTargets(ComputationContext context, SourceEntity source) {
+            Set<ComputedTarget> out = new LinkedHashSet<>();
+            for (String loc : source.locations) out.add(new ComputedTarget(loc));
+            return out;
+        }
+    }
+
+    /** Single-element CDI Instance for tests. */
+    static final class SingleInstance<T> implements Instance<T> {
+        private final T value;
+        SingleInstance(T value) { this.value = value; }
+        @Override public Instance<T> select(Annotation... qualifiers) { return this; }
+        @Override public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+            @SuppressWarnings("unchecked") Instance<U> self = (Instance<U>) this;
+            return self;
+        }
+        @Override public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            @SuppressWarnings("unchecked") Instance<U> self = (Instance<U>) this;
+            return self;
+        }
+        @Override public boolean isUnsatisfied() { return value == null; }
+        @Override public boolean isAmbiguous() { return false; }
+        @Override public void destroy(T instance) {}
+        @Override public Handle<T> getHandle() { throw new UnsupportedOperationException(); }
+        @Override public Iterable<? extends Handle<T>> handles() { return List.of(); }
+        @Override public T get() { return value; }
+        @Override public Iterator<T> iterator() { return Stream.of(value).iterator(); }
+    }
+}

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
@@ -6,6 +6,7 @@ import com.e2eq.ontology.core.ComputedEdgeProvider;
 import com.e2eq.ontology.core.ComputedEdgeRegistry;
 import com.e2eq.ontology.core.MaterializationMode;
 import com.e2eq.ontology.metrics.OntologyMetrics;
+import com.e2eq.ontology.model.OntologyEdge;
 import com.e2eq.ontology.repo.OntologyEdgeRepo;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
@@ -47,7 +48,9 @@ public class ComputedEdgeReaderInverseTest {
         when(edgeRepo.srcIdsByDst(any(DataDomain.class), anyString(), anyString())).thenReturn(Set.of());
         when(edgeRepo.srcIdsByDstIn(any(DataDomain.class), anyString(), any())).thenReturn(Set.of());
         when(edgeRepo.dstIdsBySrc(any(DataDomain.class), anyString(), anyString())).thenReturn(Set.of());
+        when(edgeRepo.findBySrcAndP(any(DataDomain.class), anyString(), anyString())).thenReturn(List.of());
         when(edgeRepo.findBySrcAndP(anyString(), any(DataDomain.class), anyString(), anyString())).thenReturn(List.of());
+        when(edgeRepo.findByDstAndP(any(DataDomain.class), anyString(), anyString())).thenReturn(List.of());
 
         sources = new ConcurrentHashMap<>();
 
@@ -108,11 +111,48 @@ public class ComputedEdgeReaderInverseTest {
     @Test
     void srcIdsByDstUnionsStoreEagerRowsWithLazy() {
         sources.put("assoc-lazy", new SourceEntity("assoc-lazy", List.of("loc-X")));
-        when(edgeRepo.srcIdsByDst(eq(domain), eq("canSeeLocation"), eq("loc-X")))
-                .thenReturn(new LinkedHashSet<>(Set.of("assoc-store")));
+        // Store row without non-EAGER provider provenance (explicit or other EAGER provider)
+        OntologyEdge storeRow = edge("assoc-store", "canSeeLocation", "loc-X", null);
+        when(edgeRepo.findByDstAndP(eq(domain), eq("loc-X"), eq("canSeeLocation")))
+                .thenReturn(List.of(storeRow));
 
         Set<String> ids = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-X");
         assertEquals(Set.of("assoc-lazy", "assoc-store"), ids);
+    }
+
+    @Test
+    void srcIdsByDstDropsStaleRowsFromNonEagerProviders() {
+        // Provider now LAZY and only grants loc-A; store still has stale loc-Y from when it was EAGER.
+        sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A")));
+        OntologyEdge stale = edge("assoc-1", "canSeeLocation", "loc-Y",
+                Map.of("providerId", "LazyProvider"));
+        when(edgeRepo.findByDstAndP(eq(domain), eq("loc-Y"), eq("canSeeLocation")))
+                .thenReturn(List.of(stale));
+        when(edgeRepo.srcIdsByDst(eq(domain), eq("canSeeLocation"), eq("loc-Y")))
+                .thenReturn(Set.of("assoc-1"));
+
+        Set<String> forStale = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-Y");
+        assertTrue(forStale.isEmpty(), "stale non-EAGER store row must not grant access");
+
+        Set<String> forFresh = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-A");
+        assertEquals(Set.of("assoc-1"), forFresh);
+    }
+
+    @Test
+    void normalizeRealmIdReplacesDotsLikeOntologyEdgeRepo() {
+        assertEquals("foo-bar-com", ComputedEdgeReader.normalizeRealmId("foo.bar.com"));
+        assertEquals("already-hyphen", ComputedEdgeReader.normalizeRealmId("already-hyphen"));
+        assertNull(ComputedEdgeReader.normalizeRealmId(null));
+    }
+
+    private static OntologyEdge edge(String src, String p, String dst, Map<String, Object> prov) {
+        OntologyEdge e = new OntologyEdge();
+        e.setSrc(src);
+        e.setP(p);
+        e.setDst(dst);
+        e.setProv(prov);
+        e.setDerived(prov != null);
+        return e;
     }
 
     // ── fixtures ──────────────────────────────────────────────────────────

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/ListQueryRewriter.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/ListQueryRewriter.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.ontology.mongo.ComputedEdgeReader;
 import com.e2eq.ontology.repo.OntologyEdgeRepo;
 import com.e2eq.ontology.core.OntologyAliasResolver;
 import dev.morphia.query.filters.Filter;
@@ -16,6 +17,11 @@ import org.bson.conversions.Bson;
  * Rewrites list queries to incorporate ontology edge constraints.
  * All operations are scoped by DataDomain (orgRefName, accountNum, tenantId, dataSegment)
  * to ensure proper isolation across organizations and accounts.
+ *
+ * <p>When a {@link ComputedEdgeReader} is available, edge lookups go through it so
+ * LAZY/ONDEMAND computed edges participate in {@code hasEdge} / {@code hasIncomingEdge}
+ * rewrites the same way EAGER store rows do. Without the reader (unit tests with a
+ * hand-rolled repo), behavior falls back to direct {@link OntologyEdgeRepo} reads.</p>
  */
 @ApplicationScoped
 public class ListQueryRewriter {
@@ -28,13 +34,23 @@ public class ListQueryRewriter {
     @Inject
     Instance<OntologyAliasResolver> aliasResolverInstance;
 
+    // Mode-aware facade for LAZY/ONDEMAND computed edges (optional for tests).
+    @Inject
+    Instance<ComputedEdgeReader> computedEdgeReaderInstance;
+
     // Testing/legacy convenience: allow manual construction with a provided repo
     private OntologyEdgeRepo edgeRepo;
+    private ComputedEdgeReader computedEdgeReader;
 
     public ListQueryRewriter() { }
     
     public ListQueryRewriter(OntologyEdgeRepo edgeRepo) {
         this.edgeRepo = edgeRepo;
+    }
+
+    public ListQueryRewriter(OntologyEdgeRepo edgeRepo, ComputedEdgeReader computedEdgeReader) {
+        this.edgeRepo = edgeRepo;
+        this.computedEdgeReader = computedEdgeReader;
     }
 
     private String canon(String predicate) {
@@ -54,18 +70,57 @@ public class ListQueryRewriter {
         throw new IllegalStateException("OntologyEdgeRepo bean not available; provide via CDI or constructor");
     }
 
+    private ComputedEdgeReader getComputedEdgeReader() {
+        if (computedEdgeReader != null) return computedEdgeReader;
+        try {
+            if (computedEdgeReaderInstance != null && !computedEdgeReaderInstance.isUnsatisfied()) {
+                return computedEdgeReaderInstance.get();
+            }
+        } catch (Throwable ignored) { }
+        return null;
+    }
+
+    /**
+     * Realm used for LAZY/ONDEMAND inverse scans. Prefer the authenticated
+     * principal's default realm (same pattern as {@link OntologyEdgeRepo});
+     * fall back to tenantId when no security context is present (tests).
+     */
+    private static String realmHint(DataDomain dataDomain) {
+        try {
+            var ctx = com.e2eq.framework.model.securityrules.SecurityContext.getPrincipalContext();
+            if (ctx.isPresent() && ctx.get().getDefaultRealm() != null
+                    && !ctx.get().getDefaultRealm().isBlank()) {
+                return ctx.get().getDefaultRealm();
+            }
+        } catch (Throwable ignored) { }
+        if (dataDomain == null) return null;
+        return dataDomain.getTenantId();
+    }
+
     private Set<String> srcIdsByDst(DataDomain dataDomain, String predicate, String dstId) {
         String p = canon(predicate);
+        ComputedEdgeReader reader = getComputedEdgeReader();
+        if (reader != null) {
+            return reader.srcIdsByDst(realmHint(dataDomain), dataDomain, p, dstId);
+        }
         return getRepo().srcIdsByDst(dataDomain, p, dstId);
     }
 
     private Set<String> srcIdsByDstIn(DataDomain dataDomain, String predicate, Collection<String> dstIds) {
         String p = canon(predicate);
+        ComputedEdgeReader reader = getComputedEdgeReader();
+        if (reader != null) {
+            return reader.srcIdsByDstIn(realmHint(dataDomain), dataDomain, p, dstIds);
+        }
         return getRepo().srcIdsByDstIn(dataDomain, p, dstIds);
     }
 
     private Set<String> dstIdsBySrc(DataDomain dataDomain, String predicate, String srcId) {
         String p = canon(predicate);
+        ComputedEdgeReader reader = getComputedEdgeReader();
+        if (reader != null) {
+            return reader.dstIdsBySrc(realmHint(dataDomain), dataDomain, p, srcId);
+        }
         return getRepo().dstIdsBySrc(dataDomain, p, srcId);
     }
 

--- a/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/ListQueryRewriter.java
+++ b/quantum-ontology-policy-bridge/src/main/java/com/e2eq/ontology/policy/ListQueryRewriter.java
@@ -84,17 +84,22 @@ public class ListQueryRewriter {
      * Realm used for LAZY/ONDEMAND inverse scans. Prefer the authenticated
      * principal's default realm (same pattern as {@link OntologyEdgeRepo});
      * fall back to tenantId when no security context is present (tests).
+     * Always normalize dots→hyphens so enumerator/loader realms match the
+     * datastore names used by the repository.
      */
     private static String realmHint(DataDomain dataDomain) {
+        String raw = null;
         try {
             var ctx = com.e2eq.framework.model.securityrules.SecurityContext.getPrincipalContext();
             if (ctx.isPresent() && ctx.get().getDefaultRealm() != null
                     && !ctx.get().getDefaultRealm().isBlank()) {
-                return ctx.get().getDefaultRealm();
+                raw = ctx.get().getDefaultRealm();
             }
         } catch (Throwable ignored) { }
-        if (dataDomain == null) return null;
-        return dataDomain.getTenantId();
+        if (raw == null && dataDomain != null) {
+            raw = dataDomain.getTenantId();
+        }
+        return ComputedEdgeReader.normalizeRealmId(raw);
     }
 
     private Set<String> srcIdsByDst(DataDomain dataDomain, String predicate, String dstId) {


### PR DESCRIPTION
## Summary
Addresses the open review feedback from merged PR #49 (calculated relations design/roadmap):

| Review item | Status before | Fix |
|-------------|---------------|-----|
| Dead ref to `implementing-territory-location-edges.md` | Still broken relative path in asciidoc | Point to `xref:../user-guide/ontology.adoc` + correct link to the markdown guide |
| Reasoner "caps iteration at 10" | Still wrong in problem statement | Document `MAX_TRANSITIVE_STEP_VISITS = 10_000` |
| LAZY/ONDEMAND only source-keyed (`findBySrcAndP`); inverse `srcIdsByDst` / hasEdge miss edges | **Still a real bug** | `ComputedEdgeReader` inverse APIs + `ListQueryRewriter` uses the facade |

## Code changes
- `ComputedEdgeReader`: `srcIdsByDst`, `srcIdsByDstIn`, `dstIdsBySrc` (store ∪ LAZY/ONDEMAND via enumerator)
- `ListQueryRewriter`: prefer `ComputedEdgeReader` when CDI provides it
- Docs + javadocs clarifying pure-repo vs mode-aware reads
- `ComputedEdgeReaderInverseTest` (3 tests)

## Test plan
- [x] `mvn -pl quantum-ontology-mongo -am test -Dtest=ComputedEdgeReaderInverseTest`
- [x] `ListQueryRewriterTest`, `HasEdgePolicyIntegrationTest`
- [ ] Optional: IT with a LAZY provider + hasEdge policy rewrite in a full app