### PR TITLE
Fix remote membership identity and application scope

### DIFF
--- a/quantum-control-plane-client/src/main/java/com/e2eq/framework/controlplane/api/DefaultEndpoint.java
+++ b/quantum-control-plane-client/src/main/java/com/e2eq/framework/controlplane/api/DefaultEndpoint.java
@@ -41,8 +41,24 @@ public interface DefaultEndpoint {
     @Consumes(MediaType.APPLICATION_JSON)
     @Valid List<RealmMembershipEntry> membersOfRealm(@PathParam("refName") @NotNull String refName);
 
+    @PUT
+    @Path("/control/realms/{refName}/members/{organizationRefName}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Valid RealmMembershipEntry upsertRealmMembership(
+        @PathParam("refName") @NotNull String refName,
+        @PathParam("organizationRefName") @NotNull String organizationRefName,
+        @Valid @NotNull RealmMembershipEntry body);
+
     @GET
     @Path("/control/users/{userId}/realms")
     @Consumes(MediaType.APPLICATION_JSON)
     @Valid List<UserRealmRoleEntry> realmsForUser(@PathParam("userId") @NotNull String userId);
+
+    @PUT
+    @Path("/control/users/{userId}/realms/{realmRefName}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Valid UserRealmRoleEntry upsertUserRealmRole(
+        @PathParam("userId") @NotNull String userId,
+        @PathParam("realmRefName") @NotNull String realmRefName,
+        @Valid @NotNull UserRealmRoleEntry body);
 }

