### PR TITLE
fix(mcp): optional @ToolArg required=false across MCP tools

### DIFF
--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpDefectTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpDefectTools.java
@@ -2,6 +2,8 @@ package com.e2eq.framework.mcp;
 
 import com.e2eq.framework.mcp.defect.Defect;
 import com.e2eq.framework.mcp.defect.DefectRepo;
+import com.e2eq.framework.model.securityrules.PrincipalContext;
+import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
@@ -54,7 +56,7 @@ public class McpDefectTools {
             defect.setStatus("open");
             defect.setArea(area);
             defect.setComponent(component);
-            defect.setReporter(reporter);
+            defect.setReporter(resolveReporter(reporter));
             Defect saved = defectRepo.save(defect);
             return objectMapper.writeValueAsString(toMap(saved));
         } catch (Exception e) {
@@ -146,6 +148,20 @@ public class McpDefectTools {
         if (severity == null || severity.isBlank()) return "medium";
         String s = severity.trim().toLowerCase();
         return SEVERITIES.contains(s) ? s : "medium";
+    }
+
+    /**
+     * Prefer an explicit reporter arg; otherwise use the authenticated caller's
+     * userId / subjectId so omitted reporter does not persist as null.
+     */
+    private String resolveReporter(String reporter) {
+        if (isPresent(reporter)) return reporter.trim();
+        Optional<PrincipalContext> principal = SecurityContext.getPrincipalContext();
+        if (principal.isEmpty()) return null;
+        PrincipalContext ctx = principal.get();
+        if (isPresent(ctx.getUserId())) return ctx.getUserId().trim();
+        if (isPresent(ctx.getSubjectId())) return ctx.getSubjectId().trim();
+        return null;
     }
 
     private boolean blankOrEquals(String filter, String value) {

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpDefectTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpDefectTools.java
@@ -40,10 +40,10 @@ public class McpDefectTools {
     String defect_create(
             @ToolArg(description = "Short summary line for the defect") String title,
             @ToolArg(description = "Full description: what is wrong, how to reproduce, and relevant context") String description,
-            @ToolArg(description = "Severity: low|medium|high|critical. Default: medium") String severity,
-            @ToolArg(description = "Subsystem/area, e.g. 'quantum-ontology-service'") String area,
-            @ToolArg(description = "Finer-grained component within the area (optional)") String component,
-            @ToolArg(description = "Who is reporting this (optional; defaults to the caller identity)") String reporter) {
+            @ToolArg(description = "Severity: low|medium|high|critical. Default: medium", required = false, defaultValue = "medium") String severity,
+            @ToolArg(description = "Subsystem/area, e.g. 'quantum-ontology-service' (optional)", required = false) String area,
+            @ToolArg(description = "Finer-grained component within the area (optional)", required = false) String component,
+            @ToolArg(description = "Who is reporting this (optional; defaults to the caller identity)", required = false) String reporter) {
         try {
             Defect defect = new Defect();
             defect.setRefName("defect-" + UUID.randomUUID());
@@ -65,9 +65,9 @@ public class McpDefectTools {
     @Tool(description = "List defects, optionally filtered by status (open|in-progress|resolved|closed), "
             + "severity (low|medium|high|critical), and/or area. Filters are case-insensitive.")
     String defect_list(
-            @ToolArg(description = "Optional status filter: open|in-progress|resolved|closed") String status,
-            @ToolArg(description = "Optional severity filter: low|medium|high|critical") String severity,
-            @ToolArg(description = "Optional area filter") String area) {
+            @ToolArg(description = "Optional status filter: open|in-progress|resolved|closed", required = false) String status,
+            @ToolArg(description = "Optional severity filter: low|medium|high|critical", required = false) String severity,
+            @ToolArg(description = "Optional area filter", required = false) String area) {
         try {
             List<Map<String, Object>> matches = defectRepo.getAllList().stream()
                     .filter(d -> blankOrEquals(status, d.getStatus()))
@@ -102,10 +102,10 @@ public class McpDefectTools {
             + "Use this to change status (open|in-progress|resolved|closed), record a resolution, reassign, or re-prioritize.")
     String defect_update(
             @ToolArg(description = "The defect refName to update") String refName,
-            @ToolArg(description = "New status: open|in-progress|resolved|closed (optional)") String status,
-            @ToolArg(description = "Resolution notes (optional)") String resolution,
-            @ToolArg(description = "Reassign to (optional)") String assignedTo,
-            @ToolArg(description = "New severity: low|medium|high|critical (optional)") String severity) {
+            @ToolArg(description = "New status: open|in-progress|resolved|closed (optional)", required = false) String status,
+            @ToolArg(description = "Resolution notes (optional)", required = false) String resolution,
+            @ToolArg(description = "Reassign to (optional)", required = false) String assignedTo,
+            @ToolArg(description = "New severity: low|medium|high|critical (optional)", required = false) String severity) {
         try {
             Optional<Defect> found = defectRepo.findByRefName(refName);
             if (found.isEmpty()) {

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpGatewayTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpGatewayTools.java
@@ -55,10 +55,10 @@ public class McpGatewayTools {
             + "logical operators (&& || !!), and expand(path) for relationship hydration.")
     String query_find(
             @ToolArg(description = "Entity type (e.g. Order, Location). Use query_rootTypes to discover valid values.") String rootType,
-            @ToolArg(description = "BIAPI query string (e.g. 'refName:LOC-001', 'status:ACTIVE && region:West')") String query,
-            @ToolArg(description = "Optional tenant realm. When omitted, the caller's default realm is used.") String realm,
-            @ToolArg(description = "Optional max number of results to return (default 50)") Integer limit,
-            @ToolArg(description = "Optional number of results to skip for pagination (default 0)") Integer skip) {
+            @ToolArg(description = "Optional BIAPI query string (e.g. 'refName:LOC-001', 'status:ACTIVE && region:West'). Omit to return unfiltered results for the type.", required = false) String query,
+            @ToolArg(description = "Optional tenant realm. When omitted, the caller's default realm is used.", required = false) String realm,
+            @ToolArg(description = "Optional max number of results to return (default 50)", required = false) Integer limit,
+            @ToolArg(description = "Optional number of results to skip for pagination (default 0)", required = false) Integer skip) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         if (query != null) args.put("query", query);
@@ -76,8 +76,8 @@ public class McpGatewayTools {
             + "More efficient than query_find when you only need the number of matching records.")
     String query_count(
             @ToolArg(description = "Entity type (e.g. Order, Location). Use query_rootTypes to discover valid values.") String rootType,
-            @ToolArg(description = "Optional BIAPI query string to filter which entities to count (e.g. 'status:ACTIVE'). If omitted, counts all entities of this type.") String query,
-            @ToolArg(description = "Optional tenant realm. When omitted, the caller's default realm is used.") String realm) {
+            @ToolArg(description = "Optional BIAPI query string to filter which entities to count (e.g. 'status:ACTIVE'). If omitted, counts all entities of this type.", required = false) String query,
+            @ToolArg(description = "Optional tenant realm. When omitted, the caller's default realm is used.", required = false) String realm) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         if (query != null) args.put("query", query);
@@ -89,7 +89,7 @@ public class McpGatewayTools {
     String query_save(
             @ToolArg(description = "Entity type (e.g. Location, Order)") String rootType,
             @ToolArg(description = "Entity data as a JSON object (field names must match the schema for this rootType)") String entity,
-            @ToolArg(description = "Optional tenant realm") String realm) {
+            @ToolArg(description = "Optional tenant realm", required = false) String realm) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         if (realm != null && !realm.isBlank()) args.put("realm", realm);
@@ -107,7 +107,7 @@ public class McpGatewayTools {
     String query_delete(
             @ToolArg(description = "Entity type (e.g. Location, Order)") String rootType,
             @ToolArg(description = "ObjectId hex string of the entity to delete") String id,
-            @ToolArg(description = "Optional tenant realm") String realm) {
+            @ToolArg(description = "Optional tenant realm", required = false) String realm) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         args.put("id", id);
@@ -119,7 +119,7 @@ public class McpGatewayTools {
     String query_deleteMany(
             @ToolArg(description = "Entity type (e.g. Location, Order)") String rootType,
             @ToolArg(description = "BIAPI query string to match entities for deletion (e.g. 'status:INACTIVE')") String query,
-            @ToolArg(description = "Optional tenant realm") String realm) {
+            @ToolArg(description = "Optional tenant realm", required = false) String realm) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         if (query != null) args.put("query", query);
@@ -137,10 +137,10 @@ public class McpGatewayTools {
     String query_import_analyze(
             @ToolArg(description = "Entity type (e.g. Location, Order). Use query_rootTypes to discover valid values.") String rootType,
             @ToolArg(description = "CSV content as a string including a header row followed by data rows") String csvContent,
-            @ToolArg(description = "Comma-separated list of entity field names matching CSV columns (e.g. 'refName,displayName,status')") String columns,
-            @ToolArg(description = "Optional tenant realm") String realm,
-            @ToolArg(description = "Optional field separator character (default ',')") String fieldSeparator,
-            @ToolArg(description = "Optional quote character (default '\"')") String quoteChar) {
+            @ToolArg(description = "Optional comma-separated list of entity field names matching CSV columns (e.g. 'refName,displayName,status'). When omitted, headers are inferred from the CSV.", required = false) String columns,
+            @ToolArg(description = "Optional tenant realm", required = false) String realm,
+            @ToolArg(description = "Optional field separator character (default ',')", required = false, defaultValue = ",") String fieldSeparator,
+            @ToolArg(description = "Optional quote character (default '\"')", required = false, defaultValue = "\"") String quoteChar) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         args.put("csvContent", csvContent);
@@ -158,11 +158,11 @@ public class McpGatewayTools {
     String query_import_rows(
             @ToolArg(description = "Session ID returned by query_import_analyze") String sessionId,
             @ToolArg(description = "Entity type used in the original analyze call") String rootType,
-            @ToolArg(description = "Optional tenant realm") String realm,
-            @ToolArg(description = "Number of rows to skip (default 0)") Integer skip,
-            @ToolArg(description = "Max rows to return (default 50)") Integer limit,
-            @ToolArg(description = "Only return rows with errors (default false)") Boolean onlyErrors,
-            @ToolArg(description = "Filter by intent: INSERT, UPDATE, or SKIP") String intent) {
+            @ToolArg(description = "Optional tenant realm", required = false) String realm,
+            @ToolArg(description = "Number of rows to skip (default 0)", required = false) Integer skip,
+            @ToolArg(description = "Max rows to return (default 50)", required = false) Integer limit,
+            @ToolArg(description = "Only return rows with errors (default false)", required = false) Boolean onlyErrors,
+            @ToolArg(description = "Filter by intent: INSERT, UPDATE, or SKIP (optional)", required = false) String intent) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("sessionId", sessionId);
         args.put("rootType", rootType);
@@ -179,7 +179,7 @@ public class McpGatewayTools {
     String query_import_commit(
             @ToolArg(description = "Session ID returned by query_import_analyze") String sessionId,
             @ToolArg(description = "Entity type used in the original analyze call") String rootType,
-            @ToolArg(description = "Optional tenant realm") String realm) {
+            @ToolArg(description = "Optional tenant realm", required = false) String realm) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("sessionId", sessionId);
         args.put("rootType", rootType);
@@ -191,7 +191,7 @@ public class McpGatewayTools {
     String query_import_cancel(
             @ToolArg(description = "Session ID returned by query_import_analyze") String sessionId,
             @ToolArg(description = "Entity type used in the original analyze call") String rootType,
-            @ToolArg(description = "Optional tenant realm") String realm) {
+            @ToolArg(description = "Optional tenant realm", required = false) String realm) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("sessionId", sessionId);
         args.put("rootType", rootType);
@@ -203,11 +203,11 @@ public class McpGatewayTools {
             + "results or writes to a file for large results. Use query_count first to estimate size.")
     String query_export(
             @ToolArg(description = "Entity type (e.g. Location, Order). Use query_rootTypes to discover valid values.") String rootType,
-            @ToolArg(description = "Optional BIAPI query to filter exported entities (e.g. 'status:ACTIVE')") String query,
-            @ToolArg(description = "Comma-separated list of columns to include in export (e.g. 'refName,displayName,status')") String columns,
-            @ToolArg(description = "Optional tenant realm") String realm,
-            @ToolArg(description = "Optional max rows to export (default: all)") Integer limit,
-            @ToolArg(description = "Optional rows to skip (default 0)") Integer skip) {
+            @ToolArg(description = "Optional BIAPI query to filter exported entities (e.g. 'status:ACTIVE')", required = false) String query,
+            @ToolArg(description = "Optional comma-separated list of columns to include in export (e.g. 'refName,displayName,status')", required = false) String columns,
+            @ToolArg(description = "Optional tenant realm", required = false) String realm,
+            @ToolArg(description = "Optional max rows to export (default: all)", required = false) Integer limit,
+            @ToolArg(description = "Optional rows to skip (default 0)", required = false) Integer skip) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         if (query != null) args.put("query", query);

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpGatewayTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpGatewayTools.java
@@ -137,14 +137,15 @@ public class McpGatewayTools {
     String query_import_analyze(
             @ToolArg(description = "Entity type (e.g. Location, Order). Use query_rootTypes to discover valid values.") String rootType,
             @ToolArg(description = "CSV content as a string including a header row followed by data rows") String csvContent,
-            @ToolArg(description = "Optional comma-separated list of entity field names matching CSV columns (e.g. 'refName,displayName,status'). When omitted, headers are inferred from the CSV.", required = false) String columns,
+            @ToolArg(description = "Comma-separated list of entity field names matching CSV columns (e.g. 'refName,displayName,status'). Required; importAnalyze does not infer headers.") String columns,
             @ToolArg(description = "Optional tenant realm", required = false) String realm,
             @ToolArg(description = "Optional field separator character (default ',')", required = false, defaultValue = ",") String fieldSeparator,
             @ToolArg(description = "Optional quote character (default '\"')", required = false, defaultValue = "\"") String quoteChar) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("rootType", rootType);
         args.put("csvContent", csvContent);
-        if (columns != null) {
+        // columns is required by QueryGatewayResource.importAnalyze (no header inference path).
+        if (columns != null && !columns.isBlank()) {
             args.put("columns", java.util.Arrays.asList(columns.split(",")));
         }
         if (realm != null && !realm.isBlank()) args.put("realm", realm);

--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpOntologyTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpOntologyTools.java
@@ -42,9 +42,9 @@ public class McpOntologyTools {
             + "Each edge includes: predicate, source/destination entity ID and type, and whether it is inferred or derived.")
     String query_relationships(
             @ToolArg(description = "The entity ID to find relationships for (e.g. the refName or ObjectId hex string of the entity)") String entityId,
-            @ToolArg(description = "Direction: 'out' for outgoing edges FROM this entity, 'in' for incoming edges TO this entity, 'both' for all. Default: 'both'") String direction,
-            @ToolArg(description = "Optional predicate filter - only return edges with this predicate (e.g. 'placedInOrg', 'canSeeLocation')") String predicate,
-            @ToolArg(description = "Optional tenant realm. When omitted, derived from the caller's security context.") String realm) {
+            @ToolArg(description = "Direction: 'out' for outgoing edges FROM this entity, 'in' for incoming edges TO this entity, 'both' for all. Default: 'both'", required = false, defaultValue = "both") String direction,
+            @ToolArg(description = "Optional predicate filter - only return edges with this predicate (e.g. 'placedInOrg', 'canSeeLocation')", required = false) String predicate,
+            @ToolArg(description = "Optional tenant realm. When omitted, derived from the caller's security context.", required = false) String realm) {
         try {
             DataDomain dataDomain = resolveDataDomain(realm);
             if (dataDomain == null) {
@@ -93,9 +93,9 @@ public class McpOntologyTools {
             + "Returns predicate name, domain (source type), range (target type), and characteristics "
             + "(transitive, symmetric, functional, inferred). Use this to discover what relationship types exist before querying edges.")
     String query_predicates(
-            @ToolArg(description = "Optional filter: only return predicates where this is the domain (source entity type), e.g. 'Associate'") String domainFilter,
-            @ToolArg(description = "Optional filter: only return predicates where this is the range (target entity type), e.g. 'Location'") String rangeFilter,
-            @ToolArg(description = "Optional tenant realm. When omitted, derived from the caller's security context.") String realm) {
+            @ToolArg(description = "Optional filter: only return predicates where this is the domain (source entity type), e.g. 'Associate'", required = false) String domainFilter,
+            @ToolArg(description = "Optional filter: only return predicates where this is the range (target entity type), e.g. 'Location'", required = false) String rangeFilter,
+            @ToolArg(description = "Optional tenant realm. When omitted, derived from the caller's security context.", required = false) String realm) {
         try {
             String resolvedRealm = resolveRealm(realm);
             OntologyRegistry registry = registryProvider.getRegistryForRealm(resolvedRealm);


### PR DESCRIPTION
## Summary
Follow-up to merged PR #60 (defect MCP tools) Codex review:

> `@ToolArg` parameters are **required by default** unless `required = false`, a `defaultValue`, or an `Optional` type.

That broke the advertised optional filters on `defect_list` / create / update. The same pattern existed on the other MCP tool classes.

## Changes
Mark documented-optional args with `required = false` (and `defaultValue` where the code already has a default):

| Class | Optional args fixed |
|-------|---------------------|
| `McpDefectTools` | severity/area/component/reporter; list filters; update fields |
| `McpOntologyTools` | direction (default `both`), predicate, realm; predicate filters |
| `McpGatewayTools` | realm, limit/skip, optional query/columns, import/export options |

Intentionally left **required**: `rootType`, `entityId`, `refName`, `entity`, `id`, `sessionId`, `csvContent`, plan `query`, deleteMany `query`.

## Test plan
- [x] `mvn -pl quantum-mcp-server -am compile`
- [ ] MCP client `tools/list` shows optional fields not in `required[]`
- [ ] Call `defect_list` with no args; call `query_count` with only `rootType`