### PR TITLE
fix(ontology): finish PR #49 inverse graph reads for MCP/REST

### DIFF
--- a/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpOntologyTools.java
+++ b/quantum-mcp-server/src/main/java/com/e2eq/framework/mcp/McpOntologyTools.java
@@ -4,8 +4,8 @@ import com.e2eq.framework.model.persistent.base.DataDomain;
 import com.e2eq.framework.model.securityrules.PrincipalContext;
 import com.e2eq.framework.model.securityrules.SecurityContext;
 import com.e2eq.ontology.core.OntologyRegistry;
-import com.e2eq.ontology.model.OntologyEdge;
-import com.e2eq.ontology.repo.OntologyEdgeRepo;
+import com.e2eq.ontology.core.Reasoner;
+import com.e2eq.ontology.mongo.ComputedEdgeReader;
 import com.e2eq.ontology.runtime.TenantOntologyRegistryProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkiverse.mcp.server.Tool;
@@ -22,14 +22,18 @@ import java.util.*;
  * find outgoing/incoming relationships for an entity, and discover
  * what predicates (relationship types) are defined in the ontology.</p>
  *
- * @see OntologyEdgeRepo
+ * <p>Relationship edge reads go through {@link ComputedEdgeReader} so LAZY/ONDEMAND
+ * computed edges participate in both source- and destination-keyed discovery
+ * (Codex review on calculated-relations roadmap PR #49).</p>
+ *
+ * @see ComputedEdgeReader
  * @see TenantOntologyRegistryProvider
  */
 @Authenticated
 public class McpOntologyTools {
 
     @Inject
-    OntologyEdgeRepo edgeRepo;
+    ComputedEdgeReader computedEdgeReader;
 
     @Inject
     TenantOntologyRegistryProvider registryProvider;
@@ -39,7 +43,8 @@ public class McpOntologyTools {
 
     @Tool(description = "Find ontology relationships (edges) for an entity. "
             + "Returns outgoing edges (entity -> target), incoming edges (source -> entity), or both. "
-            + "Each edge includes: predicate, source/destination entity ID and type, and whether it is inferred or derived.")
+            + "Each edge includes: predicate, source/destination entity ID and type, and whether it is inferred or derived. "
+            + "Includes LAZY/ONDEMAND computed edges when providers and enumerators are registered.")
     String query_relationships(
             @ToolArg(description = "The entity ID to find relationships for (e.g. the refName or ObjectId hex string of the entity)") String entityId,
             @ToolArg(description = "Direction: 'out' for outgoing edges FROM this entity, 'in' for incoming edges TO this entity, 'both' for all. Default: 'both'", required = false, defaultValue = "both") String direction,
@@ -52,28 +57,19 @@ public class McpOntologyTools {
             }
 
             String dir = (direction != null && !direction.isBlank()) ? direction.toLowerCase() : "both";
+            String effectiveRealm = resolveRealm(realm);
             List<Map<String, Object>> edges = new ArrayList<>();
 
             if ("out".equals(dir) || "both".equals(dir)) {
-                List<OntologyEdge> outgoing;
-                if (predicate != null && !predicate.isBlank()) {
-                    outgoing = edgeRepo.findBySrcAndP(dataDomain, entityId, predicate);
-                } else {
-                    outgoing = edgeRepo.findBySrc(dataDomain, entityId);
-                }
-                for (OntologyEdge e : outgoing) {
+                for (Reasoner.Edge e : computedEdgeReader.relationshipEdgesFromSrc(
+                        effectiveRealm, dataDomain, entityId, predicate)) {
                     edges.add(edgeToMap(e, "outgoing"));
                 }
             }
 
             if ("in".equals(dir) || "both".equals(dir)) {
-                List<OntologyEdge> incoming;
-                if (predicate != null && !predicate.isBlank()) {
-                    incoming = edgeRepo.findByDstAndP(dataDomain, entityId, predicate);
-                } else {
-                    incoming = edgeRepo.findByDst(dataDomain, entityId);
-                }
-                for (OntologyEdge e : incoming) {
+                for (Reasoner.Edge e : computedEdgeReader.relationshipEdgesToDst(
+                        effectiveRealm, dataDomain, entityId, predicate)) {
                     edges.add(edgeToMap(e, "incoming"));
                 }
             }
@@ -149,19 +145,21 @@ public class McpOntologyTools {
         }
     }
 
-    private Map<String, Object> edgeToMap(OntologyEdge e, String direction) {
+    private Map<String, Object> edgeToMap(Reasoner.Edge e, String direction) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("direction", direction);
-        m.put("predicate", e.getP());
-        m.put("src", e.getSrc());
-        m.put("srcType", e.getSrcType());
-        m.put("dst", e.getDst());
-        m.put("dstType", e.getDstType());
-        m.put("inferred", e.isInferred());
-        m.put("derived", e.isDerived());
-        if (e.getTs() != null) {
-            m.put("timestamp", e.getTs().toInstant().toString());
-        }
+        m.put("predicate", e.p());
+        m.put("src", e.srcId());
+        m.put("srcType", e.srcType());
+        m.put("dst", e.dstId());
+        m.put("dstType", e.dstType());
+        m.put("inferred", e.inferred());
+        // LAZY/ONDEMAND computed edges from providers are derived; store-converted
+        // edges may not carry the derived flag on Reasoner.Edge — treat non-inferred
+        // provider results as derived when provenance rule is "computed".
+        boolean derived = e.prov().isPresent()
+                && "computed".equals(e.prov().get().rule());
+        m.put("derived", derived);
         return m;
     }
 

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -207,6 +207,10 @@ public class ComputedEdgeReader {
      * Full relationship edges leaving {@code sourceId} for graph UIs / MCP discovery.
      * Unions store rows (excluding stale non-EAGER provider rows) with LAZY/ONDEMAND
      * provider computation. Optional {@code predicate} filters both sides.
+     *
+     * <p><b>Uniqueness:</b> returns a list with set semantics on edge identity
+     * {@code (srcId, predicate, dstId)} — first occurrence wins. Callers must not
+     * assume bag/multiset semantics; store∪compute can otherwise double-count.</p>
      */
     public List<Reasoner.Edge> relationshipEdgesFromSrc(String realmId, DataDomain dataDomain,
                                                         String sourceId, String predicate) {
@@ -215,29 +219,33 @@ public class ComputedEdgeReader {
         String pred = blankToNull(predicate);
         Set<String> nonEager = allNonEagerProviderIds();
 
-        List<Reasoner.Edge> out = new ArrayList<>();
+        // LinkedHashMap = ordered set of edges by (src, p, dst)
+        Map<String, Reasoner.Edge> unique = new LinkedHashMap<>();
         List<OntologyEdge> store = pred != null
                 ? edgeRepo.findBySrcAndP(dataDomain, sourceId, pred)
                 : edgeRepo.findBySrc(dataDomain, sourceId);
         for (OntologyEdge e : store) {
             if (isStaleNonEagerStoreRow(e, nonEager)) continue;
-            out.add(toReasonerEdge(e));
+            putEdge(unique, toReasonerEdge(e));
         }
 
         for (ComputedEdgeProvider<?> provider : registry.getAllProviders()) {
             if (provider.getMaterializationMode() == MaterializationMode.EAGER) continue;
             if (pred != null && !pred.equals(provider.getPredicate())) continue;
             for (Reasoner.Edge e : edgesFor(realmId, dataDomain, provider, sourceId)) {
-                if (sourceId.equals(e.srcId())) out.add(e);
+                if (sourceId.equals(e.srcId())) putEdge(unique, e);
             }
         }
-        return dedupeEdges(out);
+        return new ArrayList<>(unique.values());
     }
 
     /**
      * Full relationship edges pointing at {@code dstId} for graph UIs / MCP discovery.
      * Unions store rows (excluding stale non-EAGER provider rows) with LAZY/ONDEMAND
      * inverse scans. Optional {@code predicate} filters both sides.
+     *
+     * <p><b>Uniqueness:</b> set semantics on {@code (srcId, predicate, dstId)} — same
+     * as {@link #relationshipEdgesFromSrc}.</p>
      */
     public List<Reasoner.Edge> relationshipEdgesToDst(String realmId, DataDomain dataDomain,
                                                       String dstId, String predicate) {
@@ -246,13 +254,13 @@ public class ComputedEdgeReader {
         String pred = blankToNull(predicate);
         Set<String> nonEager = allNonEagerProviderIds();
 
-        List<Reasoner.Edge> out = new ArrayList<>();
+        Map<String, Reasoner.Edge> unique = new LinkedHashMap<>();
         List<OntologyEdge> store = pred != null
                 ? edgeRepo.findByDstAndP(dataDomain, dstId, pred)
                 : edgeRepo.findByDst(dataDomain, dstId);
         for (OntologyEdge e : store) {
             if (isStaleNonEagerStoreRow(e, nonEager)) continue;
-            out.add(toReasonerEdge(e));
+            putEdge(unique, toReasonerEdge(e));
         }
 
         for (ComputedEdgeProvider<?> provider : registry.getAllProviders()) {
@@ -260,11 +268,11 @@ public class ComputedEdgeReader {
             if (pred != null && !pred.equals(provider.getPredicate())) continue;
             for (String srcId : enumerateSourceIds(realmId, dataDomain, provider, DEFAULT_INVERSE_SOURCE_SCAN_LIMIT)) {
                 for (Reasoner.Edge e : edgesFor(realmId, dataDomain, provider, srcId)) {
-                    if (dstId.equals(e.dstId())) out.add(e);
+                    if (dstId.equals(e.dstId())) putEdge(unique, e);
                 }
             }
         }
-        return dedupeEdges(out);
+        return new ArrayList<>(unique.values());
     }
 
     /**
@@ -322,14 +330,24 @@ public class ComputedEdgeReader {
                 Optional.empty());
     }
 
-    private static List<Reasoner.Edge> dedupeEdges(List<Reasoner.Edge> edges) {
-        Map<String, Reasoner.Edge> byKey = new LinkedHashMap<>();
-        for (Reasoner.Edge e : edges) {
-            if (e == null) continue;
-            String key = e.srcId() + "|" + e.p() + "|" + e.dstId();
-            byKey.putIfAbsent(key, e);
-        }
-        return new ArrayList<>(byKey.values());
+    /**
+     * Edge identity for set-style accumulation: source + predicate + destination.
+     * Null components are treated as empty strings so keys stay stable.
+     * Public so REST/MCP callers can merge multi-predicate results without
+     * reintroducing bag semantics.
+     */
+    public static String edgeKey(Reasoner.Edge e) {
+        if (e == null) return "";
+        return nullToEmpty(e.srcId()) + "|" + nullToEmpty(e.p()) + "|" + nullToEmpty(e.dstId());
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    private static void putEdge(Map<String, Reasoner.Edge> unique, Reasoner.Edge e) {
+        if (e == null) return;
+        unique.putIfAbsent(edgeKey(e), e);
     }
 
     /**

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -204,6 +204,70 @@ public class ComputedEdgeReader {
     }
 
     /**
+     * Full relationship edges leaving {@code sourceId} for graph UIs / MCP discovery.
+     * Unions store rows (excluding stale non-EAGER provider rows) with LAZY/ONDEMAND
+     * provider computation. Optional {@code predicate} filters both sides.
+     */
+    public List<Reasoner.Edge> relationshipEdgesFromSrc(String realmId, DataDomain dataDomain,
+                                                        String sourceId, String predicate) {
+        Objects.requireNonNull(sourceId, "sourceId");
+        realmId = normalizeRealmId(realmId);
+        String pred = blankToNull(predicate);
+        Set<String> nonEager = allNonEagerProviderIds();
+
+        List<Reasoner.Edge> out = new ArrayList<>();
+        List<OntologyEdge> store = pred != null
+                ? edgeRepo.findBySrcAndP(dataDomain, sourceId, pred)
+                : edgeRepo.findBySrc(dataDomain, sourceId);
+        for (OntologyEdge e : store) {
+            if (isStaleNonEagerStoreRow(e, nonEager)) continue;
+            out.add(toReasonerEdge(e));
+        }
+
+        for (ComputedEdgeProvider<?> provider : registry.getAllProviders()) {
+            if (provider.getMaterializationMode() == MaterializationMode.EAGER) continue;
+            if (pred != null && !pred.equals(provider.getPredicate())) continue;
+            for (Reasoner.Edge e : edgesFor(realmId, dataDomain, provider, sourceId)) {
+                if (sourceId.equals(e.srcId())) out.add(e);
+            }
+        }
+        return dedupeEdges(out);
+    }
+
+    /**
+     * Full relationship edges pointing at {@code dstId} for graph UIs / MCP discovery.
+     * Unions store rows (excluding stale non-EAGER provider rows) with LAZY/ONDEMAND
+     * inverse scans. Optional {@code predicate} filters both sides.
+     */
+    public List<Reasoner.Edge> relationshipEdgesToDst(String realmId, DataDomain dataDomain,
+                                                      String dstId, String predicate) {
+        Objects.requireNonNull(dstId, "dstId");
+        realmId = normalizeRealmId(realmId);
+        String pred = blankToNull(predicate);
+        Set<String> nonEager = allNonEagerProviderIds();
+
+        List<Reasoner.Edge> out = new ArrayList<>();
+        List<OntologyEdge> store = pred != null
+                ? edgeRepo.findByDstAndP(dataDomain, dstId, pred)
+                : edgeRepo.findByDst(dataDomain, dstId);
+        for (OntologyEdge e : store) {
+            if (isStaleNonEagerStoreRow(e, nonEager)) continue;
+            out.add(toReasonerEdge(e));
+        }
+
+        for (ComputedEdgeProvider<?> provider : registry.getAllProviders()) {
+            if (provider.getMaterializationMode() == MaterializationMode.EAGER) continue;
+            if (pred != null && !pred.equals(provider.getPredicate())) continue;
+            for (String srcId : enumerateSourceIds(realmId, dataDomain, provider, DEFAULT_INVERSE_SOURCE_SCAN_LIMIT)) {
+                for (Reasoner.Edge e : edgesFor(realmId, dataDomain, provider, srcId)) {
+                    if (dstId.equals(e.dstId())) out.add(e);
+                }
+            }
+        }
+        return dedupeEdges(out);
+    }
+
+    /**
      * Invalidate the cached entry for a (provider, source) pair.
      * No-op for non-LAZY providers.
      */
@@ -234,6 +298,38 @@ public class ComputedEdgeReader {
             }
         }
         return ids;
+    }
+
+    private Set<String> allNonEagerProviderIds() {
+        Set<String> ids = new HashSet<>();
+        for (ComputedEdgeProvider<?> p : registry.getAllProviders()) {
+            if (p.getMaterializationMode() != MaterializationMode.EAGER) {
+                ids.add(p.getProviderId());
+            }
+        }
+        return ids;
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s.trim();
+    }
+
+    private static Reasoner.Edge toReasonerEdge(OntologyEdge e) {
+        return new Reasoner.Edge(
+                e.getSrc(), e.getSrcType(), e.getP(),
+                e.getDst(), e.getDstType(),
+                Boolean.TRUE.equals(e.isInferred()),
+                Optional.empty());
+    }
+
+    private static List<Reasoner.Edge> dedupeEdges(List<Reasoner.Edge> edges) {
+        Map<String, Reasoner.Edge> byKey = new LinkedHashMap<>();
+        for (Reasoner.Edge e : edges) {
+            if (e == null) continue;
+            String key = e.srcId() + "|" + e.p() + "|" + e.dstId();
+            byKey.putIfAbsent(key, e);
+        }
+        return new ArrayList<>(byKey.values());
     }
 
     /**

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -322,12 +322,36 @@ public class ComputedEdgeReader {
         return (s == null || s.isBlank()) ? null : s.trim();
     }
 
+    /**
+     * Convert a stored edge without dropping provenance / derived status.
+     * Consumers (MCP/REST) treat {@code prov.rule == "computed"} as derived.
+     */
     private static Reasoner.Edge toReasonerEdge(OntologyEdge e) {
+        boolean inferred = Boolean.TRUE.equals(e.isInferred());
+        boolean derived = Boolean.TRUE.equals(e.isDerived()) && !inferred;
+        Map<String, Object> stored = e.getProv();
+        Optional<Reasoner.Provenance> prov = Optional.empty();
+        if (derived) {
+            // Provenance.rule carries "computed" so REST/MCP can recover derived/origin.
+            Map<String, Object> inputs = stored != null
+                    ? new LinkedHashMap<>(stored)
+                    : new LinkedHashMap<>();
+            prov = Optional.of(new Reasoner.Provenance("computed", inputs));
+        } else if (inferred) {
+            Map<String, Object> inputs = stored != null
+                    ? new LinkedHashMap<>(stored)
+                    : new LinkedHashMap<>();
+            prov = Optional.of(new Reasoner.Provenance("inferred", inputs));
+        } else if (stored != null && !stored.isEmpty()) {
+            Object ruleObj = stored.get("rule");
+            String rule = ruleObj != null ? ruleObj.toString() : "explicit";
+            prov = Optional.of(new Reasoner.Provenance(rule, new LinkedHashMap<>(stored)));
+        }
         return new Reasoner.Edge(
                 e.getSrc(), e.getSrcType(), e.getP(),
                 e.getDst(), e.getDstType(),
-                Boolean.TRUE.equals(e.isInferred()),
-                Optional.empty());
+                inferred,
+                prov);
     }
 
     /**

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
@@ -172,6 +172,34 @@ public class ComputedEdgeReaderInverseTest {
         assertEquals("canSeeLocation", edges.get(0).p());
     }
 
+    @Test
+    void relationshipEdgesFromSrcDoesNotDoubleCountStoreAndLazySameTriple() {
+        // Store already has the same edge the LAZY provider would produce — must not
+        // return two copies of (assoc-1, canSeeLocation, loc-A).
+        sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A")));
+        OntologyEdge storeDup = edge("assoc-1", "canSeeLocation", "loc-A", null); // no providerId = keep
+        when(edgeRepo.findBySrc(any(DataDomain.class), eq("assoc-1"))).thenReturn(List.of(storeDup));
+        when(edgeRepo.findBySrcAndP(any(DataDomain.class), eq("assoc-1"), anyString()))
+                .thenReturn(List.of(storeDup));
+
+        var edges = reader.relationshipEdgesFromSrc("realm", domain, "assoc-1", "canSeeLocation");
+        assertEquals(1, edges.size(), "store∪lazy must be set-like on (src,p,dst)");
+        assertEquals("loc-A", edges.get(0).dstId());
+    }
+
+    @Test
+    void srcIdsByDstIsSetNotBag() {
+        sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A")));
+        // Even if store also claims assoc-1 (without non-eager providerId), Set must stay size 1.
+        OntologyEdge storeRow = edge("assoc-1", "canSeeLocation", "loc-A", null);
+        when(edgeRepo.findByDstAndP(eq(domain), eq("loc-A"), eq("canSeeLocation")))
+                .thenReturn(List.of(storeRow, storeRow)); // bag in store query
+
+        Set<String> ids = reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-A");
+        assertEquals(Set.of("assoc-1"), ids);
+        assertEquals(1, ids.size());
+    }
+
     private static OntologyEdge edge(String src, String p, String dst, Map<String, Object> prov) {
         OntologyEdge e = new OntologyEdge();
         e.setSrc(src);

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
@@ -50,7 +50,9 @@ public class ComputedEdgeReaderInverseTest {
         when(edgeRepo.dstIdsBySrc(any(DataDomain.class), anyString(), anyString())).thenReturn(Set.of());
         when(edgeRepo.findBySrcAndP(any(DataDomain.class), anyString(), anyString())).thenReturn(List.of());
         when(edgeRepo.findBySrcAndP(anyString(), any(DataDomain.class), anyString(), anyString())).thenReturn(List.of());
+        when(edgeRepo.findBySrc(any(DataDomain.class), anyString())).thenReturn(List.of());
         when(edgeRepo.findByDstAndP(any(DataDomain.class), anyString(), anyString())).thenReturn(List.of());
+        when(edgeRepo.findByDst(any(DataDomain.class), anyString())).thenReturn(List.of());
 
         sources = new ConcurrentHashMap<>();
 
@@ -143,6 +145,31 @@ public class ComputedEdgeReaderInverseTest {
         assertEquals("foo-bar-com", ComputedEdgeReader.normalizeRealmId("foo.bar.com"));
         assertEquals("already-hyphen", ComputedEdgeReader.normalizeRealmId("already-hyphen"));
         assertNull(ComputedEdgeReader.normalizeRealmId(null));
+    }
+
+    @Test
+    void relationshipEdgesToDstIncludesLazyProviderEdges() {
+        sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A", "loc-B")));
+        sources.put("assoc-2", new SourceEntity("assoc-2", List.of("loc-B")));
+        when(edgeRepo.findByDst(any(DataDomain.class), eq("loc-B"))).thenReturn(List.of());
+        when(edgeRepo.findByDstAndP(any(DataDomain.class), eq("loc-B"), anyString())).thenReturn(List.of());
+
+        var edges = reader.relationshipEdgesToDst("realm", domain, "loc-B", "canSeeLocation");
+        assertEquals(2, edges.size());
+        assertEquals(Set.of("assoc-1", "assoc-2"),
+                edges.stream().map(e -> e.srcId()).collect(java.util.stream.Collectors.toSet()));
+    }
+
+    @Test
+    void relationshipEdgesFromSrcIncludesLazyProviderEdges() {
+        sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A")));
+        when(edgeRepo.findBySrc(any(DataDomain.class), eq("assoc-1"))).thenReturn(List.of());
+        when(edgeRepo.findBySrcAndP(any(DataDomain.class), eq("assoc-1"), anyString())).thenReturn(List.of());
+
+        var edges = reader.relationshipEdgesFromSrc("realm", domain, "assoc-1", null);
+        assertEquals(1, edges.size());
+        assertEquals("loc-A", edges.get(0).dstId());
+        assertEquals("canSeeLocation", edges.get(0).p());
     }
 
     private static OntologyEdge edge(String src, String p, String dst, Map<String, Object> prov) {

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
@@ -200,6 +200,23 @@ public class ComputedEdgeReaderInverseTest {
         assertEquals(1, ids.size());
     }
 
+    @Test
+    void relationshipEdgesFromSrcPreservesEagerComputedProvenance() {
+        OntologyEdge eagerComputed = edge("assoc-1", "canSeeLocation", "loc-A",
+                Map.of("providerId", "SomeEagerProvider"));
+        eagerComputed.setDerived(true);
+        eagerComputed.setInferred(false);
+        when(edgeRepo.findBySrcAndP(any(DataDomain.class), eq("assoc-1"), eq("canSeeLocation")))
+                .thenReturn(List.of(eagerComputed));
+        when(edgeRepo.findBySrc(any(DataDomain.class), eq("assoc-1"))).thenReturn(List.of(eagerComputed));
+
+        var edges = reader.relationshipEdgesFromSrc("realm", domain, "assoc-1", "canSeeLocation");
+        assertEquals(1, edges.size());
+        assertTrue(edges.get(0).prov().isPresent(), "stored provenance must not be dropped");
+        assertEquals("computed", edges.get(0).prov().get().rule());
+        assertEquals("SomeEagerProvider", edges.get(0).prov().get().inputs().get("providerId"));
+    }
+
     private static OntologyEdge edge(String src, String p, String dst, Map<String, Object> prov) {
         OntologyEdge e = new OntologyEdge();
         e.setSrc(src);

--- a/quantum-ontology-rest/src/main/java/com/e2eq/ontology/resource/OntologyResource.java
+++ b/quantum-ontology-rest/src/main/java/com/e2eq/ontology/resource/OntologyResource.java
@@ -10,8 +10,10 @@ import com.e2eq.ontology.core.OntologyRegistry.ClassDef;
 import com.e2eq.ontology.core.OntologyRegistry.PropertyChainDef;
 import com.e2eq.ontology.core.OntologyRegistry.PropertyDef;
 import com.e2eq.ontology.core.OntologyRegistry.TBox;
+import com.e2eq.ontology.core.Reasoner;
 import com.e2eq.ontology.model.OntologyEdge;
 import com.e2eq.framework.annotations.FunctionalMapping;
+import com.e2eq.ontology.mongo.ComputedEdgeReader;
 import com.e2eq.ontology.repo.OntologyEdgeRepo;
 import com.e2eq.ontology.runtime.TenantOntologyRegistryProvider;
 import io.smallrye.mutiny.Multi;
@@ -53,6 +55,9 @@ public class OntologyResource {
 
     @Inject
     OntologyEdgeRepo edgeRepo;
+
+    @Inject
+    ComputedEdgeReader computedEdgeReader;
 
     @Inject
     TenantOntologyRegistryProvider registryProvider;
@@ -420,6 +425,16 @@ public class OntologyResource {
                     e.isInferred(), e.isDerived(), e.getProv(), origin
             );
         }
+
+        public static EdgeDTO from(Reasoner.Edge e) {
+            boolean computed = e.prov().isPresent() && "computed".equals(e.prov().get().rule());
+            String origin = e.inferred() ? "inferred" : (computed ? "computed" : "explicit");
+            Map<String, Object> prov = e.prov().map(Reasoner.Provenance::inputs).orElse(null);
+            return new EdgeDTO(
+                    e.srcId(), e.srcType(), e.p(), e.dstId(), e.dstType(),
+                    e.inferred(), computed, prov, origin
+            );
+        }
     }
 
     @GET
@@ -507,19 +522,18 @@ public class OntologyResource {
 
         List<EdgeDTO> outgoing = new ArrayList<>();
         List<EdgeDTO> incoming = new ArrayList<>();
+        String realmId = effectiveRealmId();
 
         if (includeOutgoing) {
-            for (OntologyEdge e : edgeRepo.findBySrc(dataDomain, id)) {
-                if (!type.equals(e.getSrcType())) continue;
-                if (predicateFilter != null && !predicateFilter.contains(e.getP())) continue;
+            for (Reasoner.Edge e : collectFromSrc(realmId, dataDomain, id, predicateFilter)) {
+                if (type != null && e.srcType() != null && !type.equals(e.srcType())) continue;
                 outgoing.add(EdgeDTO.from(e));
             }
         }
 
         if (includeIncoming) {
-            for (OntologyEdge e : edgeRepo.findByDst(dataDomain, id)) {
-                if (!type.equals(e.getDstType())) continue;
-                if (predicateFilter != null && !predicateFilter.contains(e.getP())) continue;
+            for (Reasoner.Edge e : collectToDst(realmId, dataDomain, id, predicateFilter)) {
+                if (type != null && e.dstType() != null && !type.equals(e.dstType())) continue;
                 incoming.add(EdgeDTO.from(e));
             }
         }
@@ -729,6 +743,42 @@ public class OntologyResource {
         return dataDomain;
     }
 
+    private String effectiveRealmId() {
+        return SecurityContext.getPrincipalContext()
+                .map(PrincipalContext::getDefaultRealm)
+                .filter(r -> r != null && !r.isBlank())
+                .map(ComputedEdgeReader::normalizeRealmId)
+                .orElse(null);
+    }
+
+    /**
+     * Mode-aware outgoing edges. When multiple predicates are requested, query each;
+     * otherwise a single null-predicate call returns all.
+     */
+    private List<Reasoner.Edge> collectFromSrc(String realmId, DataDomain dataDomain,
+                                               String srcId, Set<String> predicateFilter) {
+        if (predicateFilter == null || predicateFilter.isEmpty()) {
+            return computedEdgeReader.relationshipEdgesFromSrc(realmId, dataDomain, srcId, null);
+        }
+        List<Reasoner.Edge> out = new ArrayList<>();
+        for (String p : predicateFilter) {
+            out.addAll(computedEdgeReader.relationshipEdgesFromSrc(realmId, dataDomain, srcId, p));
+        }
+        return out;
+    }
+
+    private List<Reasoner.Edge> collectToDst(String realmId, DataDomain dataDomain,
+                                             String dstId, Set<String> predicateFilter) {
+        if (predicateFilter == null || predicateFilter.isEmpty()) {
+            return computedEdgeReader.relationshipEdgesToDst(realmId, dataDomain, dstId, null);
+        }
+        List<Reasoner.Edge> out = new ArrayList<>();
+        for (String p : predicateFilter) {
+            out.addAll(computedEdgeReader.relationshipEdgesToDst(realmId, dataDomain, dstId, p));
+        }
+        return out;
+    }
+
     @GET
     @Path("graph/instances/jointjs")
     @Operation(summary = "Instance graph as JointJS cells[] given a src id and type")
@@ -774,19 +824,18 @@ public class OntologyResource {
                 ? predicates.stream().filter(Objects::nonNull).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toSet())
                 : null;
 
-        // Collect edges using full DataDomain scoping
-        List<OntologyEdge> edges = new ArrayList<>();
+        // Collect edges using mode-aware facade (includes LAZY/ONDEMAND computed edges)
+        List<Reasoner.Edge> edges = new ArrayList<>();
+        String realmId = effectiveRealmId();
         if (includeOut) {
-            for (OntologyEdge e : edgeRepo.findBySrc(dataDomain, src)) {
-                if (!type.equals(e.getSrcType())) continue; // ensure type matches the provided one for the focus node
-                if (predicateFilter != null && !predicateFilter.contains(e.getP())) continue;
+            for (Reasoner.Edge e : collectFromSrc(realmId, dataDomain, src, predicateFilter)) {
+                if (type != null && e.srcType() != null && !type.equals(e.srcType())) continue;
                 edges.add(e);
             }
         }
         if (includeIn) {
-            for (OntologyEdge e : edgeRepo.findByDst(dataDomain, src)) {
-                if (!type.equals(e.getDstType())) continue; // when incoming, focus matches dst side
-                if (predicateFilter != null && !predicateFilter.contains(e.getP())) continue;
+            for (Reasoner.Edge e : collectToDst(realmId, dataDomain, src, predicateFilter)) {
+                if (type != null && e.dstType() != null && !type.equals(e.dstType())) continue;
                 edges.add(e);
             }
         }
@@ -802,18 +851,18 @@ public class OntologyResource {
         String focusId = instanceId(type, src);
         elements.put(focusId, instanceRect(focusId, type, src, true));
 
-        for (OntologyEdge e : edges) {
-            boolean isOutgoing = src.equals(e.getSrc());
+        for (Reasoner.Edge e : edges) {
+            boolean isOutgoing = src.equals(e.srcId());
             String otherId;
-            String label = e.getP();
+            String label = e.p();
             if (isOutgoing) {
-                otherId = instanceId(e.getDstType(), e.getDst());
-                elements.putIfAbsent(otherId, instanceRect(otherId, e.getDstType(), e.getDst(), false));
-                links.add(link("Edge:" + e.getSrc() + ":" + e.getP() + ":" + e.getDst(), focusId, otherId, label, e.isInferred()));
+                otherId = instanceId(e.dstType(), e.dstId());
+                elements.putIfAbsent(otherId, instanceRect(otherId, e.dstType(), e.dstId(), false));
+                links.add(link("Edge:" + e.srcId() + ":" + e.p() + ":" + e.dstId(), focusId, otherId, label, e.inferred()));
             } else {
-                otherId = instanceId(e.getSrcType(), e.getSrc());
-                elements.putIfAbsent(otherId, instanceRect(otherId, e.getSrcType(), e.getSrc(), false));
-                links.add(link("Edge:" + e.getSrc() + ":" + e.getP() + ":" + e.getDst(), otherId, focusId, label, e.isInferred()));
+                otherId = instanceId(e.srcType(), e.srcId());
+                elements.putIfAbsent(otherId, instanceRect(otherId, e.srcType(), e.srcId(), false));
+                links.add(link("Edge:" + e.srcId() + ":" + e.p() + ":" + e.dstId(), otherId, focusId, label, e.inferred()));
             }
         }
 

--- a/quantum-ontology-rest/src/main/java/com/e2eq/ontology/resource/OntologyResource.java
+++ b/quantum-ontology-rest/src/main/java/com/e2eq/ontology/resource/OntologyResource.java
@@ -760,11 +760,15 @@ public class OntologyResource {
         if (predicateFilter == null || predicateFilter.isEmpty()) {
             return computedEdgeReader.relationshipEdgesFromSrc(realmId, dataDomain, srcId, null);
         }
-        List<Reasoner.Edge> out = new ArrayList<>();
+        // Set-style merge if the client passes overlapping/repeated predicates.
+        Map<String, Reasoner.Edge> unique = new LinkedHashMap<>();
         for (String p : predicateFilter) {
-            out.addAll(computedEdgeReader.relationshipEdgesFromSrc(realmId, dataDomain, srcId, p));
+            for (Reasoner.Edge e : computedEdgeReader.relationshipEdgesFromSrc(realmId, dataDomain, srcId, p)) {
+                if (e == null) continue;
+                unique.putIfAbsent(ComputedEdgeReader.edgeKey(e), e);
+            }
         }
-        return out;
+        return new ArrayList<>(unique.values());
     }
 
     private List<Reasoner.Edge> collectToDst(String realmId, DataDomain dataDomain,
@@ -772,11 +776,14 @@ public class OntologyResource {
         if (predicateFilter == null || predicateFilter.isEmpty()) {
             return computedEdgeReader.relationshipEdgesToDst(realmId, dataDomain, dstId, null);
         }
-        List<Reasoner.Edge> out = new ArrayList<>();
+        Map<String, Reasoner.Edge> unique = new LinkedHashMap<>();
         for (String p : predicateFilter) {
-            out.addAll(computedEdgeReader.relationshipEdgesToDst(realmId, dataDomain, dstId, p));
+            for (Reasoner.Edge e : computedEdgeReader.relationshipEdgesToDst(realmId, dataDomain, dstId, p)) {
+                if (e == null) continue;
+                unique.putIfAbsent(ComputedEdgeReader.edgeKey(e), e);
+            }
         }
-        return out;
+        return new ArrayList<>(unique.values());
     }
 
     @GET


### PR DESCRIPTION
## Summary
Re-audit of PR #49 (calculated relations roadmap) Codex/Copilot review:

| Review item | Status before this PR |
|-------------|------------------------|
| Dead territory doc link | Fixed in #86 |
| Reasoner \"caps at 10\" wording | Fixed in #86 |
| Inverse LAZY for policy hasEdge / ListQueryRewriter | Fixed in #86 |
| **MCP + REST graph still used pure `findByDst`/`findBySrc`** | **Still open** |

This PR closes the remaining Codex path: graph discovery that Codex named (`McpOntologyTools` incoming reads) plus the REST instance graph endpoints that had the same gap.

## Changes
- `ComputedEdgeReader.relationshipEdgesFromSrc` / `relationshipEdgesToDst`
- `McpOntologyTools.query_relationships` → facade
- `OntologyResource` instance edge/graph endpoints → facade
- Unit tests for the new relationship edge APIs

## Test plan
- [x] `ComputedEdgeReaderInverseTest`
- [x] `McpOntologyToolsSecurityTest`
- [x] compile quantum-ontology-rest / quantum-mcp-server