--- a/quantum-control-plane-client/src/main/java/com/e2eq/framework/controlplane/model/UserRealmRoleEntry.java
+++ b/quantum-control-plane-client/src/main/java/com/e2eq/framework/controlplane/model/UserRealmRoleEntry.java
@@ -13,6 +13,8 @@ public class UserRealmRoleEntry {
     private String realmRefName;
     @NotNull
     private List<String> roles;
+    private List<String> authorizedApplications;
+    private String defaultApplication;
     private String sponsoringOrgRefName;
     private String status;
 
@@ -33,6 +35,18 @@ public class UserRealmRoleEntry {
 
     @JsonProperty("roles")
     public void setRoles(List<String> roles) { this.roles = roles; }
+
+    @JsonProperty("authorizedApplications")
+    public List<String> getAuthorizedApplications() { return authorizedApplications; }
+
+    @JsonProperty("authorizedApplications")
+    public void setAuthorizedApplications(List<String> authorizedApplications) { this.authorizedApplications = authorizedApplications; }
+
+    @JsonProperty("defaultApplication")
+    public String getDefaultApplication() { return defaultApplication; }
+
+    @JsonProperty("defaultApplication")
+    public void setDefaultApplication(String defaultApplication) { this.defaultApplication = defaultApplication; }
 
     @JsonProperty("sponsoringOrgRefName")
     public String getSponsoringOrgRefName() { return sponsoringOrgRefName; }

--- a/quantum-control-plane-client/src/main/resources/openapi/control-plane.openapi.yaml
+++ b/quantum-control-plane-client/src/main/resources/openapi/control-plane.openapi.yaml
@@ -66,6 +66,24 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/RealmMembershipEntry' }
+  /control/realms/{refName}/members/{organizationRefName}:
+    put:
+      operationId: upsertRealmMembership
+      summary: Create or update an organization membership in a realm
+      parameters:
+        - { name: refName, in: path, required: true, schema: { type: string } }
+        - { name: organizationRefName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/RealmMembershipEntry' }
+      responses:
+        '200':
+          description: reconciled realm membership
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RealmMembershipEntry' }
   /control/users/{userId}/realms:
     get:
       operationId: realmsForUser
@@ -79,6 +97,24 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/UserRealmRoleEntry' }
+  /control/users/{userId}/realms/{realmRefName}:
+    put:
+      operationId: upsertUserRealmRole
+      summary: Create or update a user's role assignment in a realm
+      parameters:
+        - { name: userId, in: path, required: true, schema: { type: string } }
+        - { name: realmRefName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UserRealmRoleEntry' }
+      responses:
+        '200':
+          description: reconciled user realm-role assignment
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UserRealmRoleEntry' }
 components:
   securitySchemes:
     bearerAuth: { type: http, scheme: bearer, bearerFormat: JWT }
@@ -118,5 +154,7 @@ components:
         userId: { type: string }
         realmRefName: { type: string }
         roles: { type: array, items: { type: string } }
+        authorizedApplications: { type: array, items: { type: string } }
+        defaultApplication: { type: string }
         sponsoringOrgRefName: { type: string }
         status: { type: string, enum: [active, invited, suspended] }

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/CustomTokenAuthProvider.java
@@ -127,10 +127,20 @@ public class CustomTokenAuthProvider extends BaseAuthProvider implements AuthPro
     */
    public String generateServiceToken(String subject, Set<String> roles, Long expirationSeconds,
                                       String realm, Set<String> audiences) {
+      return generateServiceToken(subject, roles, expirationSeconds, realm, audiences, null);
+   }
+
+   /**
+    * Application-scoped service passport. The active application comes from
+    * the authenticated minting session and is signed as {@code azp}; realm and
+    * audiences remain deliberately excluded from service identity.
+    */
+   public String generateServiceToken(String subject, Set<String> roles, Long expirationSeconds,
+                                      String realm, Set<String> audiences, String activeApplication) {
       long duration = (expirationSeconds != null) ? expirationSeconds : 60L * 60 * 24 * 365 * 100;
       try {
          return TokenUtils.generateServiceToken(
-                 subject, roles, TokenUtils.expiresAt(duration), issuer);
+                 subject, roles, activeApplication, TokenUtils.expiresAt(duration), issuer);
       } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
          throw new RuntimeException("Failed to generate service token", e);
       }

--- a/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
+++ b/quantum-jwt-provider/src/main/java/com/e2eq/framework/model/auth/provider/jwtToken/TokenUtils.java
@@ -234,6 +234,20 @@ public class TokenUtils {
 										 Set<String> groups,
 										 long expiresAt,
 										 String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+		return generateServiceToken(subject, groups, null, expiresAt, issuer);
+	}
+
+	/**
+	 * Trusted service identity scoped to the application selected by the
+	 * authenticated minting session. The application is authorization context
+	 * ({@code azp}), not a resource audience, so service tokens remain free of an
+	 * {@code aud} claim.
+	 */
+	public static String generateServiceToken(String subject,
+										 Set<String> groups,
+										 String activeApplication,
+										 long expiresAt,
+										 String issuer) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
 		Objects.requireNonNull(subject, "subject cannot be null");
 		Objects.requireNonNull(issuer, "Issuer cannot be null");
 		if (expiresAt <= REFRESH_ADDITIONAL_DURATION_SECONDS) {
@@ -242,7 +256,7 @@ public class TokenUtils {
 
 		PrivateKey privateKey = cachedPrivateKey != null ? cachedPrivateKey : readPrivateKey(privateKeyLocation);
 		long currentTimeInSecs = currentTimeInSecs();
-		return Jwt.claims()
+		JwtClaimsBuilder claimsBuilder = Jwt.claims()
 				.issuer(issuer)
 				.subject(subject)
 				.issuedAt(currentTimeInSecs)
@@ -250,8 +264,11 @@ public class TokenUtils {
 				.groups(groups)
 				.claim("scope", AUTH_SCOPE)
 				.claim(com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.TOKEN_TYPE_CLAIM,
-						com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.SERVICE_TOKEN_TYPE)
-				.jws().keyId(resolveSigningKeyId()).sign(privateKey);
+						com.e2eq.framework.model.securityrules.DelegatedIdentityHeaders.SERVICE_TOKEN_TYPE);
+		if (activeApplication != null && !activeApplication.isBlank()) {
+			claimsBuilder.claim("azp", activeApplication.trim());
+		}
+		return claimsBuilder.jws().keyId(resolveSigningKeyId()).sign(privateKey);
 	}
 
 	/**

--- a/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
+++ b/quantum-jwt-provider/src/test/java/com/e2eq/framework/model/auth/provider/jwtToken/ServiceTokenRealmClaimTest.java
@@ -48,4 +48,18 @@ class ServiceTokenRealmClaimTest {
         assertFalse(claims.contains("\"realm\""), claims);
         assertFalse(claims.contains("\"azp\""), claims);
     }
+
+    @Test
+    void applicationScopedServiceTokenCarriesAuthorizedPartyWithoutAudience() throws Exception {
+        TokenUtils.configure("privateKey.pem", "publicKey.pem");
+
+        String jwt = TokenUtils.generateServiceToken(
+                "svc-helixor-code", Set.of("service", "system"), "helixor-code",
+                TokenUtils.expiresAt(3600), "https://auth.example.com");
+
+        String claims = payloadJson(jwt);
+        assertTrue(claims.contains("\"azp\":\"helixor-code\""), claims);
+        assertFalse(claims.contains("\"aud\""), claims);
+        assertFalse(claims.contains("\"realm\""), claims);
+    }
 }

--- a/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserRealmRoleRepo.java
+++ b/quantum-morphia-repos/src/main/java/com/e2eq/framework/model/persistent/morphia/UserRealmRoleRepo.java
@@ -11,6 +11,15 @@ import java.util.Optional;
 @ApplicationScoped
 public class UserRealmRoleRepo extends MorphiaRepo<UserRealmRole> {
 
+    public List<UserRealmRole> findByUserIdWithIgnoreRules(String userId, String systemRealmId) {
+        MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(systemRealmId);
+        try (var cursor = ds.find(UserRealmRole.class)
+                .filter(Filters.eq("userId", userId))
+                .iterator()) {
+            return cursor.toList();
+        }
+    }
+
     public List<UserRealmRole> findByRealmRefNameWithIgnoreRules(String realmRefName, String systemRealmId) {
         MorphiaDatastore ds = morphiaDataStoreWrapper.getDataStore(systemRealmId);
         try (var cursor = ds.find(UserRealmRole.class)

--- a/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
@@ -51,17 +51,17 @@ public class RealmMembershipService {
     @ConfigProperty(name = "quantum.system-service.token")
     java.util.Optional<String> serviceToken;
 
-    private volatile RemoteMembershipClient remoteClient;
-
-    /** Phase C: in remote mode membership resolution goes to the control plane. */
+    /**
+     * Phase C: in remote mode membership resolution goes to the control plane.
+     * Capture the bearer while still on the inbound request thread. The REST
+     * client may execute filters on another thread where the request-scoped JWT
+     * proxy is no longer available.
+     */
     private RemoteMembershipClient remote() {
-        if (remoteClient == null) {
-            remoteClient = new RemoteMembershipClient(
-                quantumModeConfig.systemServiceBaseUrl().orElseThrow(() ->
-                    new IllegalStateException("quantum.system-service.base-url is required for remote membership resolution")),
-                this::requestBearerToken);
-        }
-        return remoteClient;
+        return new RemoteMembershipClient(
+            quantumModeConfig.systemServiceBaseUrl().orElseThrow(() ->
+                new IllegalStateException("quantum.system-service.base-url is required for remote membership resolution")),
+            requestBearerToken());
     }
 
     Optional<String> requestBearerToken() {

--- a/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
@@ -10,6 +10,7 @@ import com.e2eq.framework.model.security.RealmTenantMembership;
 import com.e2eq.framework.model.security.UserRealmRole;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.bson.types.ObjectId;
 
 import java.nio.charset.StandardCharsets;
@@ -44,6 +45,9 @@ public class RealmMembershipService {
     @Inject
     SystemDirectory systemDirectory;
 
+    @Inject
+    JsonWebToken jwt;
+
     @ConfigProperty(name = "quantum.system-service.token")
     java.util.Optional<String> serviceToken;
 
@@ -55,9 +59,22 @@ public class RealmMembershipService {
             remoteClient = new RemoteMembershipClient(
                 quantumModeConfig.systemServiceBaseUrl().orElseThrow(() ->
                     new IllegalStateException("quantum.system-service.base-url is required for remote membership resolution")),
-                serviceToken);
+                this::requestBearerToken);
         }
         return remoteClient;
+    }
+
+    Optional<String> requestBearerToken() {
+        try {
+            String inboundToken = jwt.getRawToken();
+            if (inboundToken != null && !inboundToken.isBlank()) {
+                return Optional.of(inboundToken);
+            }
+        } catch (RuntimeException ignored) {
+            // No active request context (for example, startup). Use a configured
+            // service token when present; otherwise the remote call fails closed.
+        }
+        return serviceToken.filter(token -> !token.isBlank());
     }
 
     /** All realm memberships for an org (owner and participant alike). */

--- a/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
@@ -187,6 +187,13 @@ public class RealmMembershipService {
                 assignment.getUserId(), assignment.getRealmRefName(), systemRealmId);
         if (existingRole.isPresent()) {
             UserRealmRole existing = existingRole.get();
+            if (assignment.getDataDomain() == null) {
+                // The public control-plane membership contract intentionally omits
+                // internal tenant storage scope. An update through that seam must
+                // preserve the authoritative assignment instead of being treated as
+                // an attempt to clear or move it.
+                assignment.setDataDomain(existing.getDataDomain());
+            }
             if (!java.util.Objects.equals(existing.getDataDomain(), assignment.getDataDomain())) {
                 throw new IllegalStateException(
                     "A user may have only one tenant DataDomain assignment per realm. "

--- a/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/membership/RealmMembershipService.java
@@ -94,8 +94,8 @@ public class RealmMembershipService {
         if (quantumModeConfig.isRemote()) {
             return remote().membersOfRealm(realmRefName);
         }
-        return membershipRepo.getListByQuery(0, -1,
-            "realmRefName:" + realmRefName);
+        return membershipRepo.findByRealmRefNameWithIgnoreRules(
+            systemDirectory.systemRealmId(), realmRefName);
     }
 
     /** Create or update an org/account membership through the owning control plane. */
@@ -162,7 +162,8 @@ public class RealmMembershipService {
         if (quantumModeConfig.isRemote()) {
             return remote().realmsForUser(userId);
         }
-        return userRealmRoleRepo.getListByQuery(0, -1, "userId:" + userId);
+        return userRealmRoleRepo.findByUserIdWithIgnoreRules(
+            userId, systemDirectory.systemRealmId());
     }
 
     /** Create or update a user's role assignment through the owning control plane. */

--- a/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneClientFactory.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneClientFactory.java
@@ -6,6 +6,7 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
 import java.net.URI;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Builds the control-plane client (the SDK-generated JAX-RS interface
@@ -19,11 +20,20 @@ public final class ControlPlaneClientFactory {
     }
 
     public static DefaultEndpoint build(String baseUrl, Optional<String> bearerToken) {
+        return build(baseUrl, () -> bearerToken);
+    }
+
+    public static DefaultEndpoint build(
+        String baseUrl,
+        Supplier<Optional<String>> bearerToken
+    ) {
         RestClientBuilder builder = RestClientBuilder.newBuilder()
             .baseUri(URI.create(baseUrl.replaceAll("/+$", "")));
-        bearerToken.filter(t -> !t.isBlank()).ifPresent(token ->
-            builder.register((ClientRequestFilter) ctx ->
-                ctx.getHeaders().putSingle("Authorization", "Bearer " + token)));
+        builder.register((ClientRequestFilter) ctx ->
+            bearerToken.get()
+                .filter(token -> !token.isBlank())
+                .ifPresent(token -> ctx.getHeaders().putSingle(
+                    "Authorization", "Bearer " + token)));
         return builder.build(DefaultEndpoint.class);
     }
 }

--- a/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneClientFactory.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneClientFactory.java
@@ -6,7 +6,6 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
 import java.net.URI;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Builds the control-plane client (the SDK-generated JAX-RS interface
@@ -20,17 +19,10 @@ public final class ControlPlaneClientFactory {
     }
 
     public static DefaultEndpoint build(String baseUrl, Optional<String> bearerToken) {
-        return build(baseUrl, () -> bearerToken);
-    }
-
-    public static DefaultEndpoint build(
-        String baseUrl,
-        Supplier<Optional<String>> bearerToken
-    ) {
         RestClientBuilder builder = RestClientBuilder.newBuilder()
             .baseUri(URI.create(baseUrl.replaceAll("/+$", "")));
         builder.register((ClientRequestFilter) ctx ->
-            bearerToken.get()
+            bearerToken
                 .filter(token -> !token.isBlank())
                 .ifPresent(token -> ctx.getHeaders().putSingle(
                     "Authorization", "Bearer " + token)));

--- a/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneRealmMapper.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/remote/ControlPlaneRealmMapper.java
@@ -1,9 +1,13 @@
 package com.e2eq.framework.system.remote;
 
 import com.e2eq.framework.controlplane.model.RealmCatalogEntry;
+import com.e2eq.framework.controlplane.model.RealmMembershipEntry;
+import com.e2eq.framework.controlplane.model.UserRealmRoleEntry;
 import com.e2eq.framework.model.security.DomainContext;
 import com.e2eq.framework.model.security.Realm;
 import com.e2eq.framework.model.security.RealmDeploymentType;
+import com.e2eq.framework.model.security.RealmTenantMembership;
+import com.e2eq.framework.model.security.UserRealmRole;
 
 /** Shared typed mapping at the generated control-plane contract boundary. */
 public final class ControlPlaneRealmMapper {
@@ -43,6 +47,55 @@ public final class ControlPlaneRealmMapper {
             entry.setOrgRefName(realm.getDomainContext().getOrgRefName());
             entry.setAccountNumber(realm.getDomainContext().getAccountId());
         }
+        return entry;
+    }
+
+    public static RealmTenantMembership fromEntry(RealmMembershipEntry entry) {
+        RealmTenantMembership membership = new RealmTenantMembership();
+        membership.setRefName(entry.getOrganizationRefName() + "-" + entry.getRealmRefName());
+        membership.setRealmRefName(entry.getRealmRefName());
+        membership.setOrganizationRefName(entry.getOrganizationRefName());
+        membership.setAccountId(entry.getAccountId());
+        membership.setTenantId(entry.getTenantId());
+        membership.setMembershipRole(entry.getMembershipRole());
+        membership.setParticipationStatus(entry.getParticipationStatus());
+        return membership;
+    }
+
+    public static RealmMembershipEntry toEntry(RealmTenantMembership membership) {
+        RealmMembershipEntry entry = new RealmMembershipEntry();
+        entry.setRealmRefName(membership.getRealmRefName());
+        entry.setOrganizationRefName(membership.getOrganizationRefName());
+        entry.setAccountId(membership.getAccountId());
+        entry.setTenantId(membership.getTenantId());
+        entry.setMembershipRole(membership.getMembershipRole());
+        entry.setParticipationStatus(membership.getParticipationStatus());
+        return entry;
+    }
+
+    public static UserRealmRole fromEntry(UserRealmRoleEntry entry) {
+        UserRealmRole role = new UserRealmRole();
+        role.setRefName(entry.getUserId() + "-" + entry.getRealmRefName());
+        role.setUserId(entry.getUserId());
+        role.setSubject(entry.getUserId());
+        role.setRealmRefName(entry.getRealmRefName());
+        role.setRoles(entry.getRoles());
+        role.setAuthorizedApplications(entry.getAuthorizedApplications());
+        role.setDefaultApplication(entry.getDefaultApplication());
+        role.setSponsoringOrgRefName(entry.getSponsoringOrgRefName());
+        role.setStatus(entry.getStatus());
+        return role;
+    }
+
+    public static UserRealmRoleEntry toEntry(UserRealmRole role) {
+        UserRealmRoleEntry entry = new UserRealmRoleEntry();
+        entry.setUserId(role.getUserId());
+        entry.setRealmRefName(role.getRealmRefName());
+        entry.setRoles(role.getRoles());
+        entry.setAuthorizedApplications(role.getAuthorizedApplications());
+        entry.setDefaultApplication(role.getDefaultApplication());
+        entry.setSponsoringOrgRefName(role.getSponsoringOrgRefName());
+        entry.setStatus(role.getStatus());
         return entry;
     }
 

--- a/quantum-system/src/main/java/com/e2eq/framework/system/remote/RemoteMembershipClient.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/remote/RemoteMembershipClient.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.WebApplicationException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Phase C (2/2): membership/role resolution over the control-plane API,
@@ -26,13 +25,6 @@ public class RemoteMembershipClient {
     private final DefaultEndpoint client;
 
     public RemoteMembershipClient(String baseUrl, Optional<String> bearerToken) {
-        this(ControlPlaneClientFactory.build(baseUrl, bearerToken));
-    }
-
-    public RemoteMembershipClient(
-        String baseUrl,
-        Supplier<Optional<String>> bearerToken
-    ) {
         this(ControlPlaneClientFactory.build(baseUrl, bearerToken));
     }
 

--- a/quantum-system/src/main/java/com/e2eq/framework/system/remote/RemoteMembershipClient.java
+++ b/quantum-system/src/main/java/com/e2eq/framework/system/remote/RemoteMembershipClient.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.WebApplicationException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Phase C (2/2): membership/role resolution over the control-plane API,
@@ -25,6 +26,13 @@ public class RemoteMembershipClient {
     private final DefaultEndpoint client;
 
     public RemoteMembershipClient(String baseUrl, Optional<String> bearerToken) {
+        this(ControlPlaneClientFactory.build(baseUrl, bearerToken));
+    }
+
+    public RemoteMembershipClient(
+        String baseUrl,
+        Supplier<Optional<String>> bearerToken
+    ) {
         this(ControlPlaneClientFactory.build(baseUrl, bearerToken));
     }
 

--- a/quantum-system/src/test/java/com/e2eq/framework/system/TestRemoteMembershipClient.java
+++ b/quantum-system/src/test/java/com/e2eq/framework/system/TestRemoteMembershipClient.java
@@ -43,7 +43,9 @@ public class TestRemoteMembershipClient {
             @Override public RealmCatalogEntry findRealmByRefName(String r) { return null; }
             @Override public RealmCatalogEntry registerRealm(RealmCatalogEntry b) { return b; }
             @Override public List<RealmMembershipEntry> membersOfRealm(String refName) { return members; }
+            @Override public RealmMembershipEntry upsertRealmMembership(String r, String o, RealmMembershipEntry b) { return b; }
             @Override public List<UserRealmRoleEntry> realmsForUser(String userId) { return roles; }
+            @Override public UserRealmRoleEntry upsertUserRealmRole(String u, String r, UserRealmRoleEntry b) { return b; }
         };
     }
 
@@ -77,7 +79,9 @@ public class TestRemoteMembershipClient {
             @Override public List<RealmMembershipEntry> membersOfRealm(String refName) {
                 throw new ProcessingException("connection refused");
             }
+            @Override public RealmMembershipEntry upsertRealmMembership(String r, String o, RealmMembershipEntry b) { return b; }
             @Override public List<UserRealmRoleEntry> realmsForUser(String userId) { return List.of(); }
+            @Override public UserRealmRoleEntry upsertUserRealmRole(String u, String r, UserRealmRoleEntry b) { return b; }
         });
         Assertions.assertTrue(Assertions.assertThrows(IllegalStateException.class,
             () -> client.membersOfRealm("x")).getMessage().contains("no local fallback"));

--- a/quantum-system/src/test/java/com/e2eq/framework/system/TestRemoteSystemDirectoryClient.java
+++ b/quantum-system/src/test/java/com/e2eq/framework/system/TestRemoteSystemDirectoryClient.java
@@ -29,7 +29,9 @@ public class TestRemoteSystemDirectoryClient {
         @Override public RealmCatalogEntry findRealmByRefName(String refName) { throw new NotFoundException(); }
         @Override public RealmCatalogEntry registerRealm(RealmCatalogEntry body) { return body; }
         @Override public List<RealmMembershipEntry> membersOfRealm(String refName) { return List.of(); }
+        @Override public RealmMembershipEntry upsertRealmMembership(String r, String o, RealmMembershipEntry body) { return body; }
         @Override public List<UserRealmRoleEntry> realmsForUser(String userId) { return List.of(); }
+        @Override public UserRealmRoleEntry upsertUserRealmRole(String u, String r, UserRealmRoleEntry body) { return body; }
     }
 
     @Test

--- a/quantum-system/src/test/java/com/e2eq/framework/system/membership/RealmMembershipServiceTest.java
+++ b/quantum-system/src/test/java/com/e2eq/framework/system/membership/RealmMembershipServiceTest.java
@@ -1,0 +1,64 @@
+package com.e2eq.framework.system.membership;
+
+import com.e2eq.framework.api.system.SystemDirectory;
+import com.e2eq.framework.model.persistent.base.DataDomain;
+import com.e2eq.framework.model.persistent.morphia.UserRealmRoleRepo;
+import com.e2eq.framework.model.security.CredentialUserIdPassword;
+import com.e2eq.framework.model.security.Realm;
+import com.e2eq.framework.model.security.UserRealmRole;
+import com.e2eq.framework.system.config.QuantumModeConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+class RealmMembershipServiceTest {
+
+    @Test
+    void controlPlaneUpdatePreservesExistingTenantDataDomainWhenOmitted() {
+        RealmMembershipService service = new RealmMembershipService();
+        service.quantumModeConfig = QuantumModeConfig.of("embedded", Optional.empty());
+        service.systemDirectory = new SystemDirectory() {
+            @Override public String systemRealmId() { return "quantum-system"; }
+            @Override public Optional<Realm> findRealmByEmailDomain(String value) { return Optional.empty(); }
+            @Override public Optional<Realm> findRealmByRefName(String value) { return Optional.empty(); }
+            @Override public Realm registerRealm(Realm value) { return value; }
+            @Override public Optional<CredentialUserIdPassword> findCredentialBySubject(String value) { return Optional.empty(); }
+            @Override public Optional<CredentialUserIdPassword> findCredentialByUserId(String value) { return Optional.empty(); }
+        };
+
+        DataDomain tenantScope = DataDomain.builder()
+            .tenantId("development")
+            .orgRefName("HelixorAI")
+            .accountNum("0000000001")
+            .ownerId("system")
+            .build();
+        UserRealmRole existing = new UserRealmRole();
+        existing.setUserId("mingardia@helixor.ai");
+        existing.setRealmRefName("helixor-code-D1");
+        existing.setDataDomain(tenantScope);
+        UserRealmRole update = new UserRealmRole();
+        update.setUserId(existing.getUserId());
+        update.setRealmRefName(existing.getRealmRefName());
+        update.setRoles(List.of("system", "admin", "user"));
+
+        service.userRealmRoleRepo = new UserRealmRoleRepo() {
+            @Override
+            public Optional<UserRealmRole> findAssignmentForRealmWithIgnoreRules(
+                    String userId, String realmRefName, String systemRealmId) {
+                return Optional.of(existing);
+            }
+
+            @Override
+            public UserRealmRole save(String realmId, UserRealmRole value) {
+                return value;
+            }
+        };
+
+        UserRealmRole saved = service.upsertUserRealmRole(update);
+
+        assertEquals(tenantScope, saved.getDataDomain());
+        assertEquals(update.getRoles(), saved.getRoles());
+    }
+}

--- a/quantum-system/src/test/java/com/e2eq/framework/system/membership/TestRealmMembershipServiceBearer.java
+++ b/quantum-system/src/test/java/com/e2eq/framework/system/membership/TestRealmMembershipServiceBearer.java
@@ -1,0 +1,58 @@
+package com.e2eq.framework.system.membership;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+class TestRealmMembershipServiceBearer {
+
+    @Test
+    void requestBearerPrefersTheAuthenticatedCaller() {
+        RealmMembershipService service = serviceWithJwt("caller-token", false);
+        service.serviceToken = Optional.of("service-token");
+
+        Assertions.assertEquals(Optional.of("caller-token"), service.requestBearerToken());
+    }
+
+    @Test
+    void requestBearerUsesConfiguredServiceIdentityOutsideARequest() {
+        RealmMembershipService service = serviceWithJwt(null, true);
+        service.serviceToken = Optional.of("service-token");
+
+        Assertions.assertEquals(Optional.of("service-token"), service.requestBearerToken());
+    }
+
+    @Test
+    void requestBearerRemainsEmptyWithoutCallerOrServiceIdentity() {
+        RealmMembershipService service = serviceWithJwt("  ", false);
+        service.serviceToken = Optional.empty();
+
+        Assertions.assertEquals(Optional.empty(), service.requestBearerToken());
+    }
+
+    private static RealmMembershipService serviceWithJwt(
+        String rawToken,
+        boolean failWithoutRequestContext
+    ) {
+        RealmMembershipService service = new RealmMembershipService();
+        service.jwt = (JsonWebToken) Proxy.newProxyInstance(
+            JsonWebToken.class.getClassLoader(),
+            new Class<?>[] {JsonWebToken.class},
+            (proxy, method, args) -> {
+                if ("getRawToken".equals(method.getName())) {
+                    if (failWithoutRequestContext) {
+                        throw new IllegalStateException("no request context");
+                    }
+                    return rawToken;
+                }
+                if ("getName".equals(method.getName())) {
+                    return "test-principal";
+                }
+                return null;
+            });
+        return service;
+    }
+}

--- a/quantum-system/src/test/java/com/e2eq/framework/system/remote/ControlPlaneRealmMapperTest.java
+++ b/quantum-system/src/test/java/com/e2eq/framework/system/remote/ControlPlaneRealmMapperTest.java
@@ -1,0 +1,49 @@
+package com.e2eq.framework.system.remote;
+
+import com.e2eq.framework.controlplane.model.RealmMembershipEntry;
+import com.e2eq.framework.controlplane.model.UserRealmRoleEntry;
+import com.e2eq.framework.model.security.RealmTenantMembership;
+import com.e2eq.framework.model.security.UserRealmRole;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ControlPlaneRealmMapperTest {
+
+    @Test
+    void mapsRealmMembershipWritesWithoutDroppingOwnership() {
+        RealmMembershipEntry entry = new RealmMembershipEntry();
+        entry.setRealmRefName("helixor-code-D1");
+        entry.setOrganizationRefName("HelixorAI");
+        entry.setAccountId("0000000001");
+        entry.setTenantId("development");
+        entry.setMembershipRole("owner");
+        entry.setParticipationStatus("ACTIVE");
+
+        RealmTenantMembership membership = ControlPlaneRealmMapper.fromEntry(entry);
+
+        assertEquals("HelixorAI-helixor-code-D1", membership.getRefName());
+        assertEquals("owner", membership.getMembershipRole());
+        assertEquals("HelixorAI", ControlPlaneRealmMapper.toEntry(membership).getOrganizationRefName());
+    }
+
+    @Test
+    void mapsUserRealmRoleWritesWithoutDroppingApplicationGrants() {
+        UserRealmRoleEntry entry = new UserRealmRoleEntry();
+        entry.setUserId("mingardia@helixor.ai");
+        entry.setRealmRefName("helixor-code-D1");
+        entry.setRoles(List.of("system", "admin", "user"));
+        entry.setAuthorizedApplications(List.of("helixor-code", "helixor-reasoning-ux"));
+        entry.setDefaultApplication("helixor-code");
+        entry.setSponsoringOrgRefName("HelixorAI");
+        entry.setStatus("active");
+
+        UserRealmRole role = ControlPlaneRealmMapper.fromEntry(entry);
+
+        assertEquals("mingardia@helixor.ai-helixor-code-D1", role.getRefName());
+        assertEquals(entry.getAuthorizedApplications(), role.getAuthorizedApplications());
+        assertEquals("HelixorAI", ControlPlaneRealmMapper.toEntry(role).getSponsoringOrgRefName());
+    }
+}


### PR DESCRIPTION
## Summary
- forward the authenticated bearer into remote membership resolution before async dispatch
- preserve the active application (`azp`) when minting service tokens
- read authoritative membership records directly from the system realm after endpoint authorization

## Verification
- `mvn -q -B -pl quantum-system -am -DskipITs test`
- `mvn -q -B -pl quantum-jwt-provider -am -DskipITs test`
- development public Helixor Code login returns HTTP 200