### PR TITLE
fix: close remaining Codex findings from PR #85 and #86

### DIFF
--- a/quantum-framework/src/main/java/com/e2eq/framework/query/QueryToPredicateJsonListener.java
+++ b/quantum-framework/src/main/java/com/e2eq/framework/query/QueryToPredicateJsonListener.java
@@ -482,17 +482,18 @@ public class QueryToPredicateJsonListener extends BIAPIQueryBaseListener {
 
     /**
      * Tokenize a text(...) search string into lower-case word terms.
-     * Whitespace-separated; leading/trailing punctuation on each token is stripped.
+     * Uses the same non-letter/non-digit split as {@link #valueHasWord} so
+     * {@code text("foo-bar")} matches a document field value {@code "foo-bar"}.
      */
     static List<String> tokenizeSearchTerms(String search) {
         if (search == null || search.isBlank()) return List.of();
-        return Arrays.stream(search.trim().split("\\s+"))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .map(s -> s.replaceAll("^[\\p{Punct}]+|[\\p{Punct}]+$", ""))
-                .filter(s -> !s.isEmpty())
-                .map(String::toLowerCase)
-                .toList();
+        List<String> terms = new ArrayList<>();
+        for (String word : WORD_SPLIT.split(search.toLowerCase())) {
+            if (!word.isEmpty()) {
+                terms.add(word);
+            }
+        }
+        return terms;
     }
 
     /**

--- a/quantum-framework/src/test/java/com/e2eq/framework/query/QueryToPredicateJsonListenerTest.java
+++ b/quantum-framework/src/test/java/com/e2eq/framework/query/QueryToPredicateJsonListenerTest.java
@@ -181,6 +181,15 @@ public class QueryToPredicateJsonListenerTest {
     }
 
     @Test
+    void testTextSearchHyphenatedTermMatchesHyphenatedFieldValue() {
+        // Query and document must share the same non-letter/non-digit tokenizer.
+        JsonNode hyphenated = nodeOf(Map.of("title", "foo-bar"));
+        assertTrue(pred("text(\"foo-bar\")").test(hyphenated));
+        assertTrue(pred("text(\"foo\")").test(hyphenated));
+        assertTrue(pred("text(\"bar\")").test(hyphenated));
+    }
+
+    @Test
     void testTextKeywordAsFieldAndValueStillParses() {
         // TEXT is a lexer keyword for text(...), but "text" remains a valid
         // unquoted field name / value so existing queries keep working.

--- a/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
+++ b/quantum-models/src/main/java/com/e2eq/framework/grammar/sql/QueryToSqlListener.java
@@ -301,6 +301,7 @@ public class QueryToSqlListener extends BIAPIQueryBaseListener {
                     switch (t) {
                         case BIAPIQueryParser.STRING:
                         case BIAPIQueryParser.QUOTED_STRING:
+                        case BIAPIQueryParser.TEXT:
                         case BIAPIQueryParser.OID:
                         case BIAPIQueryParser.REFERENCE:
                             placeholders.add(newParam(tn.getText()));

--- a/quantum-models/src/test/java/com/e2eq/framework/grammar/sql/QueryToSqlListenerTest.java
+++ b/quantum-models/src/test/java/com/e2eq/framework/grammar/sql/QueryToSqlListenerTest.java
@@ -76,6 +76,14 @@ class QueryToSqlListenerTest {
     }
 
     @Test
+    void inListAcceptsTextKeywordToken() {
+        // TEXT is a lexer keyword for text(...), but unquoted "text" in IN lists
+        // must still translate (keyword-collision fix for type:^ [text]).
+        assertWhere("type:^[text]", "type IN (?)", List.of("text"));
+        assertWhere("type:^[plain,text]", "type IN (?, ?)", List.of("plain", "text"));
+    }
+
+    @Test
     void inComposesWithScalar_paramsStayAligned() {
         assertWhere("status:ACTIVE && region:^[west,east]",
                 "(region IN (?, ?) AND status = ?)", List.of("west", "east", "ACTIVE"));

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeReader.java
@@ -172,12 +172,12 @@ public class ComputedEdgeReader {
     public Set<String> srcIdsByDstIn(String realmId, DataDomain dataDomain,
                                      String predicate, Collection<String> dstIds) {
         if (dstIds == null || dstIds.isEmpty()) return Set.of();
+        Objects.requireNonNull(predicate, "predicate");
         realmId = normalizeRealmId(realmId);
         Set<String> wanted = new HashSet<>(dstIds);
-        Set<String> ids = new LinkedHashSet<>();
-        for (String dstId : wanted) {
-            ids.addAll(storeSrcIdsExcludingNonEager(dataDomain, predicate, dstId));
-        }
+        // Bulk store lookup when no non-EAGER providers need provenance filtering;
+        // otherwise filter per-row so stale LAZY/ONDEMAND materializations drop out.
+        Set<String> ids = storeSrcIdsExcludingNonEagerIn(dataDomain, predicate, wanted);
         for (ComputedEdgeProvider<?> provider : providersForPredicate(predicate)) {
             if (provider.getMaterializationMode() == MaterializationMode.EAGER) {
                 continue;
@@ -392,6 +392,20 @@ public class ComputedEdgeReader {
         return ids;
     }
 
+    /** Bulk store contribution for multi-destination inverse queries. */
+    private Set<String> storeSrcIdsExcludingNonEagerIn(DataDomain dataDomain, String predicate,
+                                                       Collection<String> dstIds) {
+        Set<String> nonEager = nonEagerProviderIds(predicate);
+        if (nonEager.isEmpty()) {
+            return new LinkedHashSet<>(edgeRepo.srcIdsByDstIn(dataDomain, predicate, dstIds));
+        }
+        Set<String> ids = new LinkedHashSet<>();
+        for (String dstId : dstIds) {
+            ids.addAll(storeSrcIdsExcludingNonEager(dataDomain, predicate, dstId));
+        }
+        return ids;
+    }
+
     private Set<String> storeDstIdsExcludingNonEager(DataDomain dataDomain, String predicate, String sourceId) {
         Set<String> nonEager = nonEagerProviderIds(predicate);
         if (nonEager.isEmpty()) {
@@ -453,11 +467,19 @@ public class ComputedEdgeReader {
             after = page.get(page.size() - 1);
             if (page.size() < pageSize) break;
         }
+        // Fail closed: truncated inverse sets make notHasEdge / negation rewrites
+        // grant access to unseen sources that still hold the edge.
         if (all.size() >= sourceScanLimit) {
-            Log.warnf(
-                    "ComputedEdgeReader: inverse source scan hit limit %d for provider %s predicate %s; " +
-                    "results may be incomplete. Prefer EAGER materialization for high-cardinality inverse queries.",
-                    sourceScanLimit, provider.getProviderId(), provider.getPredicate());
+            List<String> probe = enumerator.listIds(
+                    realmId, dataDomain, provider.getSourceType(), after, 1);
+            if (probe != null && !probe.isEmpty()) {
+                throw new IllegalStateException(
+                        "ComputedEdgeReader inverse source scan exceeded limit " + sourceScanLimit
+                                + " for provider " + provider.getProviderId()
+                                + " predicate " + provider.getPredicate()
+                                + "; refusing incomplete inverse results (prefer EAGER materialization "
+                                + "or raise DEFAULT_INVERSE_SOURCE_SCAN_LIMIT for this workload).");
+            }
         }
         return all;
     }
@@ -538,11 +560,13 @@ public class ComputedEdgeReader {
 
     private static ComputedEdgeCache.Key cacheKey(String realmId, DataDomain dataDomain,
                                                   ComputedEdgeProvider<?> provider, String sourceId) {
+        // Always normalize so put/invalidate agree when callers pass dotted tenant ids.
+        String normalizedRealm = normalizeRealmId(realmId);
         String org = dataDomain == null ? null : dataDomain.getOrgRefName();
         String acct = dataDomain == null ? null : dataDomain.getAccountNum();
         String tenant = dataDomain == null ? null : dataDomain.getTenantId();
         int seg = dataDomain == null ? 0 : dataDomain.getDataSegment();
-        return new ComputedEdgeCache.Key(provider.getProviderId(), realmId, org, acct, tenant, seg, sourceId);
+        return new ComputedEdgeCache.Key(provider.getProviderId(), normalizedRealm, org, acct, tenant, seg, sourceId);
     }
 
     /** Same trick as BulkRecomputeService for accessing the registered loader. */

--- a/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeRecomputeHandler.java
+++ b/quantum-ontology-mongo/src/main/java/com/e2eq/ontology/mongo/ComputedEdgeRecomputeHandler.java
@@ -176,13 +176,16 @@ public class ComputedEdgeRecomputeHandler {
         }
         if (mode == MaterializationMode.LAZY) {
             // No stored edges to refresh; just punch the cache so the next read
-            // recomputes against the new dependency state.
+            // recomputes against the new dependency state. Normalize realm the same
+            // way ComputedEdgeReader.cacheKey does (dots → hyphens) so invalidation
+            // hits entries written from dotted tenant ids.
             String org = dataDomain == null ? null : dataDomain.getOrgRefName();
             String acct = dataDomain == null ? null : dataDomain.getAccountNum();
             String tenant = dataDomain == null ? null : dataDomain.getTenantId();
             int seg = dataDomain == null ? 0 : dataDomain.getDataSegment();
+            String normalizedRealm = ComputedEdgeReader.normalizeRealmId(realmId);
             computedEdgeCache.invalidate(new ComputedEdgeCache.Key(
-                    provider.getProviderId(), realmId, org, acct, tenant, seg, sourceId));
+                    provider.getProviderId(), normalizedRealm, org, acct, tenant, seg, sourceId));
             return true;
         }
 

--- a/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
+++ b/quantum-ontology-mongo/src/test/java/com/e2eq/ontology/mongo/ComputedEdgeReaderInverseTest.java
@@ -148,6 +148,38 @@ public class ComputedEdgeReaderInverseTest {
     }
 
     @Test
+    void srcIdsByDstInUsesBulkStoreLookupWhenNoNonEagerProviders() {
+        // Register only EAGER path via empty registry of LAZY providers: drop LazyProvider
+        // and use store bulk API alone.
+        registry = new ComputedEdgeRegistry();
+        reader = new ComputedEdgeReader(
+                registry,
+                new ComputedEdgeRecomputeHandler(),
+                edgeRepo,
+                new ComputedEdgeCache(),
+                new OntologyMetrics(),
+                new SingleInstance<>(null));
+        when(edgeRepo.srcIdsByDstIn(eq(domain), eq("p"), any()))
+                .thenReturn(Set.of("s1", "s2"));
+
+        Set<String> ids = reader.srcIdsByDstIn("realm", domain, "p", List.of("d1", "d2"));
+        assertEquals(Set.of("s1", "s2"), ids);
+        verify(edgeRepo, times(1)).srcIdsByDstIn(eq(domain), eq("p"), any());
+        verify(edgeRepo, never()).srcIdsByDst(eq(domain), anyString(), anyString());
+    }
+
+    @Test
+    void inverseScanTruncationFailsClosed() {
+        for (int i = 0; i < 5; i++) {
+            sources.put("assoc-" + i, new SourceEntity("assoc-" + i, List.of("loc-A")));
+        }
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> reader.srcIdsByDst("realm", domain, "canSeeLocation", "loc-A", 3));
+        assertTrue(ex.getMessage().toLowerCase().contains("limit"));
+        assertTrue(ex.getMessage().toLowerCase().contains("inverse"));
+    }
+
+    @Test
     void relationshipEdgesToDstIncludesLazyProviderEdges() {
         sources.put("assoc-1", new SourceEntity("assoc-1", List.of("loc-A", "loc-B")));
         sources.put("assoc-2", new SourceEntity("assoc-2", List.of("loc-B")));


### PR DESCRIPTION
## Summary
Closes the remaining open Codex review items that were still present on `1.4.2-SNAPSHOT` after the merged follow-up PRs #85/#86/#88.

| Finding | PR | Fix |
|---------|----|-----|
| Inverse scan cap only warned (notHasEdge false allow) | #86 P1 | Fail closed with `IllegalStateException` when more sources remain past the cap |
| Bulk store lookup regressed to O(n) per destination | #86 P2 | Use `edgeRepo.srcIdsByDstIn` when no non-EAGER providers need provenance filtering |
| Cache put/invalidate realm mismatch for dotted tenants | #86 P2 | Normalize realm in every `cacheKey` path + recompute handler invalidation |
| `text("foo-bar")` vs document tokenizer mismatch | #85 P2 | Tokenize search terms with the same `WORD_SPLIT` as field values |
| SQL IN lists drop `TEXT` keyword token (`type:^ [text]`) | #85 P2 | Accept `BIAPIQueryParser.TEXT` in `QueryToSqlListener.enterInExpr` |

## Already verified closed (no code change)
- Stale non-EAGER store row exclusion (#86)
- ListQueryRewriter dotted-tenant normalize (#86)
- Store provenance on relationship edges (#88)
- Enterprise billing #66 five findings (#68) — all present on enterprise `1.4.2-SNAPSHOT`

## Test plan
- [x] `mvn -pl quantum-ontology-mongo,quantum-framework,quantum-models -am test -Dtest=ComputedEdgeReaderInverseTest,QueryToPredicateJsonListenerTest,QueryToSqlListenerTest`